### PR TITLE
fix: remove background from keyboard shortcut display

### DIFF
--- a/apps/nextjs/src/components/keyboardShortcut.tsx
+++ b/apps/nextjs/src/components/keyboardShortcut.tsx
@@ -10,7 +10,7 @@ export function KeyboardShortcut({ children, className }: KeyboardShortcutProps)
   return (
     <kbd
       className={cn(
-        "inline-flex h-5 select-none items-center gap-1 rounded border bg-muted px-1.5 font-mono text-[10px] font-medium",
+        "inline-flex h-5 select-none items-center gap-1 rounded border px-1.5 font-mono text-[10px] font-medium",
         className,
       )}
     >


### PR DESCRIPTION
Doesn't work well in light mode