### PR TITLE
fix: iframe removal error in deep link redirection

### DIFF
--- a/apps/nextjs/src/components/deepLinkRedirect.tsx
+++ b/apps/nextjs/src/components/deepLinkRedirect.tsx
@@ -20,21 +20,24 @@ export function DeepLinkRedirect() {
           iframe.style.display = "none";
           document.body.appendChild(iframe);
 
-          const timeoutId = setTimeout(() => {
-            resolve(false);
-            document.body.removeChild(iframe);
-          }, 1000);
-
-          window.addEventListener(
-            "blur",
-            () => {
-              // The window being blurred just after opening the deep link indicates the app was opened
-              clearTimeout(timeoutId);
-              resolve(true);
+          const handleBlur = () => {
+            // The window being blurred just after opening the deep link indicates the app was opened
+            clearTimeout(timeoutId);
+            resolve(true);
+            if (iframe.parentNode === document.body) {
               document.body.removeChild(iframe);
-            },
-            { once: true },
-          );
+            }
+          };
+
+          window.addEventListener("blur", handleBlur, { once: true });
+
+          const timeoutId = setTimeout(() => {
+            window.removeEventListener("blur", handleBlur);
+            resolve(false);
+            if (iframe.parentNode === document.body) {
+              document.body.removeChild(iframe);
+            }
+          }, 1000);
 
           iframe.src = deepLink;
         });


### PR DESCRIPTION
Prevents "Failed to execute 'removeChild'" errors by adding DOM existence checks before removing the iframe. Refactors event handling for proper cleanup of event listeners to avoid memory leaks.

Error:

```
Uncaught NotFoundError: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.
    at window.addEventListener.once (layout-e123562d82f1fa86.js?dpl=dpl_HKKPpzXEjz7GMaEK8XmJJxUYVt7N:1:1951)
    at n (6569-7592176a73fdb837.js?dpl=dpl_HKKPpzXEjz7GMaEK8XmJJxUYVt7N:13:3642)
```

