### PR TITLE
feat: disable query batching and prefetching

### DIFF
--- a/apps/nextjs/src/app/(dashboard)/mailboxes/[mailbox_slug]/(inbox)/[category]/page.tsx
+++ b/apps/nextjs/src/app/(dashboard)/mailboxes/[mailbox_slug]/(inbox)/[category]/page.tsx
@@ -1,37 +1,5 @@
 import Inbox from "@/app/(dashboard)/mailboxes/[mailbox_slug]/(inbox)/_components/inbox";
-import { getUrlParams } from "@/components/utils/urls";
-import { captureExceptionAndLogIfDevelopment } from "@/lib/shared/sentry";
-import { api } from "@/trpc/server";
 
-type PageProps = {
-  category: "conversations" | "mine" | "assigned";
-  mailbox_slug: string;
-};
-const Page = async (props: {
-  params: Promise<PageProps>;
-  searchParams: Promise<Record<string, string | string[] | undefined>>;
-}) => {
-  const searchParams = await props.searchParams;
-  const params = await props.params;
-  const urlParams = getUrlParams(searchParams);
-  const conversationSlug = urlParams.get("id");
-  const status = urlParams.get("status");
-  try {
-    void api.mailbox.conversations.list.prefetch({
-      mailboxSlug: params.mailbox_slug,
-      status: status ? [status] : null,
-      cursor: null,
-      sort: urlParams.get("sort") ?? null,
-      search: urlParams.get("search") ?? null,
-      category: params.category,
-    });
-    if (conversationSlug) {
-      void api.mailbox.conversations.get.prefetch({ mailboxSlug: params.mailbox_slug, conversationSlug });
-    }
-  } catch (error) {
-    captureExceptionAndLogIfDevelopment(error);
-  }
-  return <Inbox />;
-};
+const Page = () => <Inbox />;
 
 export default Page;

--- a/apps/nextjs/src/trpc/react.tsx
+++ b/apps/nextjs/src/trpc/react.tsx
@@ -2,7 +2,7 @@
 
 import { QueryClientProvider, type QueryClient } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
-import { loggerLink, unstable_httpBatchStreamLink } from "@trpc/client";
+import { httpLink, loggerLink } from "@trpc/client";
 import { createTRPCReact } from "@trpc/react-query";
 import { lazy, Suspense, useState } from "react";
 import SuperJSON from "superjson";
@@ -45,7 +45,7 @@ export function TRPCReactProvider(props: { children: React.ReactNode }) {
         loggerLink({
           enabled: (op) => env.NODE_ENV === "development" || (op.direction === "down" && op.result instanceof Error),
         }),
-        unstable_httpBatchStreamLink({
+        httpLink({
           transformer: SuperJSON,
           url: `${getBaseUrl()}/api/trpc/lambda`,
           headers() {


### PR DESCRIPTION
Will make traces easier to understand, and we're not getting much value from these anyway. Can always add them back once we're more confident in our performance and observability.