### PR TITLE
Pull Request: Add Windows setup instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,4 +92,3 @@ npm run db:migrate
 ## License
 
 Helper is licensed under the [MIT License](LICENSE.md).
-```

--- a/README.md
+++ b/README.md
@@ -93,7 +93,3 @@ npm run db:migrate
 
 Helper is licensed under the [MIT License](LICENSE.md).
 ```
-
----
-
-Agora é só copiar e colar no seu `README.md`. Isso deve funcionar de forma bem clara para todos os sistemas. Qualquer coisa, só me chamar!

--- a/README.md
+++ b/README.md
@@ -36,6 +36,25 @@ brew install mkcert
 brew install nss
 ```
 
+#### For Windows:
+
+Open **PowerShell as Administrator** and run:
+
+```powershell
+Set-ExecutionPolicy Bypass -Scope Process -Force; `
+[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; `
+iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
+```
+
+Then:
+
+```powershell
+choco install mkcert
+mkcert -install
+```
+
+> If Chocolatey installation fails due to an existing incomplete setup, delete `C:\ProgramData\chocolatey` manually and rerun the script above.
+
 _For other operating systems, see the [mkcert installation guide](https://github.com/FiloSottile/mkcert?tab=readme-ov-file#installation)._
 
 2. Generate SSL certificates:
@@ -74,3 +93,8 @@ npm run db:migrate
 ## License
 
 Helper is licensed under the [MIT License](LICENSE.md).
+```
+
+---
+
+Agora é só copiar e colar no seu `README.md`. Isso deve funcionar de forma bem clara para todos os sistemas. Qualquer coisa, só me chamar!

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ brew install mkcert
 brew install nss
 ```
 
-#### For Windows:
+```sh
+# Install mkcert on Windows
 
 Open **PowerShell as Administrator** and run:
 
@@ -47,13 +48,13 @@ iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocola
 ```
 
 Then:
-
 ```powershell
 choco install mkcert
 mkcert -install
 ```
 
 > If Chocolatey installation fails due to an existing incomplete setup, delete `C:\ProgramData\chocolatey` manually and rerun the script above.
+```sh
 
 _For other operating systems, see the [mkcert installation guide](https://github.com/FiloSottile/mkcert?tab=readme-ov-file#installation)._
 

--- a/README.md
+++ b/README.md
@@ -38,20 +38,11 @@ brew install nss
 
 ```sh
 # Install mkcert on Windows
-
-Open **PowerShell as Administrator** and run:
-
-powershell
-Set-ExecutionPolicy Bypass -Scope Process -Force; `
-[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; `
-iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
-
-Then:
+# First ensure you have Chocolately installed: https://chocolatey.org/install
+# Then:
 powershell
 choco install mkcert
 mkcert -install
-
-If Chocolatey installation fails due to an existing incomplete setup, delete `C:\ProgramData\chocolatey` manually and rerun the script above.
 ```
 
 _For other operating systems, see the [mkcert installation guide](https://github.com/FiloSottile/mkcert?tab=readme-ov-file#installation)._

--- a/README.md
+++ b/README.md
@@ -41,20 +41,18 @@ brew install nss
 
 Open **PowerShell as Administrator** and run:
 
-```powershell
+powershell
 Set-ExecutionPolicy Bypass -Scope Process -Force; `
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; `
 iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
-```
 
 Then:
-```powershell
+powershell
 choco install mkcert
 mkcert -install
-```
 
-> If Chocolatey installation fails due to an existing incomplete setup, delete `C:\ProgramData\chocolatey` manually and rerun the script above.
-```sh
+If Chocolatey installation fails due to an existing incomplete setup, delete `C:\ProgramData\chocolatey` manually and rerun the script above.
+```
 
 _For other operating systems, see the [mkcert installation guide](https://github.com/FiloSottile/mkcert?tab=readme-ov-file#installation)._
 


### PR DESCRIPTION
**What was added**
- Added detailed steps for installing mkcert on Windows using PowerShell and Chocolatey.
- Matched the formatting style of the macOS section to keep consistency.
- Included troubleshooting note for pre-existing Chocolatey installations.

**Why this change matters**
- This project currently only had setup instructions for macOS. By adding Windows instructions:
- We make the onboarding process smoother for contributors using Windows.
- We reduce setup time and increase accessibility for a wider developer base.

**How to test**
- Run the PowerShell script provided in the README on a Windows machine with admin rights.
- Confirm mkcert installs and runs properly with mkcert -install.