### PR TITLE
feat: send replies using the agent

### DIFF
--- a/apps/nextjs/src/app/api/webhooks/slack/response/route.ts
+++ b/apps/nextjs/src/app/api/webhooks/slack/response/route.ts
@@ -1,7 +1,8 @@
-import { eq } from "drizzle-orm";
+import { and, desc, eq } from "drizzle-orm";
 import { db } from "@/db/client";
-import { conversationMessages, faqs } from "@/db/schema";
+import { agentMessages, conversationMessages, faqs } from "@/db/schema";
 import { handleKnowledgeBankSlackAction } from "@/lib/data/knowledge";
+import { handleAgentMessageSlackAction } from "@/lib/slack/agent/handleAgentMessageSlackAction";
 import { verifySlackRequest } from "@/lib/slack/client";
 import { handleMessageSlackAction } from "@/lib/slack/shared";
 
@@ -14,10 +15,22 @@ export const POST = async (request: Request) => {
   }
 
   const payload = JSON.parse(new URLSearchParams(body).get("payload") || "{}");
+  console.log(payload);
   const messageTs = payload.view?.private_metadata || payload.container?.message_ts;
 
   if (!messageTs) {
     return Response.json({ error: "Invalid payload" }, { status: 400 });
+  }
+
+  if (payload.container?.channel_ts) {
+    const agentMessage = await db.query.agentMessages.findFirst({
+      where: and(eq(agentMessages.slackChannel, payload.container.channel_id), eq(agentMessages.messageTs, messageTs)),
+      orderBy: desc(agentMessages.createdAt),
+    });
+    if (agentMessage) {
+      await handleAgentMessageSlackAction(agentMessage, payload);
+      return new Response(null, { status: 200 });
+    }
   }
 
   const message = await db.query.conversationMessages.findFirst({

--- a/apps/nextjs/src/app/api/webhooks/slack/response/route.ts
+++ b/apps/nextjs/src/app/api/webhooks/slack/response/route.ts
@@ -15,14 +15,13 @@ export const POST = async (request: Request) => {
   }
 
   const payload = JSON.parse(new URLSearchParams(body).get("payload") || "{}");
-  console.log(payload);
   const messageTs = payload.view?.private_metadata || payload.container?.message_ts;
 
   if (!messageTs) {
     return Response.json({ error: "Invalid payload" }, { status: 400 });
   }
 
-  if (payload.container?.channel_ts) {
+  if (payload.container?.channel_id) {
     const agentMessage = await db.query.agentMessages.findFirst({
       where: and(eq(agentMessages.slackChannel, payload.container.channel_id), eq(agentMessages.messageTs, messageTs)),
       orderBy: desc(agentMessages.createdAt),

--- a/apps/nextjs/src/inngest/client.ts
+++ b/apps/nextjs/src/inngest/client.ts
@@ -156,7 +156,7 @@ export const inngest = new Inngest({
       },
       "slack/agent.message": {
         data: z.object({
-          slackUserId: z.string(),
+          slackUserId: z.string().nullable(),
           currentMailboxId: z.number(),
           statusMessageTs: z.string(),
           agentThreadId: z.number(),

--- a/apps/nextjs/src/inngest/client.ts
+++ b/apps/nextjs/src/inngest/client.ts
@@ -156,7 +156,7 @@ export const inngest = new Inngest({
       },
       "slack/agent.message": {
         data: z.object({
-          event: z.any(),
+          slackUserId: z.string(),
           currentMailboxId: z.number(),
           statusMessageTs: z.string(),
           agentThreadId: z.number(),

--- a/apps/nextjs/src/inngest/client.ts
+++ b/apps/nextjs/src/inngest/client.ts
@@ -160,6 +160,7 @@ export const inngest = new Inngest({
           currentMailboxId: z.number(),
           statusMessageTs: z.string(),
           agentThreadId: z.number(),
+          confirmedReplyText: z.string().optional(),
         }),
       },
     })

--- a/apps/nextjs/src/inngest/functions/handleSlackAgentMessage.ts
+++ b/apps/nextjs/src/inngest/functions/handleSlackAgentMessage.ts
@@ -12,7 +12,7 @@ import { generateAgentResponse } from "@/lib/slack/agent/generateAgentResponse";
 import { getThreadMessages } from "@/lib/slack/agent/getThreadMessages";
 
 export const handleSlackAgentMessage = async (
-  slackUserId: string,
+  slackUserId: string | null,
   currentMailboxId: number,
   statusMessageTs: string,
   agentThreadId: number,

--- a/apps/nextjs/src/inngest/functions/handleSlackAgentMessage.ts
+++ b/apps/nextjs/src/inngest/functions/handleSlackAgentMessage.ts
@@ -1,5 +1,4 @@
 import { AppMentionEvent, GenericMessageEvent, WebClient } from "@slack/web-api";
-import { CoreMessage } from "ai";
 import { eq } from "drizzle-orm";
 import { takeUniqueOrThrow } from "@/components/utils/arrays";
 import { assertDefined } from "@/components/utils/assert";
@@ -13,10 +12,11 @@ import { generateAgentResponse } from "@/lib/slack/agent/generateAgentResponse";
 import { getThreadMessages } from "@/lib/slack/agent/getThreadMessages";
 
 export const handleSlackAgentMessage = async (
-  event: GenericMessageEvent | AppMentionEvent,
+  event: GenericMessageEvent | AppMentionEvent | null,
   currentMailboxId: number,
   statusMessageTs: string,
   agentThreadId: number,
+  confirmedReplyText: string | null,
 ) => {
   const mailbox = assertDefinedOrRaiseNonRetriableError(await getMailboxById(currentMailboxId));
   const agentThread = assertDefinedOrRaiseNonRetriableError(
@@ -25,9 +25,8 @@ export const handleSlackAgentMessage = async (
     }),
   );
 
-  const { thread_ts, channel } = event;
   const client = new WebClient(assertDefined(mailbox.slackBotToken));
-  const debug = event.text && /(?:^|\s)!debug(?:$|\s)/.test(event.text);
+  const debug = event?.text && /(?:^|\s)!debug(?:$|\s)/.test(event.text);
 
   const showStatus = async (
     status: string | null,
@@ -44,53 +43,57 @@ export const handleSlackAgentMessage = async (
 
     if (debug && status) {
       await client.chat.postMessage({
-        channel: event.channel,
-        thread_ts: event.thread_ts ?? event.ts,
+        channel: agentThread.slackChannel,
+        thread_ts: agentThread.threadTs,
         text: tool
           ? `_${status ?? "..."}_\n\n*Parameters:*\n\`\`\`\n${JSON.stringify(tool.parameters, null, 2)}\n\`\`\``
           : `_${status ?? "..."}_`,
       });
     } else if (status) {
       await client.chat.update({
-        channel: event.channel,
+        channel: agentThread.slackChannel,
         ts: statusMessageTs,
         text: `_${status}_`,
       });
     }
   };
 
-  const messages = thread_ts
-    ? await getThreadMessages(
-        assertDefined(mailbox.slackBotToken),
-        channel,
-        thread_ts,
-        assertDefined(mailbox.slackBotUserId),
-      )
-    : ([{ role: "user", content: event.text ?? "" }] satisfies CoreMessage[]);
+  const messages = await getThreadMessages(
+    assertDefined(mailbox.slackBotToken),
+    agentThread.slackChannel,
+    agentThread.threadTs,
+    assertDefined(mailbox.slackBotUserId),
+  );
 
-  const result = await generateAgentResponse(messages, mailbox, event.user, showStatus);
+  const { text, confirmReplyText } = await generateAgentResponse(
+    messages,
+    mailbox,
+    event?.user,
+    showStatus,
+    confirmedReplyText,
+  );
 
   const assistantMessage = await db
     .insert(agentMessages)
     .values({
       agentThreadId: agentThread.id,
       role: "assistant",
-      content: result,
+      content: text,
     })
     .returning()
     .then(takeUniqueOrThrow);
 
   const { ts } = await client.chat.postMessage({
-    channel: event.channel,
-    thread_ts: event.thread_ts ?? event.ts,
-    text: result,
+    channel: agentThread.slackChannel,
+    thread_ts: agentThread.threadTs,
+    text,
   });
 
   if (ts) {
     await db
       .update(agentMessages)
       .set({
-        slackChannel: event.channel,
+        slackChannel: agentThread.slackChannel,
         messageTs: ts,
       })
       .where(eq(agentMessages.id, assistantMessage.id));
@@ -99,31 +102,80 @@ export const handleSlackAgentMessage = async (
   if (!debug) {
     try {
       await client.chat.delete({
-        channel: event.channel,
+        channel: agentThread.slackChannel,
         ts: statusMessageTs,
       });
     } catch (error) {
       captureExceptionAndLog(error, {
         extra: {
           message: "Error deleting status message",
-          channel: event.channel,
+          channel: agentThread.slackChannel,
           statusMessageTs,
         },
       });
     }
   }
 
-  return result;
+  if (confirmReplyText) {
+    const { ts } = await client.chat.postMessage({
+      channel: agentThread.slackChannel,
+      thread_ts: agentThread.threadTs,
+      blocks: [
+        {
+          type: "actions",
+          elements: [
+            {
+              type: "button",
+              text: {
+                type: "plain_text",
+                text: "Edit reply",
+                emoji: true,
+              },
+              value: confirmReplyText.args.proposedMessage,
+              action_id: "edit_reply",
+            },
+            {
+              type: "button",
+              text: {
+                type: "plain_text",
+                text: "Send as is",
+              },
+              value: "send_as_is",
+              action_id: "send_as_is",
+            },
+          ],
+        },
+      ],
+    });
+
+    if (ts) {
+      await db.insert(agentMessages).values({
+        agentThreadId: confirmReplyText.args.ticketId, // TODO
+        role: "assistant",
+        content: `Confirming reply text: ${confirmReplyText.args.proposedMessage}`,
+        slackChannel: agentThread.slackChannel,
+        messageTs: ts,
+      });
+    }
+  }
+
+  return { text, agentThreadId: agentThread.id };
 };
 
 export default inngest.createFunction(
   { id: "slack-agent-message-handler" },
   { event: "slack/agent.message" },
   async ({ event, step }) => {
-    const { event: slackEvent, currentMailboxId, statusMessageTs, agentThreadId } = event.data;
+    const { event: slackEvent, currentMailboxId, statusMessageTs, agentThreadId, confirmedReplyText } = event.data;
 
     const result = await step.run("process-agent-message", async () => {
-      return await handleSlackAgentMessage(slackEvent, currentMailboxId, statusMessageTs, agentThreadId);
+      return await handleSlackAgentMessage(
+        slackEvent,
+        currentMailboxId,
+        statusMessageTs,
+        agentThreadId,
+        confirmedReplyText ?? null,
+      );
     });
 
     return { result };

--- a/apps/nextjs/src/lib/ai/index.ts
+++ b/apps/nextjs/src/lib/ai/index.ts
@@ -27,7 +27,12 @@ type CommonAIQueryOptions = {
   shortenPromptBy?: ShortenPromptOptions;
 };
 
-export const runAIQuery = async ({
+export const runAIQuery = async (options: Parameters<typeof runAIRawQuery>[0]): Promise<string> => {
+  const response = await runAIRawQuery(options);
+  return response.text;
+};
+
+export const runAIRawQuery = async ({
   messages,
   mailbox,
   queryType,
@@ -39,8 +44,8 @@ export const runAIQuery = async ({
   tools,
   functionId,
   shortenPromptBy,
-}: CommonAIQueryOptions & { maxSteps?: number; tools?: Record<string, Tool> }): Promise<string> => {
-  const response = await runWithRetry(
+}: CommonAIQueryOptions & { maxSteps?: number; tools?: Record<string, Tool> }) =>
+  await runWithRetry(
     () =>
       generateCompletion({
         messages,
@@ -58,8 +63,6 @@ export const runAIQuery = async ({
       }),
     { mailbox, queryType, model },
   );
-  return response.text;
-};
 
 export const runAIObjectQuery = async <T>({
   messages,

--- a/apps/nextjs/src/lib/slack/agent/generateAgentResponse.ts
+++ b/apps/nextjs/src/lib/slack/agent/generateAgentResponse.ts
@@ -30,7 +30,7 @@ type SearchFiltersInput = z.infer<typeof searchFiltersSchema>;
 export const generateAgentResponse = async (
   messages: CoreMessage[],
   mailbox: Mailbox,
-  slackUserId: string | undefined,
+  slackUserId: string | null,
   showStatus: (status: string | null, tool?: { toolName: string; parameters: Record<string, unknown> }) => void,
   confirmedReplyText?: string | null,
 ) => {

--- a/apps/nextjs/src/lib/slack/agent/generateAgentResponse.ts
+++ b/apps/nextjs/src/lib/slack/agent/generateAgentResponse.ts
@@ -1,5 +1,5 @@
 import { WebClient } from "@slack/web-api";
-import { CoreMessage, tool } from "ai";
+import { CoreMessage, Tool, tool } from "ai";
 import { and, eq, inArray, isNull, ne, notInArray, or, SQL } from "drizzle-orm";
 import { z } from "zod";
 import { getBaseUrl } from "@/components/constants";
@@ -11,10 +11,11 @@ import { Conversation, getConversationById, getConversationBySlug, updateConvers
 import { getAverageResponseTime } from "@/lib/data/conversation/responseTime";
 import { countSearchResults, getSearchResultIds, searchConversations } from "@/lib/data/conversation/search";
 import { searchSchema } from "@/lib/data/conversation/searchSchema";
+import { createReply } from "@/lib/data/conversationMessage";
 import { Mailbox } from "@/lib/data/mailbox";
 import { getPlatformCustomer, PlatformCustomer } from "@/lib/data/platformCustomer";
 import { getMemberStats } from "@/lib/data/stats";
-import { getClerkUserList } from "@/lib/data/user";
+import { findUserViaSlack, getClerkUserList } from "@/lib/data/user";
 import { captureExceptionAndLog } from "@/lib/shared/sentry";
 import { CLOSED_BY_AGENT_MESSAGE, MARKED_AS_SPAM_BY_AGENT_MESSAGE, REOPENED_BY_AGENT_MESSAGE } from "../constants";
 
@@ -37,6 +38,258 @@ export const generateAgentResponse = async (
   const searchToolSchema = searchSchema.omit({
     category: true,
   });
+
+  const tools: Record<string, Tool> = {
+    getCurrentSlackUser: tool({
+      description: "Get the current Slack user",
+      parameters: z.object({}),
+      execute: async () => {
+        showStatus(`Checking user...`, { toolName: "getCurrentSlackUser", parameters: { slackUserId } });
+        if (!slackUserId) return { error: "User not found" };
+        const { user } = await client.users.info({ user: slackUserId });
+        const members = await getClerkUserList(mailbox.clerkOrganizationId);
+        if (user) {
+          return {
+            id: user.id,
+            clerkUserId: members.data.find((member) => {
+              const slackAccount = member.externalAccounts.find((account) => account.provider === "oauth_slack");
+              return (
+                slackAccount?.externalId === slackUserId ||
+                member.emailAddresses.some((email) => email.emailAddress === user.profile?.email)
+              );
+            })?.id,
+            name: user.profile?.real_name,
+            email: user.profile?.email,
+          };
+        }
+        return { error: "User not found" };
+      },
+    }),
+    getMembers: tool({
+      description: "Get IDs, names and emails of all team members",
+      parameters: z.object({}),
+      execute: async () => {
+        showStatus(`Checking members...`, { toolName: "getMembers", parameters: {} });
+        const members = await getClerkUserList(mailbox.clerkOrganizationId);
+        return members.data.map((member) => ({
+          id: member.id,
+          firstName: member.firstName,
+          lastName: member.lastName,
+          emails: member.emailAddresses.map((email) => email.emailAddress),
+        }));
+      },
+    }),
+    getMemberStats: tool({
+      description: "Check how many replies members sent to tickets in a given time period",
+      parameters: z.object({
+        startDate: z.string().datetime(),
+        endDate: z.string().datetime(),
+      }),
+      execute: async ({ startDate, endDate }) => {
+        showStatus(`Checking member stats...`, { toolName: "getMemberStats", parameters: { startDate, endDate } });
+        return await getMemberStats(mailbox, { startDate: new Date(startDate), endDate: new Date(endDate) });
+      },
+    }),
+    searchTickets: tool({
+      description: "Search tickets/conversations with various filtering options",
+      parameters: searchToolSchema,
+      execute: async (input) => {
+        showStatus(`Searching tickets...`, { toolName: "searchTickets", parameters: input });
+        try {
+          const { list } = await searchConversations(mailbox, input);
+          const { results, nextCursor } = await list;
+          return {
+            tickets: results.map((conversation) =>
+              formatConversation(conversation, mailbox, conversation.platformCustomer),
+            ),
+            nextCursor,
+          };
+        } catch (error) {
+          captureExceptionAndLog(error);
+          return { error: "Failed to search tickets" };
+        }
+      },
+    }),
+    countTickets: tool({
+      description: "Count the number of tickets matching the search criteria",
+      parameters: searchToolSchema.omit({ cursor: true, limit: true }),
+      execute: async (input) => {
+        showStatus(`Counting tickets...`, { toolName: "countTickets", parameters: input });
+        const { where } = await searchConversations(mailbox, { ...input, limit: 1 });
+        return await countSearchResults(where);
+      },
+    }),
+    assignTickets: tool({
+      description: "Assign tickets to a team member or the current user",
+      parameters: z.object({
+        clerkUserId: z.string().regex(/^user_(\w+)$/),
+        ticketIds: z.array(z.union([z.string(), z.number()])),
+      }),
+      execute: async ({ clerkUserId, ticketIds }) => {
+        showStatus(`Assigning tickets...`, { toolName: "assignTickets", parameters: { clerkUserId, ticketIds } });
+        const conversations = await Promise.all(
+          ticketIds.map(async (ticketId) => {
+            const conversation = await findConversation(ticketId, mailbox);
+            if (!conversation) return null;
+            return await updateConversation(conversation.id, {
+              set: { assignedToClerkId: clerkUserId },
+              message: "Assigned by agent",
+            });
+          }),
+        );
+        return conversations.flatMap((conversation) => (conversation ? formatConversation(conversation, mailbox) : []));
+      },
+    }),
+    getAverageResponseTime: tool({
+      description: "Get the average response time for tickets in a given time period",
+      parameters: z.object({
+        startDate: z.string().datetime(),
+        endDate: z.string().datetime(),
+        filters: searchToolSchema.omit({ cursor: true, limit: true }),
+      }),
+      execute: async ({ startDate, endDate, filters }) => {
+        showStatus(`Checking average response time...`, {
+          toolName: "getAverageResponseTime",
+          parameters: { startDate, endDate, filters },
+        });
+        const averageResponseTimeSeconds = await getAverageResponseTime(
+          mailbox,
+          new Date(startDate),
+          new Date(endDate),
+          filters,
+        );
+        if (averageResponseTimeSeconds) {
+          return { averageResponseTimeSeconds };
+        }
+        return { message: "No tickets answered in the given time period" };
+      },
+    }),
+    getTicket: tool({
+      description: "Get a ticket by ID",
+      parameters: z.object({
+        id: z
+          .union([z.string(), z.number()])
+          .describe(
+            "The ID of the ticket. This can be either the numeric ID from the database or the alphanumeric slug from the URL.",
+          ),
+      }),
+      execute: async ({ id }) => {
+        showStatus(`Checking ticket...`, { toolName: "getTicket", parameters: { id } });
+        const conversation = await findConversation(id, mailbox);
+        if (!conversation) return { error: "Ticket not found" };
+        const platformCustomer = await getPlatformCustomer(mailbox.id, conversation.emailFrom ?? "");
+        return formatConversation(conversation, mailbox, platformCustomer);
+      },
+    }),
+    getTicketMessages: tool({
+      description:
+        "Get the messages of a ticket by ID. This includes messages from the user and replies from the team.",
+      parameters: z.object({
+        id: z
+          .union([z.string(), z.number()])
+          .describe(
+            "The ID of the ticket. This can be either the numeric ID from the database or the alphanumeric slug from the URL.",
+          ),
+      }),
+      execute: async ({ id }) => {
+        showStatus(`Reading ticket...`, { toolName: "getTicketMessages", parameters: { id } });
+        const conversation = await findConversation(id, mailbox);
+        if (!conversation) return { error: "Ticket not found" };
+        const messages = await db.query.conversationMessages.findMany({
+          where: and(
+            eq(conversationMessages.conversationId, conversation.id),
+            isNull(conversationMessages.deletedAt),
+            or(eq(conversationMessages.role, "user"), notInArray(conversationMessages.status, DRAFT_STATUSES)),
+          ),
+          columns: {
+            id: true,
+            cleanedUpText: true,
+            createdAt: true,
+            clerkUserId: true,
+            role: true,
+          },
+        });
+        return messages.map((message) => ({
+          id: message.id,
+          content: message.cleanedUpText,
+          createdAt: message.createdAt,
+          role: message.role,
+          clerkUserId: message.clerkUserId,
+        }));
+      },
+    }),
+    closeTickets: tool({
+      description: "Close tickets/conversations matching various filtering options",
+      parameters: z.object({
+        ids: z.array(z.union([z.string(), z.number()])).optional(),
+        filters: searchToolSchema.omit({ cursor: true, limit: true }).optional(),
+      }),
+      execute: async (input) => {
+        return await updateTicketsStatus(mailbox, "closed", input, CLOSED_BY_AGENT_MESSAGE, showStatus);
+      },
+    }),
+    reopenTickets: tool({
+      description: "Reopen tickets/conversations matching various filtering options",
+      parameters: z.object({
+        ids: z.array(z.union([z.string(), z.number()])).optional(),
+        filters: searchToolSchema.omit({ cursor: true, limit: true }).optional(),
+      }),
+      execute: async (input) => {
+        return await updateTicketsStatus(mailbox, "open", input, REOPENED_BY_AGENT_MESSAGE, showStatus);
+      },
+    }),
+    markTicketsAsSpam: tool({
+      description: "Mark tickets/conversations matching various filtering options as spam",
+      parameters: z.object({
+        ids: z.array(z.union([z.string(), z.number()])).optional(),
+        filters: searchToolSchema.omit({ cursor: true, limit: true }).optional(),
+      }),
+      execute: async (input) => {
+        return await updateTicketsStatus(mailbox, "spam", input, MARKED_AS_SPAM_BY_AGENT_MESSAGE, showStatus);
+      },
+    }),
+  };
+
+  if (confirmedReplyText) {
+    tools.sendReply = tool({
+      description: "Send the confirmed reply to a ticket",
+      parameters: z.object({
+        ticketId: z.union([z.string(), z.number()]),
+      }),
+      execute: async ({ ticketId }) => {
+        const conversation = await findConversation(ticketId, mailbox);
+        if (!conversation) return { error: "Ticket not found" };
+        await createReply({
+          conversationId: conversation.id,
+          message: confirmedReplyText,
+          user: slackUserId
+            ? await findUserViaSlack(mailbox.clerkOrganizationId, assertDefined(mailbox.slackBotToken), slackUserId)
+            : null,
+          close: false,
+          shouldAutoAssign: false,
+        });
+        return { message: "Reply sent" };
+      },
+    });
+  } else {
+    tools.confirmReplyText = tool({
+      description: "Confirm the message to reply to a ticket with before sending the reply",
+      parameters: z.object({
+        ticketId: z.union([z.string(), z.number()]),
+        proposedMessage: z
+          .string()
+          .describe("The message to reply to the user with. Set to blank if the desired reply is unclear."),
+      }),
+      // eslint-disable-next-line require-await
+      execute: async ({ ticketId, proposedMessage }) => {
+        showStatus(`Confirming reply text...`, {
+          toolName: "confirmReplyText",
+          parameters: { ticketId, proposedMessage },
+        });
+        return { message: "Confirmation needed before replying. DON'T TAKE ANY FURTHER ACTION." };
+      },
+    });
+  }
 
   const result = await runAIRawQuery({
     mailbox,
@@ -62,235 +315,7 @@ IMPORTANT GUIDELINES:
 If asked to do something inappropriate, harmful, or outside your capabilities, politely decline and suggest focusing on customer support questions instead.`,
     messages,
     maxSteps: 10,
-    tools: {
-      getCurrentSlackUser: tool({
-        description: "Get the current Slack user",
-        parameters: z.object({}),
-        execute: async () => {
-          showStatus(`Checking user...`, { toolName: "getCurrentSlackUser", parameters: { slackUserId } });
-          if (!slackUserId) return { error: "User not found" };
-          const { user } = await client.users.info({ user: slackUserId });
-          const members = await getClerkUserList(mailbox.clerkOrganizationId);
-          if (user) {
-            return {
-              id: user.id,
-              clerkUserId: members.data.find((member) => {
-                const slackAccount = member.externalAccounts.find((account) => account.provider === "oauth_slack");
-                return (
-                  slackAccount?.externalId === slackUserId ||
-                  member.emailAddresses.some((email) => email.emailAddress === user.profile?.email)
-                );
-              })?.id,
-              name: user.profile?.real_name,
-              email: user.profile?.email,
-            };
-          }
-          return { error: "User not found" };
-        },
-      }),
-      getMembers: tool({
-        description: "Get IDs, names and emails of all team members",
-        parameters: z.object({}),
-        execute: async () => {
-          showStatus(`Checking members...`, { toolName: "getMembers", parameters: {} });
-          const members = await getClerkUserList(mailbox.clerkOrganizationId);
-          return members.data.map((member) => ({
-            id: member.id,
-            firstName: member.firstName,
-            lastName: member.lastName,
-            emails: member.emailAddresses.map((email) => email.emailAddress),
-          }));
-        },
-      }),
-      getMemberStats: tool({
-        description: "Check how many replies members sent to tickets in a given time period",
-        parameters: z.object({
-          startDate: z.string().datetime(),
-          endDate: z.string().datetime(),
-        }),
-        execute: async ({ startDate, endDate }) => {
-          showStatus(`Checking member stats...`, { toolName: "getMemberStats", parameters: { startDate, endDate } });
-          return await getMemberStats(mailbox, { startDate: new Date(startDate), endDate: new Date(endDate) });
-        },
-      }),
-      searchTickets: tool({
-        description: "Search tickets/conversations with various filtering options",
-        parameters: searchToolSchema,
-        execute: async (input) => {
-          showStatus(`Searching tickets...`, { toolName: "searchTickets", parameters: input });
-          try {
-            const { list } = await searchConversations(mailbox, input);
-            const { results, nextCursor } = await list;
-            return {
-              tickets: results.map((conversation) =>
-                formatConversation(conversation, mailbox, conversation.platformCustomer),
-              ),
-              nextCursor,
-            };
-          } catch (error) {
-            captureExceptionAndLog(error);
-            return { error: "Failed to search tickets" };
-          }
-        },
-      }),
-      countTickets: tool({
-        description: "Count the number of tickets matching the search criteria",
-        parameters: searchToolSchema.omit({ cursor: true, limit: true }),
-        execute: async (input) => {
-          showStatus(`Counting tickets...`, { toolName: "countTickets", parameters: input });
-          const { where } = await searchConversations(mailbox, { ...input, limit: 1 });
-          return await countSearchResults(where);
-        },
-      }),
-      confirmReplyText: tool({
-        description: "Confirm the message to reply to a ticket with before sending the reply",
-        parameters: z.object({
-          ticketId: z.union([z.string(), z.number()]),
-          proposedMessage: z
-            .string()
-            .describe("The message to reply to the user with. Set to blank if the desired reply is unclear."),
-        }),
-        // eslint-disable-next-line require-await
-        execute: async ({ ticketId, proposedMessage }) => {
-          showStatus(`Confirming reply text...`, {
-            toolName: "confirmReplyText",
-            parameters: { ticketId, proposedMessage },
-          });
-          return { message: "Confirmation needed before replying. DON'T TAKE ANY FURTHER ACTION." };
-        },
-      }),
-      assignTickets: tool({
-        description: "Assign tickets to a team member or the current user",
-        parameters: z.object({
-          clerkUserId: z.string().regex(/^user_(\w+)$/),
-          ticketIds: z.array(z.union([z.string(), z.number()])),
-        }),
-        execute: async ({ clerkUserId, ticketIds }) => {
-          showStatus(`Assigning tickets...`, { toolName: "assignTickets", parameters: { clerkUserId, ticketIds } });
-          const conversations = await Promise.all(
-            ticketIds.map(async (ticketId) => {
-              const conversation = await findConversation(ticketId, mailbox);
-              if (!conversation) return null;
-              return await updateConversation(conversation.id, {
-                set: { assignedToClerkId: clerkUserId },
-                message: "Assigned by agent",
-              });
-            }),
-          );
-          return conversations.flatMap((conversation) =>
-            conversation ? formatConversation(conversation, mailbox) : [],
-          );
-        },
-      }),
-      getAverageResponseTime: tool({
-        description: "Get the average response time for tickets in a given time period",
-        parameters: z.object({
-          startDate: z.string().datetime(),
-          endDate: z.string().datetime(),
-          filters: searchToolSchema.omit({ cursor: true, limit: true }),
-        }),
-        execute: async ({ startDate, endDate, filters }) => {
-          showStatus(`Checking average response time...`, {
-            toolName: "getAverageResponseTime",
-            parameters: { startDate, endDate, filters },
-          });
-          const averageResponseTimeSeconds = await getAverageResponseTime(
-            mailbox,
-            new Date(startDate),
-            new Date(endDate),
-            filters,
-          );
-          if (averageResponseTimeSeconds) {
-            return { averageResponseTimeSeconds };
-          }
-          return { message: "No tickets answered in the given time period" };
-        },
-      }),
-      getTicket: tool({
-        description: "Get a ticket by ID",
-        parameters: z.object({
-          id: z
-            .union([z.string(), z.number()])
-            .describe(
-              "The ID of the ticket. This can be either the numeric ID from the database or the alphanumeric slug from the URL.",
-            ),
-        }),
-        execute: async ({ id }) => {
-          showStatus(`Checking ticket...`, { toolName: "getTicket", parameters: { id } });
-          const conversation = await findConversation(id, mailbox);
-          if (!conversation) return { error: "Ticket not found" };
-          const platformCustomer = await getPlatformCustomer(mailbox.id, conversation.emailFrom ?? "");
-          return formatConversation(conversation, mailbox, platformCustomer);
-        },
-      }),
-      getTicketMessages: tool({
-        description:
-          "Get the messages of a ticket by ID. This includes messages from the user and replies from the team.",
-        parameters: z.object({
-          id: z
-            .union([z.string(), z.number()])
-            .describe(
-              "The ID of the ticket. This can be either the numeric ID from the database or the alphanumeric slug from the URL.",
-            ),
-        }),
-        execute: async ({ id }) => {
-          showStatus(`Reading ticket...`, { toolName: "getTicketMessages", parameters: { id } });
-          const conversation = await findConversation(id, mailbox);
-          if (!conversation) return { error: "Ticket not found" };
-          const messages = await db.query.conversationMessages.findMany({
-            where: and(
-              eq(conversationMessages.conversationId, conversation.id),
-              isNull(conversationMessages.deletedAt),
-              or(eq(conversationMessages.role, "user"), notInArray(conversationMessages.status, DRAFT_STATUSES)),
-            ),
-            columns: {
-              id: true,
-              cleanedUpText: true,
-              createdAt: true,
-              clerkUserId: true,
-              role: true,
-            },
-          });
-          return messages.map((message) => ({
-            id: message.id,
-            content: message.cleanedUpText,
-            createdAt: message.createdAt,
-            role: message.role,
-            clerkUserId: message.clerkUserId,
-          }));
-        },
-      }),
-      closeTickets: tool({
-        description: "Close tickets/conversations matching various filtering options",
-        parameters: z.object({
-          ids: z.array(z.union([z.string(), z.number()])).optional(),
-          filters: searchToolSchema.omit({ cursor: true, limit: true }).optional(),
-        }),
-        execute: async (input) => {
-          return await updateTicketsStatus(mailbox, "closed", input, CLOSED_BY_AGENT_MESSAGE, showStatus);
-        },
-      }),
-      reopenTickets: tool({
-        description: "Reopen tickets/conversations matching various filtering options",
-        parameters: z.object({
-          ids: z.array(z.union([z.string(), z.number()])).optional(),
-          filters: searchToolSchema.omit({ cursor: true, limit: true }).optional(),
-        }),
-        execute: async (input) => {
-          return await updateTicketsStatus(mailbox, "open", input, REOPENED_BY_AGENT_MESSAGE, showStatus);
-        },
-      }),
-      markTicketsAsSpam: tool({
-        description: "Mark tickets/conversations matching various filtering options as spam",
-        parameters: z.object({
-          ids: z.array(z.union([z.string(), z.number()])).optional(),
-          filters: searchToolSchema.omit({ cursor: true, limit: true }).optional(),
-        }),
-        execute: async (input) => {
-          return await updateTicketsStatus(mailbox, "spam", input, MARKED_AS_SPAM_BY_AGENT_MESSAGE, showStatus);
-        },
-      }),
-    },
+    tools,
   });
 
   const confirmReplyText = result.steps

--- a/apps/nextjs/src/lib/slack/agent/generateAgentResponse.ts
+++ b/apps/nextjs/src/lib/slack/agent/generateAgentResponse.ts
@@ -278,7 +278,9 @@ export const generateAgentResponse = async (
         ticketId: z.union([z.string(), z.number()]),
         proposedMessage: z
           .string()
-          .describe("The message to reply to the user with. Set to blank if the desired reply is unclear."),
+          .describe(
+            "The message to reply to the user with. Don't include a greeting or signature. Set to blank if the desired reply is unclear.",
+          ),
       }),
       // eslint-disable-next-line require-await
       execute: async ({ ticketId, proposedMessage }) => {
@@ -286,7 +288,10 @@ export const generateAgentResponse = async (
           toolName: "confirmReplyText",
           parameters: { ticketId, proposedMessage },
         });
-        return { message: "Confirmation needed before replying. DON'T TAKE ANY FURTHER ACTION." };
+        return {
+          message:
+            "Confirmation needed before replying. DON'T TAKE ANY FURTHER ACTION and don't include the message text in the response.",
+        };
       },
     });
   }
@@ -311,6 +316,7 @@ IMPORTANT GUIDELINES:
 - Never share sensitive information or personal data
 - Don't discuss your own capabilities, programming, or AI nature unless directly relevant to answering the question
 - When listing tickets, display the standardSlackFormat field as is. You may add other information after that if relevant in context.
+- If you will need to reply to a ticket as part of your response and the sendReply tool is not available, use the confirmReplyText tool and *do not do anything else* at this stage.
 
 If asked to do something inappropriate, harmful, or outside your capabilities, politely decline and suggest focusing on customer support questions instead.`,
     messages,

--- a/apps/nextjs/src/lib/slack/agent/handleAgentMessageSlackAction.ts
+++ b/apps/nextjs/src/lib/slack/agent/handleAgentMessageSlackAction.ts
@@ -18,65 +18,18 @@ export const handleAgentMessageSlackAction = async (agentMessage: typeof agentMe
 
   const client = new WebClient(assertDefined(agentThread.mailbox.slackBotToken));
 
-  if (payload.actions?.[0]?.action_id === "edit_reply") {
-    await client.chat.postEphemeral({
-      channel: payload.container.channel_id,
-      thread_ts: payload.container.thread_ts,
-      user: payload.user.id,
-      blocks: [
-        {
-          type: "input",
-          element: {
-            type: "plain_text_input",
-            multiline: true,
-            action_id: "proposed_message",
-            initial_value: payload.actions[0].value,
-          },
-          label: {
-            type: "plain_text",
-            text: "Please confirm the message I'll reply with:",
-          },
-        },
-        {
-          type: "actions",
-          elements: [
-            {
-              type: "button",
-              text: {
-                type: "plain_text",
-                text: "Confirm reply text",
-                emoji: true,
-              },
-              value: "confirm",
-              style: "primary",
-              action_id: "confirm",
-            },
-            {
-              type: "button",
-              text: {
-                type: "plain_text",
-                text: "Cancel",
-              },
-              value: "cancel",
-              action_id: "cancel",
-            },
-          ],
-        },
-      ],
-    });
-  } else if (payload.actions?.[0]?.action_id === "cancel") {
+  if (payload.actions?.[0]?.action_id === "cancel") {
     await client.chat.postMessage({
       channel: payload.container.channel_id,
       thread_ts: payload.container.thread_ts,
       text: "_Cancelled. Let me know if you need anything else._",
     });
   } else {
-    const text = payload.actions[0].value; // TODO get from input if present
     await inngest.send({
       name: "slack/agent.message",
       data: {
-        event: null,
-        confirmedReplyText: text,
+        slackUserId: payload.user.id,
+        confirmedReplyText: payload.state.values.proposed_message.proposed_message.value,
         agentThreadId: agentMessage.agentThreadId,
         currentMailboxId: agentThread.mailboxId,
         statusMessageTs: await postThinkingMessage(client, agentThread.slackChannel, agentThread.threadTs),

--- a/apps/nextjs/src/lib/slack/agent/handleAgentMessageSlackAction.ts
+++ b/apps/nextjs/src/lib/slack/agent/handleAgentMessageSlackAction.ts
@@ -1,0 +1,90 @@
+import { WebClient } from "@slack/web-api";
+import { eq } from "drizzle-orm";
+import { assertDefined } from "@/components/utils/assert";
+import { db } from "@/db/client";
+import { agentMessages, agentThreads } from "@/db/schema";
+import { inngest } from "@/inngest/client";
+import { postThinkingMessage } from "@/lib/slack/agent/handleMessages";
+
+export const handleAgentMessageSlackAction = async (agentMessage: typeof agentMessages.$inferSelect, payload: any) => {
+  const agentThread = assertDefined(
+    await db.query.agentThreads.findFirst({
+      where: eq(agentThreads.id, agentMessage.agentThreadId),
+      with: {
+        mailbox: true,
+      },
+    }),
+  );
+
+  const client = new WebClient(assertDefined(agentThread.mailbox.slackBotToken));
+
+  if (payload.actions?.[0]?.action_id === "edit_reply") {
+    await client.chat.postEphemeral({
+      channel: payload.container.channel_id,
+      thread_ts: payload.container.thread_ts,
+      user: payload.user.id,
+      blocks: [
+        {
+          type: "input",
+          element: {
+            type: "plain_text_input",
+            multiline: true,
+            action_id: "proposed_message",
+            initial_value: payload.actions[0].value,
+          },
+          label: {
+            type: "plain_text",
+            text: "Please confirm the message I'll reply with:",
+          },
+        },
+        {
+          type: "actions",
+          elements: [
+            {
+              type: "button",
+              text: {
+                type: "plain_text",
+                text: "Confirm reply text",
+                emoji: true,
+              },
+              value: "confirm",
+              style: "primary",
+              action_id: "confirm",
+            },
+            {
+              type: "button",
+              text: {
+                type: "plain_text",
+                text: "Cancel",
+              },
+              value: "cancel",
+              action_id: "cancel",
+            },
+          ],
+        },
+      ],
+    });
+  } else if (payload.actions?.[0]?.action_id === "cancel") {
+    await client.chat.postMessage({
+      channel: payload.container.channel_id,
+      thread_ts: payload.container.thread_ts,
+      text: "_Cancelled. Let me know if you need anything else._",
+    });
+  } else {
+    const text = payload.actions[0].value; // TODO get from input if present
+    await inngest.send({
+      name: "slack/agent.message",
+      data: {
+        event: null,
+        confirmedReplyText: text,
+        agentThreadId: agentMessage.agentThreadId,
+        currentMailboxId: agentThread.mailboxId,
+        statusMessageTs: await postThinkingMessage(client, agentThread.slackChannel, agentThread.threadTs),
+      },
+    });
+  }
+  await client.chat.delete({
+    channel: payload.container.channel_id,
+    ts: payload.container.message_ts,
+  });
+};

--- a/apps/nextjs/src/lib/slack/agent/handleMessages.ts
+++ b/apps/nextjs/src/lib/slack/agent/handleMessages.ts
@@ -59,7 +59,7 @@ export async function handleMessage(event: GenericMessageEvent | AppMentionEvent
   await inngest.send({
     name: "slack/agent.message",
     data: {
-      event,
+      slackUserId: event.user ?? null,
       currentMailboxId: mailbox.id,
       statusMessageTs: await postThinkingMessage(client, event.channel, event.thread_ts ?? event.ts),
       agentThreadId: agentThread.id,

--- a/apps/nextjs/src/lib/slack/agent/handleMessages.ts
+++ b/apps/nextjs/src/lib/slack/agent/handleMessages.ts
@@ -55,20 +55,13 @@ export async function handleMessage(event: GenericMessageEvent | AppMentionEvent
   }
 
   const client = new WebClient(assertDefined(mailbox.slackBotToken));
-  const statusMessage = await client.chat.postMessage({
-    channel: event.channel,
-    thread_ts: event.thread_ts ?? event.ts,
-    text: "_Thinking..._",
-  });
-
-  if (!statusMessage?.ts) throw new Error("Failed to post initial message");
 
   await inngest.send({
     name: "slack/agent.message",
     data: {
       event,
       currentMailboxId: mailbox.id,
-      statusMessageTs: statusMessage.ts,
+      statusMessageTs: await postThinkingMessage(client, event.channel, event.thread_ts ?? event.ts),
       agentThreadId: agentThread.id,
     },
   });
@@ -129,6 +122,18 @@ export const isAgentThread = async (event: GenericMessageEvent, mailboxInfo: Sla
   }
 
   return false;
+};
+
+export const postThinkingMessage = async (client: WebClient, channel: string, threadTs: string) => {
+  const message = await client.chat.postMessage({
+    channel,
+    thread_ts: threadTs,
+    text: "_Thinking..._",
+  });
+
+  if (!message?.ts) throw new Error("Failed to post initial message");
+
+  return message.ts;
 };
 
 const askWhichMailbox = async (event: GenericMessageEvent | AppMentionEvent, mailboxes: Mailbox[]) => {


### PR DESCRIPTION
[ref](https://anti--work.slack.com/archives/C068HHZ64M9/p1745151598747579?thread_ts=1745074808.351449&cid=C068HHZ64M9)

Adds a two-step reply tool to the agent which first posts a message to confirm the text (allowing the user to edit it) and then creates the reply.

https://github.com/user-attachments/assets/abcf3e4b-3f26-44e8-b04e-4f96b4645826