### PR TITLE
fix: request cache clerk calls

### DIFF
--- a/apps/nextjs/src/lib/data/mailbox.ts
+++ b/apps/nextjs/src/lib/data/mailbox.ts
@@ -45,9 +45,8 @@ const getSlackConnectUrl = (mailboxSlug: string): string | null => {
 };
 
 export const getMailboxInfo = async (mailbox: typeof mailboxes.$inferSelect) => {
-  const organization = await getClerkOrganization(mailbox.clerkOrganizationId);
   const subscription = await db.query.subscriptions.findFirst({
-    where: and(eq(subscriptions.clerkOrganizationId, organization.id)),
+    where: and(eq(subscriptions.clerkOrganizationId, mailbox.clerkOrganizationId)),
     columns: {
       canceledAt: true,
       status: true,

--- a/apps/nextjs/src/lib/data/organization.ts
+++ b/apps/nextjs/src/lib/data/organization.ts
@@ -23,9 +23,9 @@ export const setPrivateMetadata = async (organizationId: string, metadata: Recor
   return await clerkClient.organizations.updateOrganizationMetadata(organizationId, { privateMetadata: metadata });
 };
 
-export const getOrganizationMembers = async (organizationId: string, limit = 100) => {
+export const getOrganizationMembers = cache(async (organizationId: string, limit = 100) => {
   return await clerkClient.organizations.getOrganizationMembershipList({ organizationId, limit });
-};
+});
 
 export const getOrganizationAdminUsers = async (organizationId: string) => {
   const members = await getOrganizationMembers(organizationId);

--- a/apps/nextjs/src/lib/data/user.ts
+++ b/apps/nextjs/src/lib/data/user.ts
@@ -33,13 +33,13 @@ export const findUserViaSlack = cache(async (organizationId: string, token: stri
       user.emailAddresses.some((address) => address.emailAddress === slackUser?.profile?.email),
     ) ?? null
   );
-};
+});
 
-export const getOAuthAccessToken = async (clerkUserId: string, provider: "oauth_google" | "oauth_slack") => {
+export const getOAuthAccessToken = cache(async (clerkUserId: string, provider: "oauth_google" | "oauth_slack") => {
   const tokens = await clerkClient.users.getUserOauthAccessToken(clerkUserId, provider);
   return tokens.data[0]?.token;
-};
+});
 
-export const setPrivateMetadata = async (user: User, metadata: UserPrivateMetadata) => {
+export const setPrivateMetadata = cache(async (user: User, metadata: UserPrivateMetadata) => {
   await clerkClient.users.updateUserMetadata(user.id, { privateMetadata: metadata });
-};
+});


### PR DESCRIPTION
- Cache other Clerk calls in the same request
- Remove unncessary Clerk call that is fetching the organization