### PR TITLE
feat: remove current signature feature

### DIFF
--- a/apps/expo/src/types/api.ts
+++ b/apps/expo/src/types/api.ts
@@ -312,7 +312,7 @@ export declare const appRouter: import("@trpc/server/unstable-core-do-not-import
                   draft: {
                     id: number;
                     responseToId: number;
-                    body: string;
+                    body: string | null;
                     isStale: boolean;
                   } | null;
                   files: {
@@ -440,7 +440,7 @@ export declare const appRouter: import("@trpc/server/unstable-core-do-not-import
             draft: {
               id: number;
               responseToId: number;
-              body: string;
+              body: string | null;
               isStale: boolean;
             } | null;
             customerMetadata: {
@@ -468,7 +468,7 @@ export declare const appRouter: import("@trpc/server/unstable-core-do-not-import
                   draft: {
                     id: number;
                     responseToId: number;
-                    body: string;
+                    body: string | null;
                     isStale: boolean;
                   } | null;
                   files: {

--- a/apps/nextjs/src/lib/data/conversationMessage.ts
+++ b/apps/nextjs/src/lib/data/conversationMessage.ts
@@ -29,7 +29,6 @@ const isAiDraftStale = (draft: typeof conversationMessages.$inferSelect, mailbox
 export const serializeResponseAiDraft = (
   draft: typeof conversationMessages.$inferSelect,
   mailbox: typeof mailboxes.$inferSelect,
-  user?: User,
 ) => {
   if (!draft?.responseToId) {
     return null;
@@ -37,16 +36,9 @@ export const serializeResponseAiDraft = (
   return {
     id: draft.id,
     responseToId: draft.responseToId,
-    body: bodyWithSignature(draft.body, user),
+    body: draft.body,
     isStale: isAiDraftStale(draft, mailbox),
   };
-};
-
-export const bodyWithSignature = (body?: string | null, user?: User) => {
-  if (body && user?.firstName) {
-    return `${body}<br><br>Best,<br>${user?.firstName}`;
-  }
-  return body ?? "";
 };
 
 export const getMessagesOnly = async (conversationId: number) => {
@@ -354,8 +346,7 @@ export const createReply = async (
 
     const lastAiDraft = await getLastAiGeneratedDraft(conversationId, tx);
     if (lastAiDraft?.body) {
-      const draftBody = user ? bodyWithSignature(lastAiDraft.body, user) : lastAiDraft.body;
-      if (message && cleanupMessage(draftBody) === cleanupMessage(message)) {
+      if (message && cleanupMessage(lastAiDraft.body) === cleanupMessage(message)) {
         await tx
           .update(conversationMessages)
           .set({ isPerfect: true })

--- a/apps/nextjs/src/lib/slack/shared.ts
+++ b/apps/nextjs/src/lib/slack/shared.ts
@@ -5,7 +5,7 @@ import { assertDefined } from "@/components/utils/assert";
 import { db } from "@/db/client";
 import { conversations } from "@/db/schema";
 import { updateConversation } from "@/lib/data/conversation";
-import { bodyWithSignature, createReply, getLastAiGeneratedDraft } from "@/lib/data/conversationMessage";
+import { createReply, getLastAiGeneratedDraft } from "@/lib/data/conversationMessage";
 import { addNote } from "@/lib/data/note";
 import { getOrganizationMembers } from "@/lib/data/organization";
 import { findUserViaSlack, getClerkUser } from "@/lib/data/user";
@@ -237,7 +237,6 @@ const openRespondModal = async (
   triggerId: string,
 ) => {
   const draft = await getLastAiGeneratedDraft(message.conversationId);
-  const draftBody = bodyWithSignature(draft?.body, user);
   await openSlackModal({
     token: assertDefined(conversation.mailbox.slackBotToken),
     triggerId,
@@ -252,7 +251,7 @@ const openRespondModal = async (
           label: { type: "plain_text", text: "Reply" },
           element: {
             type: "plain_text_input",
-            initial_value: draftBody,
+            initial_value: draft?.body ?? "",
             multiline: true,
             focus_on_load: true,
             action_id: "message",

--- a/apps/nextjs/src/trpc/router/mailbox/conversations/index.ts
+++ b/apps/nextjs/src/trpc/router/mailbox/conversations/index.ts
@@ -103,7 +103,7 @@ export const conversationsRouter = {
 
     return {
       ...(await serializeConversationWithMessages(ctx.mailbox, ctx.conversation)),
-      draft: draft ? serializeResponseAiDraft(draft, ctx.mailbox, user) : null,
+      draft: draft ? serializeResponseAiDraft(draft, ctx.mailbox) : null,
     };
   }),
   create: mailboxProcedure

--- a/apps/nextjs/tests/lib/data/conversationMessage.test.ts
+++ b/apps/nextjs/tests/lib/data/conversationMessage.test.ts
@@ -95,32 +95,6 @@ describe("serializeResponseAiDraft", () => {
       isStale: true,
     });
   });
-
-  it("includes signature when provided", async () => {
-    const { mailbox, user } = await userFactory.createRootUser({ userOverrides: { firstName: "John" } });
-    const { conversation } = await conversationFactory.create(mailbox.id);
-    const { message } = await conversationMessagesFactory.create(conversation.id, { role: "user" });
-    const { message: draft } = await conversationMessagesFactory.create(conversation.id, {
-      role: "ai_assistant",
-      body: "This is a draft",
-      responseToId: message.id,
-      status: "draft",
-    });
-
-    expect(serializeResponseAiDraft(draft, mailbox)).toEqual({
-      id: draft.id,
-      responseToId: message.id,
-      body: `This is a draft`,
-      isStale: false,
-    });
-
-    expect(serializeResponseAiDraft(draft, mailbox, user)).toEqual({
-      id: draft.id,
-      responseToId: message.id,
-      body: `This is a draft<br><br>Best,<br>John`,
-      isStale: false,
-    });
-  });
 });
 
 describe("getMessages", () => {

--- a/apps/nextjs/tests/lib/data/conversationMessage.test.ts
+++ b/apps/nextjs/tests/lib/data/conversationMessage.test.ts
@@ -518,13 +518,13 @@ describe("createReply", () => {
 
     const result = await createReply({
       conversationId: conversation.id,
-      message: `<p>AI generated response</p><p>Best,</p><p>${user.firstName}</p>`,
+      message: `<p>AI generated response</p>`,
       user,
     });
 
     const createdMessage = await getConversationMessageById(result);
     expect(createdMessage).toMatchObject({
-      body: `<p>AI generated response</p><p>Best,</p><p>${user.firstName}</p>`,
+      body: `<p>AI generated response</p>`,
       isPerfect: true,
     });
   });

--- a/apps/nextjs/tests/lib/slack/shared.test.ts
+++ b/apps/nextjs/tests/lib/slack/shared.test.ts
@@ -20,7 +20,6 @@ vi.mock("@/lib/slack/client", () => ({
 
 vi.mock("@/lib/data/conversationMessage", () => ({
   createReply: vi.fn(),
-  bodyWithSignature: vi.fn(),
   getLastAiGeneratedDraft: vi.fn(),
 }));
 


### PR DESCRIPTION
Part of #128 

Removes the current automatic signature on AI drafts; this will be replaced by the new one for all emails.

AI drafts are rarely used so we can merge this first.