### PR TITLE
fix: VIP notifications for merged tickets

### DIFF
--- a/apps/nextjs/src/app/(dashboard)/mailboxes/[mailbox_slug]/(inbox)/_components/conversation.tsx
+++ b/apps/nextjs/src/app/(dashboard)/mailboxes/[mailbox_slug]/(inbox)/_components/conversation.tsx
@@ -10,6 +10,7 @@ import {
 import { ChannelProvider } from "ably/react";
 import FileSaver from "file-saver";
 import { PanelRightClose, PanelRightOpen } from "lucide-react";
+import Link from "next/link";
 import { useEffect, useLayoutEffect, useState } from "react";
 import { useStickToBottom } from "use-stick-to-bottom";
 import { create } from "zustand";
@@ -270,7 +271,7 @@ const ConversationContent = () => {
   }, [nativePlatform, conversationInfo?.subject]);
 
   return (
-    <ResizablePanelGroup direction="horizontal" className="flex w-full">
+    <ResizablePanelGroup direction="horizontal" className="relative flex w-full">
       <ResizablePanel defaultSize={75} minSize={50} maxSize={85}>
         <ResizablePanelGroup direction="vertical" className="flex w-full flex-col bg-background">
           <ResizablePanel
@@ -282,6 +283,16 @@ const ConversationContent = () => {
             }}
           >
             <div className="flex flex-col h-full">
+              {conversationInfo?.mergedInto?.slug && (
+                <div className="absolute inset-0 z-50 bg-background/75 flex flex-col items-center justify-center gap-4 h-full text-lg">
+                  Merged into another conversation.
+                  <Button variant="subtle" asChild>
+                    <Link href={`/mailboxes/${mailboxSlug}/conversations?id=${conversationInfo.mergedInto.slug}`}>
+                      View
+                    </Link>
+                  </Button>
+                </div>
+              )}
               <CarouselContext.Provider
                 value={{
                   currentIndex: previewFileIndex,

--- a/apps/nextjs/src/inngest/functions/checkVipResponseTimes.ts
+++ b/apps/nextjs/src/inngest/functions/checkVipResponseTimes.ts
@@ -36,6 +36,7 @@ export default inngest.createFunction(
           and(
             eq(conversations.mailboxId, mailbox.id),
             isNull(conversations.assignedToClerkId),
+            isNull(conversations.mergedIntoId),
             eq(conversations.status, "open"),
             gt(
               sql`EXTRACT(EPOCH FROM (NOW() - ${conversations.lastUserEmailCreatedAt})) / 3600`,

--- a/apps/nextjs/src/lib/data/conversation.ts
+++ b/apps/nextjs/src/lib/data/conversation.ts
@@ -201,8 +201,16 @@ export const serializeConversationWithMessages = async (
     ? await getPlatformCustomer(mailbox.id, conversation.emailFrom)
     : null;
 
+  const mergedInto = conversation.mergedIntoId
+    ? await db.query.conversations.findFirst({
+        where: eq(conversations.id, conversation.mergedIntoId),
+        columns: { slug: true },
+      })
+    : null;
+
   return {
     ...serializeConversation(mailbox, conversation, platformCustomer),
+    mergedInto,
     customerMetadata: platformCustomer
       ? {
           name: platformCustomer.name,


### PR DESCRIPTION
[ref](https://anti--work.slack.com/archives/C085P30V4LT/p1743538005874069?thread_ts=1743537610.284869&cid=C085P30V4LT)

* Excludes merged tickets from the VIP response time alert
* Updates VIP Slack messages to link to the original ticket rather than the merged one
* Adds an overlay to merged conversations so it's obvious if something links to them