### PR TITLE
fix: reload conversation list when taking actions in the app

### DIFF
--- a/apps/expo/src/app/(dashboard)/conversations/[id].tsx
+++ b/apps/expo/src/app/(dashboard)/conversations/[id].tsx
@@ -8,6 +8,7 @@ import { InformationCircleIcon, LinkIcon } from "react-native-heroicons/outline"
 import { SafeAreaProvider, SafeAreaView } from "react-native-safe-area-context";
 import { WebView } from "react-native-webview";
 import { useAuthenticatedUrl } from "@/components/useGenerateUrl";
+import { api } from "@/utils/api";
 import { backgroundColor, cssIconInterop } from "@/utils/css";
 
 cssIconInterop(InformationCircleIcon);
@@ -32,6 +33,8 @@ export default function ConversationView() {
   const { id, mailboxSlug } = useLocalSearchParams<{ id: string; mailboxSlug: string }>();
   const webViewRef = useRef<WebView>(null);
   const navigation = useNavigation();
+
+  const utils = api.useUtils();
 
   const url = useAuthenticatedUrl(`/mailboxes/${mailboxSlug}/conversations?id=${id}`);
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -71,6 +74,8 @@ export default function ConversationView() {
               });
             } else if (data.type === "openUrl" && data.url) {
               Linking.openURL(data.url);
+            } else if (data.type === "conversationUpdated") {
+              utils.mailbox.conversations.list.invalidate();
             }
           }}
         />

--- a/apps/expo/src/app/(dashboard)/conversations/[id].tsx
+++ b/apps/expo/src/app/(dashboard)/conversations/[id].tsx
@@ -76,6 +76,7 @@ export default function ConversationView() {
               Linking.openURL(data.url);
             } else if (data.type === "conversationUpdated") {
               utils.mailbox.conversations.list.invalidate();
+              utils.mailbox.conversations.listWithPreview.invalidate();
             }
           }}
         />

--- a/apps/nextjs/src/app/(dashboard)/mailboxes/[mailbox_slug]/(inbox)/_components/conversationListContext.tsx
+++ b/apps/nextjs/src/app/(dashboard)/mailboxes/[mailbox_slug]/(inbox)/_components/conversationListContext.tsx
@@ -3,6 +3,7 @@ import { useQueryState } from "nuqs";
 import { createContext, useContext, useEffect, useMemo } from "react";
 import { useBreakpoint } from "@/components/useBreakpoint";
 import { useDebouncedCallback } from "@/components/useDebouncedCallback";
+import { getExpoPlatform } from "@/components/useNativePlatform";
 import { assertDefined } from "@/components/utils/assert";
 import { RouterOutputs } from "@/trpc";
 import { api } from "@/trpc/react";
@@ -52,6 +53,7 @@ export const ConversationListContextProvider = ({
 
   const moveToNextConversation = () => {
     if (!conversations.length) return setId(null);
+    if (getExpoPlatform()) return; // In Expo the conversation is effectively a modal so it's confusing to navigate within it
 
     let nextConversation;
     const currentIndex = conversations.findIndex((c) => c.slug === currentConversationSlug);

--- a/apps/nextjs/src/app/(dashboard)/mailboxes/[mailbox_slug]/(inbox)/_components/conversationSidebar.tsx
+++ b/apps/nextjs/src/app/(dashboard)/mailboxes/[mailbox_slug]/(inbox)/_components/conversationSidebar.tsx
@@ -3,6 +3,7 @@ import { ArrowTopRightOnSquareIcon, CurrencyDollarIcon, EnvelopeIcon } from "@he
 import { useState } from "react";
 import CopyToClipboard from "react-copy-to-clipboard";
 import { AssignPopoverButton } from "@/app/(dashboard)/mailboxes/[mailbox_slug]/(inbox)/_components/assignPopoverButton";
+import { useConversationContext } from "@/app/(dashboard)/mailboxes/[mailbox_slug]/(inbox)/_components/conversationContext";
 import { Conversation } from "@/app/types/global";
 import { toast } from "@/components/hooks/use-toast";
 import HumanizedTime from "@/components/humanizedTime";
@@ -30,11 +31,7 @@ interface ConversationItemProps {
   status: "open" | "closed" | "spam" | null;
   mailboxSlug: string;
   navigateToConversation: (slug: string) => void;
-  removeConversation: () => void;
-  updateConversation: (
-    params: { mailboxSlug: string; conversationSlug: string; status: "open" | "closed" | "spam" },
-    options: { onSuccess: () => void; onError: () => void },
-  ) => void;
+  updateStatus: (status: "closed" | "spam" | "open") => void;
 }
 
 const ConversationItem = ({
@@ -46,8 +43,7 @@ const ConversationItem = ({
   status,
   mailboxSlug,
   navigateToConversation,
-  removeConversation,
-  updateConversation,
+  updateStatus,
 }: ConversationItemProps) => (
   <div
     key={slug}
@@ -72,18 +68,7 @@ const ConversationItem = ({
           className="h-6 w-6 opacity-0 group-hover:opacity-100 transition-opacity"
           onClick={(e) => {
             e.stopPropagation();
-            updateConversation(
-              { mailboxSlug, conversationSlug: slug, status: "closed" },
-              {
-                onSuccess: () => {
-                  removeConversation();
-                  toast({ title: "Conversation closed" });
-                },
-                onError: () => {
-                  toast({ variant: "destructive", title: "Failed to close conversation" });
-                },
-              },
-            );
+            updateStatus("closed");
           }}
         >
           <ArrowUturnLeftIcon className="h-4 w-4 text-muted-foreground hover:text-foreground" />
@@ -99,8 +84,8 @@ const ConversationItem = ({
 );
 
 const ConversationSidebar = ({ mailboxSlug, conversation }: ConversationSidebarProps) => {
-  const { navigateToConversation, removeConversation } = useConversationListContext();
-  const { mutate: updateConversation } = api.mailbox.conversations.update.useMutation();
+  const { navigateToConversation } = useConversationListContext();
+  const { updateStatus } = useConversationContext();
   const [previousExpanded, setPreviousExpanded] = useState(true);
   const [similarExpanded, setSimilarExpanded] = useState(false);
 
@@ -214,8 +199,7 @@ const ConversationSidebar = ({ mailboxSlug, conversation }: ConversationSidebarP
                       status={conv.status}
                       mailboxSlug={mailboxSlug}
                       navigateToConversation={navigateToConversation}
-                      removeConversation={removeConversation}
-                      updateConversation={updateConversation}
+                      updateStatus={updateStatus}
                     />
                   ))
                 )}
@@ -247,8 +231,7 @@ const ConversationSidebar = ({ mailboxSlug, conversation }: ConversationSidebarP
                       similarity={similarConversations?.similarityMap?.[conv.slug]}
                       mailboxSlug={mailboxSlug}
                       navigateToConversation={navigateToConversation}
-                      removeConversation={removeConversation}
-                      updateConversation={updateConversation}
+                      updateStatus={updateStatus}
                     />
                   ))
                 )}

--- a/apps/nextjs/src/app/(dashboard)/mailboxes/[mailbox_slug]/(inbox)/_components/useAssignTicket.ts
+++ b/apps/nextjs/src/app/(dashboard)/mailboxes/[mailbox_slug]/(inbox)/_components/useAssignTicket.ts
@@ -1,19 +1,19 @@
+import { useConversationContext } from "@/app/(dashboard)/mailboxes/[mailbox_slug]/(inbox)/_components/conversationContext";
 import { useConversationListContext } from "@/app/(dashboard)/mailboxes/[mailbox_slug]/(inbox)/_components/conversationListContext";
 import { useConversationsListInput } from "@/app/(dashboard)/mailboxes/[mailbox_slug]/(inbox)/_components/shared/queries";
 import { toast } from "@/components/hooks/use-toast";
-import { assertDefined } from "@/components/utils/assert";
 import { api } from "@/trpc/react";
 
 export const useAssignTicket = () => {
-  const { mutate: update } = api.mailbox.conversations.update.useMutation();
   const utils = api.useUtils();
   const { input } = useConversationsListInput();
-  const { mailboxSlug, currentConversationSlug, conversationListData, moveToNextConversation, removeConversation } =
+  const { currentConversationSlug, conversationListData, moveToNextConversation, removeConversation } =
     useConversationListContext();
+  const { updateConversation } = useConversationContext();
 
   const assignTicket = (assignedTo: { id: string; displayName: string } | null, message?: string | null) => {
     const assignedToId = assignedTo?.id ?? null;
-    update({ mailboxSlug, conversationSlug: assertDefined(currentConversationSlug), assignedToId, message });
+    updateConversation({ assignedToId, message });
 
     utils.mailbox.conversations.list.setInfiniteData(input, (data) => {
       if (!data) return data;

--- a/apps/nextjs/src/components/nativeAppIntegration.tsx
+++ b/apps/nextjs/src/components/nativeAppIntegration.tsx
@@ -19,9 +19,11 @@ export function NativeAppIntegration() {
     if (!tauriPlatform && !window.ReactNativeWebView) return;
     if (tauriPlatform && getCurrentWebview().label === "tab_bar") return;
 
-    listen<string>("tab-context-menu", (event) => {
-      setRecentlyClosedTabs(event.payload ? JSON.parse(event.payload) : null);
-    });
+    if (tauriPlatform) {
+      listen<string>("tab-context-menu", (event) => {
+        setRecentlyClosedTabs(event.payload ? JSON.parse(event.payload) : null);
+      });
+    }
 
     const handleLinkClick = (event: MouseEvent) => {
       const target = event.target as HTMLElement;


### PR DESCRIPTION
Fixes #164 

Bit of a brute-force solution at the moment, reloading the entire list. Once performance starts to matter we can improve it by passing the changes and using `setData` instead of invalidating.