### PR TITLE
fix: list item content overflow in search results

### DIFF
--- a/apps/nextjs/src/app/(dashboard)/mailboxes/[mailbox_slug]/search/page.tsx
+++ b/apps/nextjs/src/app/(dashboard)/mailboxes/[mailbox_slug]/search/page.tsx
@@ -336,7 +336,7 @@ function SearchResultItem({
         onClick={(e) => e.stopPropagation()}
         className="mt-0.5"
       />
-      <Link href={`/mailboxes/${params.mailbox_slug}/conversations?id=${conversation.slug}`} className="flex-1">
+      <Link href={`/mailboxes/${params.mailbox_slug}/conversations?id=${conversation.slug}`} className="flex-1 min-w-0 overflow-hidden">
         <div className="flex items-start justify-between gap-4">
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-2 mb-1">


### PR DESCRIPTION
fix: #102 

### Before
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/373552e6-7bf4-44ff-be0b-d48c1221db28" />


### After
<img width="1508" alt="image" src="https://github.com/user-attachments/assets/905f107e-1587-4fd4-95af-34138d27451a" />
