### PR TITLE
feat: format drafts as markdown and trim whitespace

### DIFF
--- a/apps/nextjs/src/app/(dashboard)/mailboxes/[mailbox_slug]/(inbox)/_components/messageActions.tsx
+++ b/apps/nextjs/src/app/(dashboard)/mailboxes/[mailbox_slug]/(inbox)/_components/messageActions.tsx
@@ -135,7 +135,7 @@ const EmailEditorComponent = React.forwardRef<
           actionButtons={actionButtons}
           signature={
             user?.firstName ? (
-              <div className="mt-6 text-muted-foreground">
+              <div className="mt-1 text-muted-foreground">
                 Best,
                 <br />
                 {user.firstName}

--- a/apps/nextjs/src/components/tiptap/editor.css
+++ b/apps/nextjs/src/components/tiptap/editor.css
@@ -10,16 +10,28 @@
 .ProseMirror p {
   font-size: 16px;
   line-height: 1.5;
+  margin-bottom: 1em;
 }
 
 .ProseMirror ul {
   list-style-type: disc;
   padding-left: 2em;
+  margin-bottom: 1em;
 }
 
 .ProseMirror ol {
   list-style-type: decimal;
   padding-left: 2em;
+  margin-bottom: 1em;
+}
+
+.ProseMirror li {
+  margin-top: 0.5em;
+  margin-bottom: 0.5em;
+}
+
+.ProseMirror li p {
+  margin: 0;
 }
 
 .ProseMirror a {

--- a/apps/nextjs/src/lib/data/conversationMessage.ts
+++ b/apps/nextjs/src/lib/data/conversationMessage.ts
@@ -3,6 +3,7 @@ import { addSeconds } from "date-fns";
 import { and, asc, desc, eq, inArray, isNotNull, isNull, ne, notInArray, or, SQL } from "drizzle-orm";
 import { htmlToText } from "html-to-text";
 import DOMPurify from "isomorphic-dompurify";
+import { marked } from "marked";
 import { EMAIL_UNDO_COUNTDOWN_SECONDS } from "@/components/constants";
 import { takeUniqueOrThrow } from "@/components/utils/arrays";
 import { db, Transaction } from "@/db/client";
@@ -419,7 +420,7 @@ export const createAiDraft = async (
   return await createConversationMessage(
     {
       conversationId,
-      body: body.replace("\n", "<br>"),
+      body: DOMPurify.sanitize(marked.parse(body.trim().replace(/\n\n+/g, "\n\n"))),
       role: "ai_assistant",
       status: "draft",
       responseToId,


### PR DESCRIPTION
Fixes #280 

Markdown works better in my testing than just replacing newlines.

Also added spacing to the editor styles so what you see is more similar to how it appears in the message list later.