### PR TITLE
fix: update conversation links in RealtimeEvents and GitHub router

### DIFF
--- a/apps/nextjs/src/app/(dashboard)/mailboxes/[mailbox_slug]/dashboard/_components/realtimeEvents.tsx
+++ b/apps/nextjs/src/app/(dashboard)/mailboxes/[mailbox_slug]/dashboard/_components/realtimeEvents.tsx
@@ -73,7 +73,7 @@ const RealtimeEventsContent = ({ mailboxSlug }: { mailboxSlug: string }) => {
         <motion.div key={event.id} layout>
           <Panel className="p-0">
             <Link
-              href={`/mailboxes/${mailboxSlug}/conversations?id=${event.id}`}
+              href={`/mailboxes/${mailboxSlug}/conversations?id=${event.conversationSlug}`}
               className={cn(
                 "flex flex-col p-5 transition-colors hover:bg-muted",
                 event.isVip && "bg-bright/10 hover:bg-bright/20",

--- a/apps/nextjs/src/trpc/router/mailbox/conversations/github.ts
+++ b/apps/nextjs/src/trpc/router/mailbox/conversations/github.ts
@@ -31,7 +31,7 @@ export const githubRouter = {
           owner: ctx.mailbox.githubRepoOwner,
           repo: ctx.mailbox.githubRepoName,
           title: input.title,
-          body: `${input.body}\n\n*Created from [${ctx.conversation.subject}](${getBaseUrl()}/mailboxes/${ctx.mailbox.slug}/conversations?id=${ctx.conversation.id})*`,
+          body: `${input.body}\n\n*Created from [${ctx.conversation.subject}](${getBaseUrl()}/mailboxes/${ctx.mailbox.slug}/conversations?id=${ctx.conversation.slug})*`,
         });
 
         await db


### PR DESCRIPTION
fix : #81 

### Description: 

- Changed conversation ID to conversationSlug in RealtimeEvents component link.
- Updated body text in GitHub router to use conversationSlug instead of conversation ID for consistency.


### Screenshot 


https://github.com/user-attachments/assets/7c82a2e9-6032-4471-a430-4897b49f7015

