### PR TITLE
feat: color themes

### DIFF
--- a/apps/nextjs/src/app/(dashboard)/mailboxes/[mailbox_slug]/_components/clientLayout.tsx
+++ b/apps/nextjs/src/app/(dashboard)/mailboxes/[mailbox_slug]/_components/clientLayout.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { createContext, useContext, useMemo, useState } from "react";
+import { DeepLinkRedirect } from "@/components/deepLinkRedirect";
+import { TauriDragArea } from "@/components/tauriDragArea";
+import { useNativePlatform } from "@/components/useNativePlatform";
+import { buildThemeCss, MailboxTheme } from "@/lib/themes";
+import { LayoutInfoProvider } from "./useLayoutInfo";
+
+const InboxThemeContext = createContext<{
+  theme: MailboxTheme | undefined;
+  setTheme: (theme: MailboxTheme | undefined) => void;
+}>({
+  theme: undefined,
+  setTheme: () => {},
+});
+
+export const useInboxTheme = () => useContext(InboxThemeContext);
+
+export default function InboxClientLayout({
+  children,
+  theme: initialTheme,
+}: {
+  children: React.ReactNode;
+  theme?: MailboxTheme;
+}) {
+  const { nativePlatform, isLegacyTauri } = useNativePlatform();
+  const [theme, setTheme] = useState<MailboxTheme | undefined>(initialTheme);
+
+  const themeCss = useMemo(() => buildThemeCss(theme), [theme]);
+
+  return (
+    <InboxThemeContext.Provider value={{ theme, setTheme }}>
+      <style>{themeCss}</style>
+      <LayoutInfoProvider>
+        {nativePlatform === "macos" && isLegacyTauri && <TauriDragArea className="top-0 inset-x-0 h-3" />}
+        <DeepLinkRedirect />
+        {children}
+      </LayoutInfoProvider>
+    </InboxThemeContext.Provider>
+  );
+}

--- a/apps/nextjs/src/app/(dashboard)/mailboxes/[mailbox_slug]/layout.tsx
+++ b/apps/nextjs/src/app/(dashboard)/mailboxes/[mailbox_slug]/layout.tsx
@@ -1,18 +1,16 @@
-"use client";
+import InboxClientLayout from "@/app/(dashboard)/mailboxes/[mailbox_slug]/_components/clientLayout";
+import { api } from "@/trpc/server";
 
-import { DeepLinkRedirect } from "@/components/deepLinkRedirect";
-import { TauriDragArea } from "@/components/tauriDragArea";
-import { useNativePlatform } from "@/components/useNativePlatform";
-import { LayoutInfoProvider } from "./_components/useLayoutInfo";
+export default async function InboxLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: Promise<{ mailbox_slug: string }>;
+}) {
+  const { preferences } = await api.mailbox.preferences.get({
+    mailboxSlug: (await params).mailbox_slug,
+  });
 
-export default function InboxLayout({ children }: { children: React.ReactNode }) {
-  const { nativePlatform, isLegacyTauri } = useNativePlatform();
-
-  return (
-    <LayoutInfoProvider>
-      {nativePlatform === "macos" && isLegacyTauri && <TauriDragArea className="top-0 inset-x-0 h-3" />}
-      <DeepLinkRedirect />
-      {children}
-    </LayoutInfoProvider>
-  );
+  return <InboxClientLayout theme={preferences?.theme}>{children}</InboxClientLayout>;
 }

--- a/apps/nextjs/src/app/(dashboard)/mailboxes/[mailbox_slug]/settings/_components/preferencesSetting.tsx
+++ b/apps/nextjs/src/app/(dashboard)/mailboxes/[mailbox_slug]/settings/_components/preferencesSetting.tsx
@@ -5,10 +5,12 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { api } from "@/trpc/react";
 import ConfettiSetting, { type ConfettiUpdates } from "./confettiSetting";
 import MailboxNameSetting, { type MailboxNameUpdates } from "./mailboxNameSetting";
+import ThemeSetting, { type ThemeUpdates } from "./themeSetting";
 
 export type PreferencesUpdates = {
   confettiSetting: ConfettiUpdates;
   mailboxNameSetting?: MailboxNameUpdates;
+  themeSetting?: ThemeUpdates;
 };
 
 const PreferencesSetting = ({ onChange }: { onChange: (updates: PreferencesUpdates) => void }) => {
@@ -39,10 +41,18 @@ const PreferencesSetting = ({ onChange }: { onChange: (updates: PreferencesUpdat
           onChange={(updates) => onChange({ confettiSetting: data?.preferences, mailboxNameSetting: updates })}
         />
       )}
-      <ConfettiSetting
-        confettiData={data?.preferences}
-        onChange={(updates) => onChange({ confettiSetting: updates })}
-      />
+      {data && (
+        <>
+          <ConfettiSetting
+            confettiData={{ confetti: data.preferences?.confetti ?? false }}
+            onChange={(updates) => onChange({ confettiSetting: updates })}
+          />
+          <ThemeSetting
+            themeData={{ theme: data.preferences?.theme }}
+            onChange={(updates) => onChange({ confettiSetting: data?.preferences, themeSetting: updates })}
+          />
+        </>
+      )}
     </div>
   );
 };

--- a/apps/nextjs/src/app/(dashboard)/mailboxes/[mailbox_slug]/settings/_components/settings.tsx
+++ b/apps/nextjs/src/app/(dashboard)/mailboxes/[mailbox_slug]/settings/_components/settings.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useClerk } from "@clerk/nextjs";
 import {
   BookOpenIcon,
   Cog6ToothIcon,
@@ -60,7 +59,6 @@ type SettingsProps = {
 };
 
 const Settings = ({ onUpdateSettings, mailbox, supportAccount }: SettingsProps) => {
-  const { signOut } = useClerk();
   const [isTransitionPending, startTransition] = useTransition();
   const [isUpdating, setIsUpdating] = useState(false);
   const [pendingUpdates, setPendingUpdates] = useState<PendingUpdates>({});
@@ -96,17 +94,6 @@ const Settings = ({ onUpdateSettings, mailbox, supportAccount }: SettingsProps) 
     Boolean(pendingUpdates.customer) ||
     Boolean(pendingUpdates.autoClose) ||
     Boolean(pendingUpdates.preferences);
-
-  const handleSignOut = async () => {
-    try {
-      await signOut({ redirectUrl: getTauriPlatform() ? "/login" : "/" });
-    } catch (error) {
-      toast({
-        variant: "destructive",
-        title: "Failed to sign out",
-      });
-    }
-  };
 
   const items = [
     {

--- a/apps/nextjs/src/app/(dashboard)/mailboxes/[mailbox_slug]/settings/_components/themeSetting.tsx
+++ b/apps/nextjs/src/app/(dashboard)/mailboxes/[mailbox_slug]/settings/_components/themeSetting.tsx
@@ -5,6 +5,7 @@ import { useInboxTheme } from "@/app/(dashboard)/mailboxes/[mailbox_slug]/_compo
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { useDebouncedCallback } from "@/components/useDebouncedCallback";
+import { normalizeHex } from "@/lib/themes";
 import SectionWrapper from "./sectionWrapper";
 
 export type ThemeUpdates = {
@@ -13,6 +14,7 @@ export type ThemeUpdates = {
     foreground: string;
     primary: string;
     accent: string;
+    sidebarBackground: string;
   };
 };
 
@@ -32,6 +34,7 @@ const ThemeSetting = ({
       foreground: "#000000",
       primary: "#000000",
       accent: "#000000",
+      sidebarBackground: "#ffffff",
     },
   );
 
@@ -43,6 +46,7 @@ const ThemeSetting = ({
         foreground: getComputedStyle(root).getPropertyValue("--foreground").trim() || "#000000",
         primary: getComputedStyle(root).getPropertyValue("--primary").trim() || "#000000",
         accent: getComputedStyle(root).getPropertyValue("--bright").trim() || "#000000",
+        sidebarBackground: getComputedStyle(root).getPropertyValue("--sidebar-background").trim() || "#ffffff",
       });
     }
   }, []);
@@ -52,8 +56,9 @@ const ThemeSetting = ({
   const handleColorChange =
     (color: keyof NonNullable<ThemeUpdates["theme"]>) => (e: React.ChangeEvent<HTMLInputElement>) => {
       setTheme({ ...theme, [color]: e.target.value });
-      debouncedSetWindowTheme({ ...theme, [color]: e.target.value });
-      onChange({ theme: { ...theme, [color]: e.target.value } });
+      const normalized = /#([0-9a-f]{3})$/i.test(e.target.value) ? `#${normalizeHex(e.target.value)}` : e.target.value;
+      onChange({ theme: { ...theme, [color]: normalized } });
+      if (/#([0-9a-f]{6})$/i.test(normalized)) debouncedSetWindowTheme({ ...theme, [color]: normalized });
     };
 
   const handleSwitchChange = (checked: boolean) => {
@@ -129,6 +134,24 @@ const ThemeSetting = ({
                 className="h-10 w-20 p-1"
               />
               <Input type="text" value={theme.accent} onChange={handleColorChange("accent")} className="w-[200px]" />
+            </div>
+          </div>
+
+          <div className="flex flex-col space-y-2">
+            <Label>Sidebar Color</Label>
+            <div className="grid grid-cols-[auto_1fr] gap-2">
+              <Input
+                type="color"
+                value={theme.sidebarBackground}
+                onChange={handleColorChange("sidebarBackground")}
+                className="h-10 w-20 p-1"
+              />
+              <Input
+                type="text"
+                value={theme.sidebarBackground}
+                onChange={handleColorChange("sidebarBackground")}
+                className="w-[200px]"
+              />
             </div>
           </div>
         </div>

--- a/apps/nextjs/src/app/(dashboard)/mailboxes/[mailbox_slug]/settings/_components/themeSetting.tsx
+++ b/apps/nextjs/src/app/(dashboard)/mailboxes/[mailbox_slug]/settings/_components/themeSetting.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import SectionWrapper from "./sectionWrapper";
+
+export type ThemeUpdates = {
+  theme?: {
+    background: string;
+    foreground: string;
+    primary: string;
+    accent: string;
+  };
+};
+
+const ThemeSetting = ({
+  themeData,
+  onChange,
+}: {
+  themeData: ThemeUpdates;
+  onChange: (updates: ThemeUpdates) => void;
+}) => {
+  const [isEnabled, setIsEnabled] = useState(!!themeData.theme);
+  const [theme, setTheme] = useState(
+    themeData.theme ?? {
+      background: "#ffffff",
+      foreground: "#000000",
+      primary: "#000000",
+      accent: "#000000",
+    },
+  );
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (!isEnabled) {
+      setTheme({
+        background: getComputedStyle(root).getPropertyValue("--background").trim() || "#ffffff",
+        foreground: getComputedStyle(root).getPropertyValue("--foreground").trim() || "#000000",
+        primary: getComputedStyle(root).getPropertyValue("--primary").trim() || "#000000",
+        accent: getComputedStyle(root).getPropertyValue("--bright").trim() || "#000000",
+      });
+    }
+  }, []);
+
+  const handleColorChange =
+    (color: keyof NonNullable<ThemeUpdates["theme"]>) => (e: React.ChangeEvent<HTMLInputElement>) => {
+      setTheme({ ...theme, [color]: e.target.value });
+      onChange({ theme: { ...theme, [color]: e.target.value } });
+    };
+
+  const handleSwitchChange = (checked: boolean) => {
+    setIsEnabled(checked);
+    if (!checked) onChange({ theme: undefined });
+  };
+
+  return (
+    <SectionWrapper
+      title="Custom Theme"
+      description="Choose the appearance of your mailbox with custom colors"
+      initialSwitchChecked={isEnabled}
+      onSwitchChange={handleSwitchChange}
+    >
+      {isEnabled && (
+        <div className="space-y-4">
+          <div className="flex flex-col space-y-2">
+            <Label>Background Color</Label>
+            <div className="grid grid-cols-[auto_1fr] gap-2">
+              <Input
+                type="color"
+                value={theme.background}
+                onChange={handleColorChange("background")}
+                className="h-10 w-20 p-1"
+              />
+              <Input
+                type="text"
+                value={theme.background}
+                onChange={handleColorChange("background")}
+                className="w-[200px]"
+              />
+            </div>
+          </div>
+
+          <div className="flex flex-col space-y-2">
+            <Label>Foreground Color</Label>
+            <div className="grid grid-cols-[auto_1fr] gap-2">
+              <Input
+                type="color"
+                value={theme.foreground}
+                onChange={handleColorChange("foreground")}
+                className="h-10 w-20 p-1"
+              />
+              <Input
+                type="text"
+                value={theme.foreground}
+                onChange={handleColorChange("foreground")}
+                className="w-[200px]"
+              />
+            </div>
+          </div>
+
+          <div className="flex flex-col space-y-2">
+            <Label>Primary Color</Label>
+            <div className="grid grid-cols-[auto_1fr] gap-2">
+              <Input
+                type="color"
+                value={theme.primary}
+                onChange={handleColorChange("primary")}
+                className="h-10 w-20 p-1"
+              />
+              <Input type="text" value={theme.primary} onChange={handleColorChange("primary")} className="w-[200px]" />
+            </div>
+          </div>
+
+          <div className="flex flex-col space-y-2">
+            <Label>Accent Color</Label>
+            <div className="grid grid-cols-[auto_1fr] gap-2">
+              <Input
+                type="color"
+                value={theme.accent}
+                onChange={handleColorChange("accent")}
+                className="h-10 w-20 p-1"
+              />
+              <Input type="text" value={theme.accent} onChange={handleColorChange("accent")} className="w-[200px]" />
+            </div>
+          </div>
+        </div>
+      )}
+    </SectionWrapper>
+  );
+};
+
+export default ThemeSetting;

--- a/apps/nextjs/src/app/(dashboard)/mailboxes/[mailbox_slug]/settings/_components/themeSetting.tsx
+++ b/apps/nextjs/src/app/(dashboard)/mailboxes/[mailbox_slug]/settings/_components/themeSetting.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { useInboxTheme } from "@/app/(dashboard)/mailboxes/[mailbox_slug]/_components/clientLayout";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { useDebouncedCallback } from "@/components/useDebouncedCallback";
 import SectionWrapper from "./sectionWrapper";
 
 export type ThemeUpdates = {
@@ -21,6 +23,8 @@ const ThemeSetting = ({
   themeData: ThemeUpdates;
   onChange: (updates: ThemeUpdates) => void;
 }) => {
+  const { setTheme: setWindowTheme } = useInboxTheme();
+
   const [isEnabled, setIsEnabled] = useState(!!themeData.theme);
   const [theme, setTheme] = useState(
     themeData.theme ?? {
@@ -43,9 +47,12 @@ const ThemeSetting = ({
     }
   }, []);
 
+  const debouncedSetWindowTheme = useDebouncedCallback(setWindowTheme, 200);
+
   const handleColorChange =
     (color: keyof NonNullable<ThemeUpdates["theme"]>) => (e: React.ChangeEvent<HTMLInputElement>) => {
       setTheme({ ...theme, [color]: e.target.value });
+      debouncedSetWindowTheme({ ...theme, [color]: e.target.value });
       onChange({ theme: { ...theme, [color]: e.target.value } });
     };
 

--- a/apps/nextjs/src/app/(dashboard)/mailboxes/[mailbox_slug]/settings/page.tsx
+++ b/apps/nextjs/src/app/(dashboard)/mailboxes/[mailbox_slug]/settings/page.tsx
@@ -92,6 +92,7 @@ const Page = async (props: { params: Promise<PageProps> }) => {
           mailboxSlug: params.mailbox_slug,
           preferences: {
             confetti: pendingUpdates?.preferences?.confettiSetting?.confetti ?? false,
+            theme: pendingUpdates?.preferences?.themeSetting?.theme ?? undefined,
           },
         });
       } catch (e) {

--- a/apps/nextjs/src/components/ui/button.tsx
+++ b/apps/nextjs/src/components/ui/button.tsx
@@ -15,7 +15,7 @@ export const buttonVariants = cva(
           "border border-destructive text-destructive hover:bg-primary hover:text-primary-foreground",
         outlined: "border border-primary text-foreground hover:bg-secondary",
         outlined_subtle: "border border-border text-foreground hover:bg-secondary",
-        subtle: "bg-secondary text-primary hover:bg-primary hover:text-primary-foreground",
+        subtle: "bg-secondary text-secondary-foreground hover:bg-primary hover:text-primary-foreground",
         ghost: "text-primary hover:bg-secondary",
         bare: "text-primary hover:bg-secondary p-0 h-auto",
         link: "text-primary underline-offset-4 hover:underline",

--- a/apps/nextjs/src/components/ui/input.tsx
+++ b/apps/nextjs/src/components/ui/input.tsx
@@ -18,7 +18,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
           <input
             type={type}
             className={cn(
-              "w-full rounded-lg bg-background border-border text-sm focus:border-transparent focus:outline-hidden focus:ring-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
+              "w-full rounded-lg bg-background border border-border text-sm focus:border-transparent focus:outline-hidden focus:ring-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
               "placeholder:text-muted-foreground",
               "text-base",
               iconsPrefix && "pl-10",

--- a/apps/nextjs/src/db/schema/mailboxes.ts
+++ b/apps/nextjs/src/db/schema/mailboxes.ts
@@ -51,6 +51,7 @@ export const mailboxes = pgTable(
           foreground: string;
           primary: string;
           accent: string;
+          sidebarBackground: string;
         };
       }>()
       .default({

--- a/apps/nextjs/src/db/schema/mailboxes.ts
+++ b/apps/nextjs/src/db/schema/mailboxes.ts
@@ -46,6 +46,12 @@ export const mailboxes = pgTable(
     preferences: jsonb()
       .$type<{
         confetti: boolean;
+        theme?: {
+          background: string;
+          foreground: string;
+          primary: string;
+          accent: string;
+        };
       }>()
       .default({
         confetti: false,

--- a/apps/nextjs/src/lib/themes.ts
+++ b/apps/nextjs/src/lib/themes.ts
@@ -1,0 +1,64 @@
+import { type Mailbox } from "@/lib/data/mailbox";
+
+export type MailboxTheme = NonNullable<Mailbox["preferences"]>["theme"];
+
+export const buildThemeCss = (theme: MailboxTheme) => {
+  if (!theme) return "";
+
+  const { background, foreground, primary, accent } = theme;
+
+  const getLuminance = (hexColor: string) => {
+    const r = parseInt(hexColor.slice(1, 3), 16);
+    const g = parseInt(hexColor.slice(3, 5), 16);
+    const b = parseInt(hexColor.slice(5, 7), 16);
+    const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+    return luminance;
+  };
+
+  const getContrastColor = (hexColor: string, candidate: string) => {
+    const luminance = getLuminance(hexColor);
+    const candidateLuminance = getLuminance(candidate);
+    if ((luminance > 0.5 && candidateLuminance < 0.2) || (luminance < 0.5 && candidateLuminance > 0.8)) {
+      return candidate;
+    }
+    return luminance > 0.5 ? "#000000" : "#ffffff";
+  };
+
+  const sidebarForeground = getContrastColor(primary, foreground);
+
+  return `
+    :root,
+    .light,
+    .dark {
+      --sidebar-width: 280px;
+      --sidebar-width-mobile: 100%;
+      --sidebar-background: ${primary};
+      --sidebar-foreground: ${sidebarForeground};
+      --sidebar-primary: ${primary};
+      --sidebar-primary-foreground: ${sidebarForeground};
+      --sidebar-accent: color-mix(in srgb, ${sidebarForeground} 20%, transparent);
+      --sidebar-accent-foreground: ${sidebarForeground};
+      --sidebar-border: color-mix(in srgb, ${sidebarForeground} 50%, ${primary});
+      --sidebar-ring: color-mix(in srgb, ${sidebarForeground} 50%, ${primary});
+      --background: ${background};
+      --foreground: ${foreground};
+      --card: ${background};
+      --card-foreground: ${foreground};
+      --popover: ${background};
+      --popover-foreground: ${foreground};
+      --primary: ${primary};
+      --primary-foreground: ${getContrastColor(primary, foreground)};
+      --secondary: color-mix(in srgb, ${accent} 20%, ${background});
+      --secondary-foreground: ${foreground};
+      --muted: color-mix(in srgb, ${foreground} 50%, ${background});
+      --muted-foreground: ${foreground};
+      --accent: ${primary};
+      --accent-foreground: ${getContrastColor(primary, foreground)};
+      --border: color-mix(in srgb, ${foreground} 50%, ${background});
+      --input: color-mix(in srgb, ${foreground} 50%, ${background});
+      --ring: color-mix(in srgb, ${primary} 50%, ${background});
+      --bright: ${accent};
+      --bright-foreground: ${getContrastColor(accent, foreground)};
+    }
+  `;
+};

--- a/apps/nextjs/src/lib/themes.ts
+++ b/apps/nextjs/src/lib/themes.ts
@@ -2,21 +2,21 @@ import { type Mailbox } from "@/lib/data/mailbox";
 
 export type MailboxTheme = NonNullable<Mailbox["preferences"]>["theme"];
 
+export const normalizeHex = (color = "") => {
+  if (color.startsWith("#")) color = color.slice(1);
+  if (color.length === 3)
+    color = color
+      .split("")
+      .map((c) => c + c)
+      .join("");
+  if (!/^[0-9a-f]{6}$/i.test(color)) return "ffffff"; // If something invalid is entered in the input, default to white
+  return color;
+};
+
 export const buildThemeCss = (theme: MailboxTheme) => {
   if (!theme) return "";
 
-  const { background, foreground, primary, accent } = theme;
-
-  const normalizeHex = (color: string) => {
-    if (color.startsWith("#")) color = color.slice(1);
-    if (color.length === 3)
-      color = color
-        .split("")
-        .map((c) => c + c)
-        .join("");
-    if (!/^[0-9a-f]{6}$/i.test(color)) return "ffffff"; // If something invalid is entered in the input, default to white
-    return color;
-  };
+  const { background, foreground, primary, accent, sidebarBackground } = theme;
 
   const getLuminance = (hexColor: string) => {
     const normalizedHex = normalizeHex(hexColor);
@@ -36,7 +36,7 @@ export const buildThemeCss = (theme: MailboxTheme) => {
     return luminance > 0.5 ? "#000000" : "#ffffff";
   };
 
-  const sidebarForeground = getContrastColor(primary, foreground);
+  const sidebarForeground = getContrastColor(sidebarBackground, foreground);
 
   return `
     :root,
@@ -44,14 +44,14 @@ export const buildThemeCss = (theme: MailboxTheme) => {
     .dark {
       --sidebar-width: 280px;
       --sidebar-width-mobile: 100%;
-      --sidebar-background: ${primary};
+      --sidebar-background: ${sidebarBackground};
       --sidebar-foreground: ${sidebarForeground};
-      --sidebar-primary: ${primary};
+      --sidebar-primary: ${sidebarBackground};
       --sidebar-primary-foreground: ${sidebarForeground};
       --sidebar-accent: color-mix(in srgb, ${sidebarForeground} 20%, transparent);
       --sidebar-accent-foreground: ${sidebarForeground};
-      --sidebar-border: color-mix(in srgb, ${sidebarForeground} 50%, ${primary});
-      --sidebar-ring: color-mix(in srgb, ${sidebarForeground} 50%, ${primary});
+      --sidebar-border: color-mix(in srgb, ${sidebarForeground} 20%, ${sidebarBackground});
+      --sidebar-ring: color-mix(in srgb, ${sidebarForeground} 50%, ${sidebarBackground});
       --background: ${background};
       --foreground: ${foreground};
       --card: ${background};
@@ -62,12 +62,12 @@ export const buildThemeCss = (theme: MailboxTheme) => {
       --primary-foreground: ${getContrastColor(primary, foreground)};
       --secondary: color-mix(in srgb, ${accent} 20%, ${background});
       --secondary-foreground: ${foreground};
-      --muted: color-mix(in srgb, ${foreground} 50%, ${background});
+      --muted: color-mix(in srgb, ${foreground} 10%, ${background});
       --muted-foreground: ${foreground};
       --accent: ${primary};
       --accent-foreground: ${getContrastColor(primary, foreground)};
-      --border: color-mix(in srgb, ${foreground} 50%, ${background});
-      --input: color-mix(in srgb, ${foreground} 50%, ${background});
+      --border: color-mix(in srgb, ${foreground} 20%, ${background});
+      --input: color-mix(in srgb, ${foreground} 20%, ${background});
       --ring: color-mix(in srgb, ${primary} 50%, ${background});
       --bright: ${accent};
       --bright-foreground: ${getContrastColor(accent, foreground)};

--- a/apps/nextjs/src/lib/themes.ts
+++ b/apps/nextjs/src/lib/themes.ts
@@ -14,6 +14,7 @@ export const buildThemeCss = (theme: MailboxTheme) => {
         .split("")
         .map((c) => c + c)
         .join("");
+    if (!/^[0-9a-f]{6}$/i.test(color)) return "ffffff"; // If something invalid is entered in the input, default to white
     return color;
   };
 

--- a/apps/nextjs/src/lib/themes.ts
+++ b/apps/nextjs/src/lib/themes.ts
@@ -7,10 +7,21 @@ export const buildThemeCss = (theme: MailboxTheme) => {
 
   const { background, foreground, primary, accent } = theme;
 
+  const normalizeHex = (color: string) => {
+    if (color.startsWith("#")) color = color.slice(1);
+    if (color.length === 3)
+      color = color
+        .split("")
+        .map((c) => c + c)
+        .join("");
+    return color;
+  };
+
   const getLuminance = (hexColor: string) => {
-    const r = parseInt(hexColor.slice(1, 3), 16);
-    const g = parseInt(hexColor.slice(3, 5), 16);
-    const b = parseInt(hexColor.slice(5, 7), 16);
+    const normalizedHex = normalizeHex(hexColor);
+    const r = parseInt(normalizedHex.slice(0, 2), 16);
+    const g = parseInt(normalizedHex.slice(2, 4), 16);
+    const b = parseInt(normalizedHex.slice(4, 6), 16);
     const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
     return luminance;
   };

--- a/apps/nextjs/src/trpc/router/mailbox/preferences.ts
+++ b/apps/nextjs/src/trpc/router/mailbox/preferences.ts
@@ -25,10 +25,11 @@ export const preferencesRouter = {
           confetti: z.boolean(),
           theme: z
             .object({
-              background: z.string(),
-              foreground: z.string(),
-              primary: z.string(),
-              accent: z.string(),
+              background: z.string().regex(/^#([0-9a-f]{6})$/i),
+              foreground: z.string().regex(/^#([0-9a-f]{6})$/i),
+              primary: z.string().regex(/^#([0-9a-f]{6})$/i),
+              accent: z.string().regex(/^#([0-9a-f]{6})$/i),
+              sidebarBackground: z.string().regex(/^#([0-9a-f]{6})$/i),
             })
             .optional(),
         }),

--- a/apps/nextjs/src/trpc/router/mailbox/preferences.ts
+++ b/apps/nextjs/src/trpc/router/mailbox/preferences.ts
@@ -1,21 +1,21 @@
 import { TRPCRouterRecord } from "@trpc/server";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
+import { assertDefined } from "@/components/utils/assert";
 import { db } from "@/db/client";
 import { mailboxes } from "@/db/schema";
 import { mailboxProcedure } from "./procedure";
 
 export const preferencesRouter = {
   get: mailboxProcedure.query(async ({ ctx }) => {
-    const result = await db
-      .select({
-        preferences: mailboxes.preferences,
-      })
-      .from(mailboxes)
-      .where(eq(mailboxes.id, ctx.mailbox.id))
-      .limit(1);
-
-    return result[0];
+    return assertDefined(
+      await db.query.mailboxes.findFirst({
+        where: eq(mailboxes.id, ctx.mailbox.id),
+        columns: {
+          preferences: true,
+        },
+      }),
+    );
   }),
 
   update: mailboxProcedure
@@ -23,6 +23,14 @@ export const preferencesRouter = {
       z.object({
         preferences: z.object({
           confetti: z.boolean(),
+          theme: z
+            .object({
+              background: z.string(),
+              foreground: z.string(),
+              primary: z.string(),
+              accent: z.string(),
+            })
+            .optional(),
         }),
       }),
     )


### PR DESCRIPTION
The most basic way to do color themes with our current CSS. We can expand this into something much nicer, but for now it allows us to play around with branded themes, local dev theme, etc.

![Screenshot 2025-04-23 at 12 32 02](https://github.com/user-attachments/assets/48647140-8499-4287-bde5-fc793dc83f8d)

![Screenshot 2025-04-23 at 12 30 56](https://github.com/user-attachments/assets/925f0a4e-9118-4c22-a9f2-e52be83e8f66)

![Screenshot 2025-04-23 at 11 51 13](https://github.com/user-attachments/assets/21f8eb6f-79bc-4559-a107-f995e76615e7)

Previews in real-time as you edit the theme, which IMO is a bad idea since you can make the site unusable, but it's the easiest preview method for now:

https://github.com/user-attachments/assets/cb4c5231-5feb-40d8-9bf5-c5203fb035e7
