### PR TITLE
fix(web): horizontroll scroll in mobile and desktop view

### DIFF
--- a/apps/nextjs/src/app/(dashboard)/mailboxes/[mailbox_slug]/(inbox)/[category]/layout.tsx
+++ b/apps/nextjs/src/app/(dashboard)/mailboxes/[mailbox_slug]/(inbox)/[category]/layout.tsx
@@ -17,7 +17,7 @@ async function ConversationsLayout({
 
   return (
     <SidebarProvider>
-      <div className="flex-1 flex h-full flex-col lg:flex-row">
+      <div className="flex-1 flex h-full flex-col lg:flex-row min-w-0">
         <AppSidebar mailboxSlug={mailbox_slug} sidebarInfo={sidebarInfo} />
         <main className="flex flex-col min-h-screen text-foreground w-full">{children}</main>
       </div>

--- a/apps/nextjs/src/app/(dashboard)/mailboxes/[mailbox_slug]/(inbox)/[category]/layout.tsx
+++ b/apps/nextjs/src/app/(dashboard)/mailboxes/[mailbox_slug]/(inbox)/[category]/layout.tsx
@@ -19,7 +19,7 @@ async function ConversationsLayout({
     <SidebarProvider>
       <div className="flex-1 flex h-full flex-col lg:flex-row min-w-0">
         <AppSidebar mailboxSlug={mailbox_slug} sidebarInfo={sidebarInfo} />
-        <main className="flex flex-col min-h-screen text-foreground w-full">{children}</main>
+        <main className="flex flex-col min-h-screen text-foreground w-full min-w-0">{children}</main>
       </div>
     </SidebarProvider>
   );


### PR DESCRIPTION
fix: #118 

## Before

### Mobile
https://github.com/user-attachments/assets/08a10777-e189-4298-abbe-3f881d9c98d8

### Desktop


https://github.com/user-attachments/assets/981faebd-202d-492b-b563-21eab9e4202f




## After

### Mobile

https://github.com/user-attachments/assets/3926542a-1cc5-4cad-85b3-2773442bf191

### Desktop

<img width="1511" alt="image" src="https://github.com/user-attachments/assets/7a00a338-6dd6-4d1f-a069-aeb478eb7cb3" />
