### PR TITLE
fix: improve open count query

### DIFF
--- a/apps/expo/src/types/api.ts
+++ b/apps/expo/src/types/api.ts
@@ -52,31 +52,15 @@ export declare const appRouter: import("@trpc/server/unstable-core-do-not-import
           slug: string;
         }[];
       }>;
-      countByStatus: import("@trpc/server").TRPCQueryProcedure<{
+      openCount: import("@trpc/server").TRPCQueryProcedure<{
         input: {
           mailboxSlug: string;
         };
         output: {
-          conversations: {
-            open: number;
-            closed: number;
-            spam: number;
-          };
-          mine: {
-            open: number;
-            closed: number;
-            spam: number;
-          };
-          assigned: {
-            open: number;
-            closed: number;
-            spam: number;
-          };
-          unassigned: {
-            open: number;
-            closed: number;
-            spam: number;
-          };
+          conversations: number;
+          mine: number;
+          assigned: number;
+          unassigned: number;
         };
       }>;
       get: import("@trpc/server").TRPCQueryProcedure<{

--- a/apps/nextjs/src/app/(dashboard)/mailboxes/[mailbox_slug]/(inbox)/_components/conversationListContext.tsx
+++ b/apps/nextjs/src/app/(dashboard)/mailboxes/[mailbox_slug]/(inbox)/_components/conversationListContext.tsx
@@ -73,7 +73,7 @@ export const ConversationListContextProvider = ({
     router.refresh();
 
     utils.mailbox.conversations.list.invalidate();
-    utils.mailbox.countByStatus.invalidate();
+    utils.mailbox.openCount.invalidate();
   }, 1000);
 
   const removeConversationFromList = () => {

--- a/apps/nextjs/src/app/(dashboard)/mailboxes/[mailbox_slug]/(inbox)/_components/list.tsx
+++ b/apps/nextjs/src/app/(dashboard)/mailboxes/[mailbox_slug]/(inbox)/_components/list.tsx
@@ -171,15 +171,12 @@ const ListContent = ({ variant }: { variant: "desktop" | "mobile" }) => {
   }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
 
   const statusOptions = useMemo(() => {
-    const statuses = status.flatMap((status) =>
-      status.status
+    const statuses = status.flatMap((s) =>
+      s.status
         ? {
-            value: status.status,
-            label:
-              status.status === "open"
-                ? `${status.count.toLocaleString()} ${capitalize(status.status)}`
-                : capitalize(status.status),
-            selected: searchParams.status ? searchParams.status == status.status : status.status === "open",
+            value: s.status as StatusOption,
+            label: s.status === "open" ? `${s.count.toLocaleString()} ${capitalize(s.status)}` : capitalize(s.status),
+            selected: searchParams.status ? searchParams.status == s.status : s.status === "open",
           }
         : [],
     );
@@ -187,7 +184,7 @@ const ListContent = ({ variant }: { variant: "desktop" | "mobile" }) => {
     if (searchParams.status) {
       if (!statuses.some((s) => s.value === searchParams.status)) {
         statuses.push({
-          value: searchParams.status,
+          value: searchParams.status as StatusOption,
           label:
             searchParams.status === "open" ? `0 ${capitalize(searchParams.status)}` : capitalize(searchParams.status),
           selected: true,

--- a/apps/nextjs/src/app/(dashboard)/mailboxes/[mailbox_slug]/(inbox)/_components/list.tsx
+++ b/apps/nextjs/src/app/(dashboard)/mailboxes/[mailbox_slug]/(inbox)/_components/list.tsx
@@ -171,15 +171,11 @@ const ListContent = ({ variant }: { variant: "desktop" | "mobile" }) => {
   }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
 
   const statusOptions = useMemo(() => {
-    const statuses = status.flatMap((s) =>
-      s.status
-        ? {
-            value: s.status as StatusOption,
-            label: s.status === "open" ? `${s.count.toLocaleString()} ${capitalize(s.status)}` : capitalize(s.status),
-            selected: searchParams.status ? searchParams.status == s.status : s.status === "open",
-          }
-        : [],
-    );
+    const statuses = status.flatMap((s) => ({
+      value: s.status as StatusOption,
+      label: s.status === "open" ? `${s.count.toLocaleString()} ${capitalize(s.status)}` : capitalize(s.status),
+      selected: searchParams.status ? searchParams.status == s.status : s.status === "open",
+    }));
 
     if (searchParams.status) {
       if (!statuses.some((s) => s.value === searchParams.status)) {

--- a/apps/nextjs/src/app/(dashboard)/mailboxes/[mailbox_slug]/(inbox)/_components/list.tsx
+++ b/apps/nextjs/src/app/(dashboard)/mailboxes/[mailbox_slug]/(inbox)/_components/list.tsx
@@ -137,14 +137,14 @@ const ListContent = ({ variant }: { variant: "desktop" | "mobile" }) => {
 
   const conversations = conversationListData?.conversations ?? [];
   const total = conversationListData?.total ?? 0;
-  const { data: countData } = api.mailbox.countByStatus.useQuery({ mailboxSlug: input.mailboxSlug });
-  const status = countData
-    ? (["open", "closed", "spam"] as const)
-        .map((status) => ({
-          status,
-          count: countData[category][status] ?? 0,
-        }))
-        .filter((c) => c.count > 0 || c.status === "open")
+  const { data: openCount } = api.mailbox.openCount.useQuery({ mailboxSlug: input.mailboxSlug });
+
+  const status = openCount
+    ? [
+        { status: "open", count: openCount[category] },
+        { status: "closed", count: 0 },
+        { status: "spam", count: 0 },
+      ]
     : [];
   const defaultSort = conversationListData?.defaultSort;
 
@@ -176,9 +176,9 @@ const ListContent = ({ variant }: { variant: "desktop" | "mobile" }) => {
         ? {
             value: status.status,
             label:
-              status.status === "closed" || status.status === "spam"
-                ? capitalize(status.status)
-                : `${status.count.toLocaleString()} ${capitalize(status.status)}`,
+              status.status === "open"
+                ? `${status.count.toLocaleString()} ${capitalize(status.status)}`
+                : capitalize(status.status),
             selected: searchParams.status ? searchParams.status == status.status : status.status === "open",
           }
         : [],
@@ -189,9 +189,7 @@ const ListContent = ({ variant }: { variant: "desktop" | "mobile" }) => {
         statuses.push({
           value: searchParams.status,
           label:
-            searchParams.status === "closed" || searchParams.status === "spam"
-              ? capitalize(searchParams.status)
-              : `0 ${capitalize(searchParams.status)}`,
+            searchParams.status === "open" ? `0 ${capitalize(searchParams.status)}` : capitalize(searchParams.status),
           selected: true,
         });
       }

--- a/apps/nextjs/src/app/(dashboard)/mailboxes/[mailbox_slug]/(inbox)/_components/mobileList.tsx
+++ b/apps/nextjs/src/app/(dashboard)/mailboxes/[mailbox_slug]/(inbox)/_components/mobileList.tsx
@@ -15,7 +15,7 @@ export const MobileList = () => {
   const [conversationSlug] = useQueryState("id");
   const { nativePlatform, isLegacyTauri } = useNativePlatform();
 
-  const { data: countData } = api.mailbox.countByStatus.useQuery(
+  const { data: openCount } = api.mailbox.openCount.useQuery(
     { mailboxSlug },
     {
       staleTime: 0,
@@ -33,7 +33,7 @@ export const MobileList = () => {
       {nativePlatform === "macos" && isLegacyTauri && <TauriDragArea className="top-0 inset-x-0 h-8" />}
       <AppInstallBanner />
       <CategoryNav
-        countByStatus={countData}
+        openCount={openCount}
         mailboxSlug={mailboxSlug}
         variant="mobile"
         className={cn("flex items-center h-14 px-4", nativePlatform === "macos" && "mt-8")}

--- a/apps/nextjs/src/app/(dashboard)/mailboxes/[mailbox_slug]/_components/appSidebar.tsx
+++ b/apps/nextjs/src/app/(dashboard)/mailboxes/[mailbox_slug]/_components/appSidebar.tsx
@@ -65,7 +65,7 @@ declare global {
 }
 
 export function AppSidebar({ mailboxSlug, sidebarInfo }: Props) {
-  const { countByStatus, mailboxes, currentMailbox, loggedInName, avatarName, trialInfo } = sidebarInfo;
+  const { openCount, mailboxes, currentMailbox, loggedInName, avatarName, trialInfo } = sidebarInfo;
   const pathname = usePathname();
   const { isMobile } = useSidebar();
   const { signOut } = useClerk();
@@ -174,7 +174,7 @@ export function AppSidebar({ mailboxSlug, sidebarInfo }: Props) {
           </div>
         ) : (
           <>
-            <CategoryNav countByStatus={countByStatus} mailboxSlug={mailboxSlug} variant="sidebar" />
+            <CategoryNav openCount={openCount} mailboxSlug={mailboxSlug} variant="sidebar" />
             <ConversationList mailboxSlug={mailboxSlug} />
           </>
         )}

--- a/apps/nextjs/src/app/(dashboard)/mailboxes/[mailbox_slug]/_components/categoryNav.tsx
+++ b/apps/nextjs/src/app/(dashboard)/mailboxes/[mailbox_slug]/_components/categoryNav.tsx
@@ -17,13 +17,13 @@ export const CATEGORY_LABELS = {
 };
 
 export const CategoryNav = ({
-  countByStatus,
+  openCount,
   mailboxSlug,
   variant,
   prefix,
   className,
 }: {
-  countByStatus?: SidebarInfo["countByStatus"];
+  openCount?: SidebarInfo["openCount"];
   mailboxSlug: string;
   variant: ChipVariant;
   prefix?: ReactNode;
@@ -36,7 +36,7 @@ export const CategoryNav = ({
       label: CATEGORY_LABELS.mine,
       icon: HeroUser,
       href: `/mailboxes/${mailboxSlug}/mine`,
-      count: countByStatus?.mine?.open ?? 0,
+      count: openCount?.mine ?? 0,
     },
     {
       label: CATEGORY_LABELS.all,
@@ -47,13 +47,13 @@ export const CategoryNav = ({
       label: CATEGORY_LABELS.assigned,
       icon: HeroUsers,
       href: `/mailboxes/${mailboxSlug}/assigned`,
-      count: countByStatus?.assigned?.open ?? 0,
+      count: openCount?.assigned ?? 0,
     },
     {
       label: CATEGORY_LABELS.unassigned,
       icon: HeroUserMinus,
       href: `/mailboxes/${mailboxSlug}/unassigned`,
-      count: countByStatus?.unassigned?.open ?? 0,
+      count: openCount?.unassigned ?? 0,
     },
   ];
 

--- a/apps/nextjs/src/app/(dashboard)/mailboxes/[mailbox_slug]/_components/getSidebarInfo.ts
+++ b/apps/nextjs/src/app/(dashboard)/mailboxes/[mailbox_slug]/_components/getSidebarInfo.ts
@@ -2,9 +2,9 @@ import { currentUser } from "@clerk/nextjs/server";
 import { api } from "@/trpc/server";
 
 export const getSidebarInfo = async (mailboxSlug: string) => {
-  const [user, countByStatus, mailboxes, { trialInfo }] = await Promise.all([
+  const [user, openCount, mailboxes, { trialInfo }] = await Promise.all([
     currentUser(),
-    api.mailbox.countByStatus({ mailboxSlug }),
+    api.mailbox.openCount({ mailboxSlug }),
     api.mailbox.list(),
     api.organization.getOnboardingStatus(),
   ]);
@@ -14,7 +14,7 @@ export const getSidebarInfo = async (mailboxSlug: string) => {
   const loggedInEmail = user?.primaryEmailAddress?.emailAddress;
   const avatarName = loggedInEmail || loggedInName;
 
-  return { countByStatus, mailboxes, currentMailbox, loggedInName, loggedInEmail, avatarName, trialInfo };
+  return { openCount, mailboxes, currentMailbox, loggedInName, loggedInEmail, avatarName, trialInfo };
 };
 
 export type SidebarInfo = Awaited<ReturnType<typeof getSidebarInfo>>;


### PR DESCRIPTION
- Only return the open count per status, since that’s the only one we display.
- Simplify the logic to reduce both query complexity and the total number of queries.
- Renamed tRPC query from `countByStatus` to `openCount`