### PR TITLE
fix: update lastUserEmailCreatedAt when merging conversations

### DIFF
--- a/apps/nextjs/src/inngest/functions/mergeSimilarConversations.ts
+++ b/apps/nextjs/src/inngest/functions/mergeSimilarConversations.ts
@@ -147,6 +147,21 @@ Should the current conversation be merged into any of the others? If so, which o
       }
 
       await db.update(conversations).set({ mergedIntoId: mergeIntoId }).where(eq(conversations.id, conversation.id));
+      if (conversation.lastUserEmailCreatedAt) {
+        await db
+          .update(conversations)
+          .set({
+            lastUserEmailCreatedAt: new Date(
+              Math.max(
+                conversation.lastUserEmailCreatedAt.getTime(),
+                ...(targetConversation.lastUserEmailCreatedAt
+                  ? [targetConversation.lastUserEmailCreatedAt.getTime()]
+                  : []),
+              ),
+            ),
+          })
+          .where(eq(conversations.id, mergeIntoId));
+      }
 
       return {
         message: `Conversation ${conversation.id} merged into ${mergeIntoId}`,


### PR DESCRIPTION
Noticed locally that merged conversations wouldn't be bumped to the top of the "Newest" list because the timestamp was still the last message in the original conversation.