### PR TITLE
Revert "feat: benchmark Clerk API calls"

### DIFF
--- a/apps/nextjs/src/lib/data/organization.ts
+++ b/apps/nextjs/src/lib/data/organization.ts
@@ -8,30 +8,24 @@ import { db } from "@/db/client";
 import { subscriptions } from "@/db/schema";
 import { env } from "@/env";
 import { redis } from "@/lib/redis/client";
-import { benchmarkApiCall, clerkClient, getClerkUserList } from "./user";
+import { clerkClient, getClerkUserList } from "./user";
 
 export const ADDITIONAL_PAID_ORGANIZATION_IDS = env.ADDITIONAL_PAID_ORGANIZATION_IDS?.split(",") ?? [];
 
 export const getClerkOrganization = cache(async (organizationId: string) => {
-  return await benchmarkApiCall(() => clerkClient.organizations.getOrganization({ organizationId }));
+  return await clerkClient.organizations.getOrganization({ organizationId });
 });
 
 export const addMember = async (organizationId: string, userId: string) => {
-  return await benchmarkApiCall(() =>
-    clerkClient.organizations.createOrganizationMembership({ organizationId, userId, role: "org:member" }),
-  );
+  return await clerkClient.organizations.createOrganizationMembership({ organizationId, userId, role: "org:member" });
 };
 
 export const setPrivateMetadata = async (organizationId: string, metadata: Record<string, any>) => {
-  return await benchmarkApiCall(() =>
-    clerkClient.organizations.updateOrganizationMetadata(organizationId, { privateMetadata: metadata }),
-  );
+  return await clerkClient.organizations.updateOrganizationMetadata(organizationId, { privateMetadata: metadata });
 };
 
 export const getOrganizationMembers = async (organizationId: string, limit = 100) => {
-  return await benchmarkApiCall(() =>
-    clerkClient.organizations.getOrganizationMembershipList({ organizationId, limit }),
-  );
+  return await clerkClient.organizations.getOrganizationMembershipList({ organizationId, limit });
 };
 
 export const getOrganizationAdminUsers = async (organizationId: string) => {
@@ -45,20 +39,18 @@ export const getOrganizationAdminUsers = async (organizationId: string) => {
 };
 
 export const getOrganizationMemberships = async (userId: string) => {
-  return await benchmarkApiCall(() => clerkClient.users.getOrganizationMembershipList({ userId }));
+  return await clerkClient.users.getOrganizationMembershipList({ userId });
 };
 
 export const createOrganization = async (user: User) => {
-  return await benchmarkApiCall(() =>
-    clerkClient.organizations.createOrganization({
-      name: user.firstName ? `${user.firstName}'s Organization` : "My Organization",
-      createdBy: user.id,
-      privateMetadata: {
-        freeTrialEndsAt: addDays(new Date(), FREE_TRIAL_PERIOD_DAYS).toISOString(),
-        automatedRepliesCount: 0,
-      },
-    }),
-  );
+  return await clerkClient.organizations.createOrganization({
+    name: user.firstName ? `${user.firstName}'s Organization` : "My Organization",
+    createdBy: user.id,
+    privateMetadata: {
+      freeTrialEndsAt: addDays(new Date(), FREE_TRIAL_PERIOD_DAYS).toISOString(),
+      automatedRepliesCount: 0,
+    },
+  });
 };
 
 export type SubscriptionStatus = "paid" | "free_trial" | "free_trial_expired";

--- a/apps/nextjs/src/lib/data/user.ts
+++ b/apps/nextjs/src/lib/data/user.ts
@@ -4,30 +4,15 @@ import { getSlackUser } from "../slack/client";
 
 export const clerkClient = createClerkClient({ secretKey: env.CLERK_SECRET_KEY });
 
-export async function benchmarkApiCall<T>(apiCallFn: () => Promise<T>, thresholdMs = 3000): Promise<T> {
-  const startTime = performance.now();
-  try {
-    return await apiCallFn();
-  } finally {
-    const duration = performance.now() - startTime;
-    if (duration > thresholdMs) {
-      console.warn(`Clerk API call took ${duration.toFixed(2)}ms, which exceeds the ${thresholdMs}ms threshold`);
-    }
-  }
-}
-
-export const getClerkUser = (userId: string | null) =>
-  userId ? benchmarkApiCall(() => clerkClient.users.getUser(userId)) : null;
+export const getClerkUser = (userId: string | null) => (userId ? clerkClient.users.getUser(userId) : null);
 
 export const getClerkUserList = (
   organizationId: string,
   { limit = 100, ...params }: NonNullable<Parameters<ClerkClient["users"]["getUserList"]>[0]> = {},
-) => benchmarkApiCall(() => clerkClient.users.getUserList({ limit, ...params, organizationId: [organizationId] }));
+) => clerkClient.users.getUserList({ limit, ...params, organizationId: [organizationId] });
 
 export const findUserByEmail = async (organizationId: string, email: string) => {
-  const { data } = await benchmarkApiCall(() =>
-    clerkClient.users.getUserList({ organizationId: [organizationId], emailAddress: [email] }),
-  );
+  const { data } = await clerkClient.users.getUserList({ organizationId: [organizationId], emailAddress: [email] });
   return data[0] ?? null;
 };
 
@@ -48,10 +33,10 @@ export const findUserViaSlack = async (organizationId: string, token: string, sl
 };
 
 export const getOAuthAccessToken = async (clerkUserId: string, provider: "oauth_google" | "oauth_slack") => {
-  const tokens = await benchmarkApiCall(() => clerkClient.users.getUserOauthAccessToken(clerkUserId, provider));
+  const tokens = await clerkClient.users.getUserOauthAccessToken(clerkUserId, provider);
   return tokens.data[0]?.token;
 };
 
 export const setPrivateMetadata = async (user: User, metadata: UserPrivateMetadata) => {
-  await benchmarkApiCall(() => clerkClient.users.updateUserMetadata(user.id, { privateMetadata: metadata }));
+  await clerkClient.users.updateUserMetadata(user.id, { privateMetadata: metadata });
 };


### PR DESCRIPTION
Reverts antiwork/helper#122

The Clerk API doesn't seem problematic after all, and we have proper traces on Sentry now for these.