### PR TITLE
Allow users to close the Helper widget by typing "close", "exit", "cancel", etc.

### DIFF
--- a/components/widget/ChatInput.tsx
+++ b/components/widget/ChatInput.tsx
@@ -128,9 +128,13 @@ export default function ChatInput({
 
   const submit = () => {
     const normalizedInput = input.trim().toLowerCase();
-    if (["exit", "cancel", "close", "stop", "quit", "end", "bye"].some(cmd => normalizedInput === cmd) || 
-        normalizedInput.includes("exit chat") || normalizedInput.includes("exit this chat") ||  normalizedInput.includes("close this chat") || 
-        normalizedInput.includes("close chat")) {
+    if (
+      ["exit", "cancel", "close", "stop", "quit", "end", "bye"].some((cmd) => normalizedInput === cmd) ||
+      normalizedInput.includes("exit chat") ||
+      normalizedInput.includes("exit this chat") ||
+      normalizedInput.includes("close this chat") ||
+      normalizedInput.includes("close chat")
+    ) {
       closeWidget();
       return;
     }

--- a/components/widget/ChatInput.tsx
+++ b/components/widget/ChatInput.tsx
@@ -9,7 +9,7 @@ import ShadowHoverButton from "@/components/widget/ShadowHoverButton";
 import { useScreenshotStore } from "@/components/widget/widgetState";
 import { captureExceptionAndLog } from "@/lib/shared/sentry";
 import { cn } from "@/lib/utils";
-import { sendScreenshot } from "@/lib/widget/messages";
+import { closeWidget, sendScreenshot } from "@/lib/widget/messages";
 
 type Props = {
   input: string;
@@ -127,6 +127,13 @@ export default function ChatInput({
   }, [screenshot]);
 
   const submit = () => {
+    const normalizedInput = input.trim().toLowerCase();
+    if (["exit", "cancel", "close", "stop", "quit", "end", "bye"].some(cmd => normalizedInput === cmd) || 
+        normalizedInput.includes("exit chat") || normalizedInput.includes("exit this chat") ||  normalizedInput.includes("close this chat") || 
+        normalizedInput.includes("close chat")) {
+      closeWidget();
+      return;
+    }
     if (includeScreenshot) {
       sendScreenshot();
     } else {


### PR DESCRIPTION
## What

- One word messages: `"exit", "cancel", "close", "stop", "quit", "end", "bye"` will automatically close the widget.
- Messages that include the phrases `"exit chat", "exit this chat", "cancel chat", "cancel this chat"`, will automatically close the widget.

## Why

Partially addresses #360