### PR TITLE
Add manual controls to scrolling chips

### DIFF
--- a/packages/nextjs/components/ui/chip.tsx
+++ b/packages/nextjs/components/ui/chip.tsx
@@ -73,6 +73,7 @@ export const ChipContainer = ({
   const containerRef = React.useRef<HTMLDivElement>(null)
   const [showLeft, setShowLeft] = React.useState(false)
   const [showRight, setShowRight] = React.useState(false)
+  const [isHovered, setIsHovered] = React.useState(false)
 
   const checkScroll = () => {
     const el = containerRef.current
@@ -100,19 +101,26 @@ export const ChipContainer = ({
   }
 
   return (
-    <div className="relative">
+    <div 
+      className="relative group"
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+    >
       {showLeft && (
-        <>
-          <div className="absolute left-0 top-0 h-full w-14 pointer-events-none bg-gradient-to-r from-sidebar via-sidebar via-[40%] to-transparent z-10" />
-          <button
-            className="absolute left-1 top-1/2 -translate-y-1/2 z-20 flex items-center justify-center rounded-full h-8 w-8 bg-bright text-primary dark:text-sidebar transition-colors shadow leading-normal ml-2"
-            onClick={() => scrollBy(-120)}
-            tabIndex={-1}
-            aria-label="Scroll left"
-          >
-            <ChevronLeft className="w-4 h-4" />
-          </button>
-        </>
+        <div className="absolute left-0 top-0 h-full w-14 pointer-events-none bg-gradient-to-r from-sidebar via-sidebar via-[40%] to-transparent z-10" />
+      )}
+      {showLeft && (
+        <button
+          className={cn(
+            "absolute left-1 top-1/2 -translate-y-1/2 z-20 flex items-center justify-center rounded-full h-8 w-8 bg-bright text-primary dark:text-sidebar transition-opacity duration-200 shadow leading-normal ml-2",
+            isHovered ? "opacity-100" : "opacity-0"
+          )}
+          onClick={() => scrollBy(-120)}
+          tabIndex={-1}
+          aria-label="Scroll left"
+        >
+          <ChevronLeft className="w-4 h-4" />
+        </button>
       )}
       <div
         ref={containerRef}
@@ -130,17 +138,20 @@ export const ChipContainer = ({
         {children}
       </div>
       {showRight && (
-        <>
-          <div className="absolute right-0 top-0 h-full w-14 pointer-events-none bg-gradient-to-l from-sidebar via-sidebar via-[40%] to-transparent z-10" />
-          <button
-            className="absolute right-1 top-1/2 -translate-y-1/2 z-20 flex items-center justify-center rounded-full h-8 w-8 bg-bright text-primary dark:text-sidebar transition-colors shadow leading-normal mr-2"
-            onClick={() => scrollBy(120)}
-            tabIndex={-1}
-            aria-label="Scroll right"
-          >
-            <ChevronRight className="w-4 h-4" />
-          </button>
-        </>
+        <div className="absolute right-0 top-0 h-full w-14 pointer-events-none bg-gradient-to-l from-sidebar via-sidebar via-[40%] to-transparent z-10" />
+      )}
+      {showRight && (
+        <button
+          className={cn(
+            "absolute right-1 top-1/2 -translate-y-1/2 z-20 flex items-center justify-center rounded-full h-8 w-8 bg-bright text-primary dark:text-sidebar transition-opacity duration-200 shadow leading-normal mr-2",
+            isHovered ? "opacity-100" : "opacity-0"
+          )}
+          onClick={() => scrollBy(120)}
+          tabIndex={-1}
+          aria-label="Scroll right"
+        >
+          <ChevronRight className="w-4 h-4" />
+        </button>
       )}
     </div>
   )

--- a/packages/nextjs/components/ui/chip.tsx
+++ b/packages/nextjs/components/ui/chip.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import * as React from "react";
 import { cn } from "@/lib/utils";
+import { ChevronLeft, ChevronRight } from "lucide-react"
 
 export type ChipVariant = "sidebar" | "mobile";
 
@@ -66,41 +67,82 @@ Chip.displayName = "Chip";
 export const ChipContainer = ({
   className,
   storageKey = "chipContainerScroll",
+  children,
   ...props
 }: React.HTMLAttributes<HTMLDivElement> & { storageKey?: string }) => {
-  const containerRef = React.useRef<HTMLDivElement>(null);
+  const containerRef = React.useRef<HTMLDivElement>(null)
+  const [showLeft, setShowLeft] = React.useState(false)
+  const [showRight, setShowRight] = React.useState(false)
+
+  const checkScroll = () => {
+    const el = containerRef.current
+    if (!el) return
+    setShowLeft(el.scrollLeft > 0)
+    setShowRight(el.scrollLeft + el.clientWidth < el.scrollWidth - 1)
+  }
 
   React.useEffect(() => {
-    const container = containerRef.current;
-    if (!container) return;
-
+    const el = containerRef.current
+    if (!el) return
     const handleScroll = () => {
-      sessionStorage.setItem(storageKey, container.scrollLeft.toString());
-    };
-
-    const savedScroll = sessionStorage.getItem(storageKey);
-    if (savedScroll) {
-      container.scrollLeft = parseInt(savedScroll);
+      sessionStorage.setItem(storageKey, el.scrollLeft.toString())
+      checkScroll()
     }
+    const savedScroll = sessionStorage.getItem(storageKey)
+    if (savedScroll) el.scrollLeft = parseInt(savedScroll)
+    el.addEventListener("scroll", handleScroll)
+    checkScroll()
+    return () => el.removeEventListener("scroll", handleScroll)
+  }, [storageKey])
 
-    container.addEventListener("scroll", handleScroll);
-    return () => container.removeEventListener("scroll", handleScroll);
-  }, [storageKey]);
+  const scrollBy = (amount: number) => {
+    containerRef.current?.scrollBy({ left: amount, behavior: "smooth" })
+  }
 
   return (
-    <div
-      ref={containerRef}
-      className={cn(
-        "flex gap-1.5 overflow-x-auto px-4 py-2 md:pb-4",
-        "[scrollbar-color:var(--scrollbar-color,rgba(0,0,0,0.4))_transparent]",
-        "[&::-webkit-scrollbar]{height:4px}",
-        "[&::-webkit-scrollbar-thumb]{background:rgba(0,0,0,0.4)}",
-        "dark:[&::-webkit-scrollbar-thumb]{background:rgba(255,255,255,0.4)}",
-        "dark:[--scrollbar-color:rgba(255,255,255,0.4)]",
-        className,
+    <div className="relative">
+      {showLeft && (
+        <>
+          <div className="absolute left-0 top-0 h-full w-10 pointer-events-none bg-gradient-to-r from-sidebar via-sidebar via-[40%] to-transparent z-10" />
+          <button
+            className="absolute left-1 top-1/2 -translate-y-1/2 z-20 flex items-center justify-center rounded-full h-8 w-8 bg-bright text-primary dark:text-sidebar transition-colors shadow leading-normal"
+            onClick={() => scrollBy(-120)}
+            tabIndex={-1}
+            aria-label="Scroll left"
+          >
+            <ChevronLeft className="w-4 h-4" />
+          </button>
+        </>
       )}
-      {...props}
-    />
-  );
-};
-ChipContainer.displayName = "ChipContainer";
+      <div
+        ref={containerRef}
+        className={cn(
+          "flex gap-1.5 overflow-x-auto px-4 py-4",
+          "[scrollbar-color:var(--scrollbar-color,rgba(0,0,0,0.4))_transparent]",
+          "[&::-webkit-scrollbar]{height:4px}",
+          "[&::-webkit-scrollbar-thumb]{background:rgba(0,0,0,0.4)}",
+          "dark:[&::-webkit-scrollbar-thumb]{background:rgba(255,255,255,0.4)}",
+          "dark:[--scrollbar-color:rgba(255,255,255,0.4)]",
+          className
+        )}
+        {...props}
+      >
+        {children}
+      </div>
+      {showRight && (
+        <>
+          <div className="absolute right-0 top-0 h-full w-10 pointer-events-none bg-gradient-to-l from-sidebar via-sidebar via-[40%] to-transparent z-10" />
+          <button
+            className="absolute right-1 top-1/2 -translate-y-1/2 z-20 flex items-center justify-center rounded-full h-8 w-8 bg-bright text-primary dark:text-sidebar transition-colors shadow leading-normal"
+            onClick={() => scrollBy(120)}
+            tabIndex={-1}
+            aria-label="Scroll right"
+          >
+            <ChevronRight className="w-4 h-4" />
+          </button>
+        </>
+      )}
+    </div>
+  )
+}
+ChipContainer.displayName = "ChipContainer"

--- a/packages/nextjs/components/ui/chip.tsx
+++ b/packages/nextjs/components/ui/chip.tsx
@@ -103,9 +103,9 @@ export const ChipContainer = ({
     <div className="relative">
       {showLeft && (
         <>
-          <div className="absolute left-0 top-0 h-full w-10 pointer-events-none bg-gradient-to-r from-sidebar via-sidebar via-[40%] to-transparent z-10" />
+          <div className="absolute left-0 top-0 h-full w-14 pointer-events-none bg-gradient-to-r from-sidebar via-sidebar via-[40%] to-transparent z-10" />
           <button
-            className="absolute left-1 top-1/2 -translate-y-1/2 z-20 flex items-center justify-center rounded-full h-8 w-8 bg-bright text-primary dark:text-sidebar transition-colors shadow leading-normal"
+            className="absolute left-1 top-1/2 -translate-y-1/2 z-20 flex items-center justify-center rounded-full h-8 w-8 bg-bright text-primary dark:text-sidebar transition-colors shadow leading-normal ml-2"
             onClick={() => scrollBy(-120)}
             tabIndex={-1}
             aria-label="Scroll left"
@@ -131,9 +131,9 @@ export const ChipContainer = ({
       </div>
       {showRight && (
         <>
-          <div className="absolute right-0 top-0 h-full w-10 pointer-events-none bg-gradient-to-l from-sidebar via-sidebar via-[40%] to-transparent z-10" />
+          <div className="absolute right-0 top-0 h-full w-14 pointer-events-none bg-gradient-to-l from-sidebar via-sidebar via-[40%] to-transparent z-10" />
           <button
-            className="absolute right-1 top-1/2 -translate-y-1/2 z-20 flex items-center justify-center rounded-full h-8 w-8 bg-bright text-primary dark:text-sidebar transition-colors shadow leading-normal"
+            className="absolute right-1 top-1/2 -translate-y-1/2 z-20 flex items-center justify-center rounded-full h-8 w-8 bg-bright text-primary dark:text-sidebar transition-colors shadow leading-normal mr-2"
             onClick={() => scrollBy(120)}
             tabIndex={-1}
             aria-label="Scroll right"

--- a/packages/nextjs/components/ui/sidebar.tsx
+++ b/packages/nextjs/components/ui/sidebar.tsx
@@ -128,7 +128,7 @@ const SidebarInput = React.forwardRef<React.ElementRef<typeof Input>, React.Comp
 SidebarInput.displayName = "SidebarInput";
 
 const SidebarHeader = React.forwardRef<HTMLDivElement, React.ComponentProps<"div">>(({ className, ...props }, ref) => {
-  return <div ref={ref} data-sidebar="header" className={cn("flex flex-col gap-2 p-2", className)} {...props} />;
+  return <div ref={ref} data-sidebar="header" className={cn("flex flex-col gap-2 p-2 pb-0", className)} {...props} />;
 });
 SidebarHeader.displayName = "SidebarHeader";
 


### PR DESCRIPTION
## What

- Add manual controls to the horizontal chip scroll 


https://github.com/user-attachments/assets/bd403920-e658-4334-ad0c-02999808892c



## Why 

- The current UI looks unintentionally cut-off and people don’t expect it to scroll

## Note for feedback
Controls appear on hover since there’s already a lot going on in the sidebar—  I think the gradient helps hint that you can scroll/navigate. Happy to update to always show the arrows if it’s still not clear.
