### PR TITLE
feat: move agent reply logic to Inngest job

### DIFF
--- a/apps/nextjs/src/inngest/client.ts
+++ b/apps/nextjs/src/inngest/client.ts
@@ -154,6 +154,13 @@ export const inngest = new Inngest({
           conversationId: z.number(),
         }),
       },
+      "slack/agent.message": {
+        data: z.object({
+          event: z.any(),
+          currentMailboxId: z.number(),
+          statusMessageTs: z.string(),
+        }),
+      },
     })
     .fromUnion<NonZodEvents>(),
   middleware: [sentryMiddleware()],

--- a/apps/nextjs/src/inngest/client.ts
+++ b/apps/nextjs/src/inngest/client.ts
@@ -159,6 +159,7 @@ export const inngest = new Inngest({
           event: z.any(),
           currentMailboxId: z.number(),
           statusMessageTs: z.string(),
+          agentThreadId: z.number(),
         }),
       },
     })

--- a/apps/nextjs/src/inngest/functions/index.ts
+++ b/apps/nextjs/src/inngest/functions/index.ts
@@ -15,6 +15,7 @@ import generateFilePreview from "./generateFilePreview";
 import generateWeeklyReports, { generateMailboxWeeklyReport } from "./generateWeeklyReports";
 import handleAutoResponse from "./handleAutoResponse";
 import handleGmailWebhookEvent from "./handleGmailWebhookEvent";
+import handleSlackAgentMessage from "./handleSlackAgentMessage";
 import handleStripeWebhookEvent from "./handleStripeWebhookEvent";
 import hardDeleteRecordsForNonPayingOrgs from "./hardDeleteRecordsForNonPayingOrgs";
 import importGmailThreads from "./importGmailThreads";
@@ -64,4 +65,5 @@ export default [
   ...autoCloseInactiveConversationsFunctions,
   updateSuggestedActions,
   autoAssignConversation,
+  handleSlackAgentMessage,
 ];

--- a/apps/nextjs/src/lib/slack/agent/handleMessages.ts
+++ b/apps/nextjs/src/lib/slack/agent/handleMessages.ts
@@ -1,70 +1,35 @@
 import { AppMentionEvent, AssistantThreadStartedEvent, GenericMessageEvent, WebClient } from "@slack/web-api";
-import { CoreMessage } from "ai";
-import { and, eq } from "drizzle-orm";
-import { takeUniqueOrThrow } from "@/components/utils/arrays";
 import { assertDefined } from "@/components/utils/assert";
-import { db } from "@/db/client";
-import { agentMessages, agentThreads } from "@/db/schema";
+import { inngest } from "@/inngest/client";
 import { Mailbox } from "@/lib/data/mailbox";
 import { SlackMailboxInfo, WHICH_MAILBOX_MESSAGE } from "@/lib/slack/agent/findMailboxForEvent";
-import { generateAgentResponse } from "@/lib/slack/agent/generateAgentResponse";
-import { getThreadMessages } from "@/lib/slack/client";
 
 export async function handleMessage(event: GenericMessageEvent | AppMentionEvent, mailboxInfo: SlackMailboxInfo) {
   if (!mailboxInfo.currentMailbox) {
     await askWhichMailbox(event, mailboxInfo.mailboxes);
     return;
   }
+
   const mailbox = mailboxInfo.currentMailbox;
   if (event.bot_id || event.bot_id === mailbox.slackBotUserId || event.bot_profile) return;
 
-  const existingThread = await db.query.agentThreads.findFirst({
-    where: and(eq(agentThreads.slackChannel, event.channel), eq(agentThreads.threadTs, event.thread_ts ?? event.ts)),
+  const client = new WebClient(assertDefined(mailbox.slackBotToken));
+  const statusMessage = await client.chat.postMessage({
+    channel: event.channel,
+    thread_ts: event.thread_ts ?? event.ts,
+    text: "_Thinking..._",
   });
-  const agentThread = existingThread
-    ? existingThread
-    : await db
-        .insert(agentThreads)
-        .values({
-          mailboxId: mailbox.id,
-          slackChannel: event.channel,
-          threadTs: event.thread_ts ?? event.ts,
-        })
-        .returning()
-        .then(takeUniqueOrThrow);
 
-  if (event.text) {
-    const [message] = await db
-      .insert(agentMessages)
-      .values({
-        agentThreadId: agentThread.id,
-        role: "user",
-        content: event.text,
-        slackChannel: event.channel,
-        messageTs: event.ts,
-      })
-      .onConflictDoNothing()
-      .returning();
-    if (!message) return;
-  }
+  if (!statusMessage?.ts) throw new Error("Failed to post initial message");
 
-  const { thread_ts, channel } = event;
-  const { showStatus, showResult } = await replyHandler(
-    new WebClient(assertDefined(mailbox.slackBotToken)),
-    event,
-    agentThread,
-  );
-
-  const messages = thread_ts
-    ? await getThreadMessages(
-        assertDefined(mailbox.slackBotToken),
-        channel,
-        thread_ts,
-        assertDefined(mailbox.slackBotUserId),
-      )
-    : ([{ role: "user", content: event.text ?? "" }] satisfies CoreMessage[]);
-  const result = await generateAgentResponse(messages, mailbox, event.user, showStatus);
-  showResult(result);
+  await inngest.send({
+    name: "slack/agent.message",
+    data: {
+      event,
+      currentMailboxId: mailbox.id,
+      statusMessageTs: statusMessage.ts,
+    },
+  });
 }
 
 export async function handleAssistantThreadMessage(event: AssistantThreadStartedEvent, mailboxInfo: SlackMailboxInfo) {
@@ -117,78 +82,6 @@ export const isAgentThread = async (event: GenericMessageEvent, mailboxInfo: Sla
   }
 
   return false;
-};
-
-const replyHandler = async (
-  client: WebClient,
-  event: { channel: string; thread_ts?: string; ts: string; text?: string },
-  agentThread: typeof agentThreads.$inferSelect,
-) => {
-  const debug = event.text && /(?:^|\s)!debug(?:$|\s)/.test(event.text);
-
-  const statusMessage = await client.chat.postMessage({
-    channel: event.channel,
-    thread_ts: event.thread_ts ?? event.ts,
-    text: "_Thinking..._",
-  });
-
-  if (!statusMessage?.ts) throw new Error("Failed to post initial message");
-
-  const showStatus = async (
-    status: string | null,
-    tool?: { toolName: string; parameters: Record<string, unknown> },
-  ) => {
-    if (tool && agentThread) {
-      await db.insert(agentMessages).values({
-        agentThreadId: agentThread.id,
-        role: "tool",
-        content: status ?? "",
-        metadata: tool,
-      });
-    }
-
-    if (debug) {
-      await client.chat.postMessage({
-        channel: event.channel,
-        thread_ts: event.thread_ts ?? event.ts,
-        text: tool
-          ? `_${status ?? "..."}_\n\n*Parameters:*\n\`\`\`\n${JSON.stringify(tool.parameters, null, 2)}\n\`\`\``
-          : `_${status ?? "..."}_`,
-      });
-    } else if (status) {
-      await client.chat.update({
-        channel: event.channel,
-        ts: statusMessage.ts!,
-        text: `_${status}_`,
-      });
-    }
-  };
-
-  const showResult = async (result: string) => {
-    if (agentThread) {
-      await db.insert(agentMessages).values({
-        agentThreadId: agentThread.id,
-        role: "assistant",
-        content: result,
-        slackChannel: event.channel,
-        messageTs: event.thread_ts ?? event.ts,
-      });
-    }
-
-    await client.chat.postMessage({
-      channel: event.channel,
-      thread_ts: event.thread_ts ?? event.ts,
-      text: result,
-    });
-    if (!debug) {
-      await client.chat.delete({
-        channel: event.channel,
-        ts: statusMessage.ts!,
-      });
-    }
-  };
-
-  return { showStatus, showResult };
 };
 
 const askWhichMailbox = async (event: GenericMessageEvent | AppMentionEvent, mailboxes: Mailbox[]) => {

--- a/apps/nextjs/src/lib/slack/agent/handleMessages.ts
+++ b/apps/nextjs/src/lib/slack/agent/handleMessages.ts
@@ -1,5 +1,9 @@
 import { AppMentionEvent, AssistantThreadStartedEvent, GenericMessageEvent, WebClient } from "@slack/web-api";
+import { and, eq } from "drizzle-orm";
+import { takeUniqueOrThrow } from "@/components/utils/arrays";
 import { assertDefined } from "@/components/utils/assert";
+import { db } from "@/db/client";
+import { agentMessages, agentThreads } from "@/db/schema";
 import { inngest } from "@/inngest/client";
 import { Mailbox } from "@/lib/data/mailbox";
 import { SlackMailboxInfo, WHICH_MAILBOX_MESSAGE } from "@/lib/slack/agent/findMailboxForEvent";
@@ -12,6 +16,43 @@ export async function handleMessage(event: GenericMessageEvent | AppMentionEvent
 
   const mailbox = mailboxInfo.currentMailbox;
   if (event.bot_id || event.bot_id === mailbox.slackBotUserId || event.bot_profile) return;
+
+  const existingThread = await db.query.agentThreads.findFirst({
+    where: and(eq(agentThreads.slackChannel, event.channel), eq(agentThreads.threadTs, event.thread_ts ?? event.ts)),
+  });
+
+  const agentThread = existingThread
+    ? existingThread
+    : await db
+        .insert(agentThreads)
+        .values({
+          mailboxId: mailbox.id,
+          slackChannel: event.channel,
+          threadTs: event.thread_ts ?? event.ts,
+        })
+        .returning()
+        .then(takeUniqueOrThrow);
+
+  let message = null;
+  if (event.text) {
+    const [createdMessage] = await db
+      .insert(agentMessages)
+      .values({
+        agentThreadId: agentThread.id,
+        role: "user",
+        content: event.text,
+        slackChannel: event.channel,
+        messageTs: event.ts,
+      })
+      .onConflictDoNothing()
+      .returning();
+
+    message = createdMessage;
+  }
+
+  if (!message || !event.text) {
+    return;
+  }
 
   const client = new WebClient(assertDefined(mailbox.slackBotToken));
   const statusMessage = await client.chat.postMessage({
@@ -28,6 +69,7 @@ export async function handleMessage(event: GenericMessageEvent | AppMentionEvent
       event,
       currentMailboxId: mailbox.id,
       statusMessageTs: statusMessage.ts,
+      agentThreadId: agentThread.id,
     },
   });
 }


### PR DESCRIPTION
Will give us better observability when the agent doesn't work properly. Not sure of the latency of Inngest processing - this might make responses too slow - but worth a try to debug some issues with it not replying.