### PR TITLE
chore: fix TypeScript errors in tests

### DIFF
--- a/apps/nextjs/package.json
+++ b/apps/nextjs/package.json
@@ -27,7 +27,7 @@
     "start": "npx next start",
     "test": "npm run with-dev-env vitest",
     "test:watch": "npm run with-dev-env vitest -- --watch",
-    "typecheck": "tsc --noEmit && npm run with-dev-env npm run build && npm run db:check",
+    "typecheck": "npm run with-dev-env npm run build; BUILD_EXIT=$?; tsc --noEmit && ([ $BUILD_EXIT -eq 0 ] && npm run db:check || exit $BUILD_EXIT)",
     "with-dev-env": "dotenv -e ./.env.development.local -e ./.env.local --"
   },
   "overrides": {

--- a/apps/nextjs/package.json
+++ b/apps/nextjs/package.json
@@ -27,7 +27,7 @@
     "start": "npx next start",
     "test": "npm run with-dev-env vitest",
     "test:watch": "npm run with-dev-env vitest -- --watch",
-    "typecheck": "npm run with-dev-env npm run build && npm run db:check",
+    "typecheck": "tsc --noEmit && npm run with-dev-env npm run build && npm run db:check",
     "with-dev-env": "dotenv -e ./.env.development.local -e ./.env.local --"
   },
   "overrides": {

--- a/apps/nextjs/src/lib/gmail/lib.tsx
+++ b/apps/nextjs/src/lib/gmail/lib.tsx
@@ -4,7 +4,7 @@ import { and, desc, isNotNull, isNull } from "drizzle-orm";
 import { htmlToText } from "html-to-text";
 import MailComposer from "nodemailer/lib/mail-composer";
 import { db } from "@/db/client";
-import { conversationMessages, conversations, files, mailboxes } from "@/db/schema";
+import { conversationMessages, conversations, files } from "@/db/schema";
 import AIReplyEmail from "@/emails/aiReply";
 import { getClerkUser } from "@/lib/data/user";
 import { getFileStream } from "@/s3/utils";
@@ -13,7 +13,6 @@ export const convertConversationMessageToRaw = async (
   email: typeof conversationMessages.$inferSelect & {
     conversation: typeof conversations.$inferSelect & {
       emailFrom: string;
-      mailbox: Pick<typeof mailboxes.$inferSelect, "id" | "name" | "widgetHost">;
     };
     files: (typeof files.$inferSelect)[];
   },

--- a/apps/nextjs/tests/lib/ai/index.test.ts
+++ b/apps/nextjs/tests/lib/ai/index.test.ts
@@ -29,6 +29,9 @@ const mockCompletionResponse = {
   experimental_providerMetadata: {},
   request: {},
   reasoning: "",
+  reasoningDetails: [],
+  sources: [],
+  providerMetadata: {},
 } satisfies GenerateTextResult<Record<string, CoreTool>, undefined>;
 
 describe("runAIQuery", () => {
@@ -107,6 +110,9 @@ describe("runAIQuery", () => {
         },
       },
       reasoning: "",
+      reasoningDetails: [],
+      sources: [],
+      providerMetadata: {},
       experimental_output: undefined as never,
       toolCalls: [],
       toolResults: [],
@@ -170,6 +176,7 @@ describe("runAIObjectQuery", () => {
         throw new Error("Not implemented");
       },
       ...mockCompletionResponse,
+      providerMetadata: {},
     });
   });
 
@@ -202,6 +209,7 @@ describe("runAIObjectQuery", () => {
           cachedPromptTokens: 100,
         },
       },
+      providerMetadata: {},
       logprobs: [],
       toJsonResponse: () => {
         throw new Error("Not implemented");

--- a/apps/nextjs/tests/lib/data/conversation.test.ts
+++ b/apps/nextjs/tests/lib/data/conversation.test.ts
@@ -17,7 +17,6 @@ import {
   getConversationBySlugAndMailbox,
   getNonSupportParticipants,
   getRelatedConversations,
-  MAX_RELATED_CONVERSATIONS_COUNT,
   updateConversation,
 } from "@/lib/data/conversation";
 import { getClerkOrganization } from "@/lib/data/organization";
@@ -330,8 +329,8 @@ describe("getRelatedConversations", () => {
     });
 
     vi.mocked(searchEmailsByKeywords).mockResolvedValue([
-      { id: message1.id, conversationId: conversation1.id },
-      { id: message2.id, conversationId: conversation2.id },
+      { id: message1.id, conversationId: conversation1.id, cleanedUpText: message1.cleanedUpText },
+      { id: message2.id, conversationId: conversation2.id, cleanedUpText: message2.cleanedUpText },
     ]);
 
     // Get all related conversations


### PR DESCRIPTION
`tsc` gives more useful output than `build` and checks more files so I often want to use it locally, but we have some type errors in test files that bloat the output.

This also adds `tsc` to the typecheck command so we get better output in CI.