### PR TITLE
fix: agent should only respond to threads after an explicitly mention

### DIFF
--- a/apps/nextjs/src/lib/slack/agent/handleMessages.ts
+++ b/apps/nextjs/src/lib/slack/agent/handleMessages.ts
@@ -75,7 +75,7 @@ export const isAgentThread = async (event: GenericMessageEvent, mailboxInfo: Sla
   });
 
   for (const message of messages ?? []) {
-    if (message.user === mailbox.slackBotUserId) return true;
+    if (message.user !== mailbox.slackBotUserId && message.text?.includes(`<@${mailbox.slackBotUserId}>`)) return true;
   }
 
   return false;


### PR DESCRIPTION
Fixes a bug where it would respond without a mention if you replied to a "New message from VIP customer ..." thread for example