### PR TITLE
fix: disable Sentry middleware traces

### DIFF
--- a/apps/nextjs/next.config.ts
+++ b/apps/nextjs/next.config.ts
@@ -188,5 +188,8 @@ export default process.env.VERCEL_ENV === "production"
       // https://docs.sentry.io/product/crons/
       // https://vercel.com/docs/cron-jobs
       automaticVercelMonitors: true,
+
+      // Avoid cluttering traces with a ton of middleware spans.
+      autoInstrumentMiddleware: false,
     })
   : nextConfig;


### PR DESCRIPTION
There are vastly more of these than any other transactions; they're not really useful and massively increase the number of spans we're sending.

(not 100% sure of the effect this will have, will revert if it disables more than just the middleware spans themselves)