### PR TITLE
feat: add proactive suggestion buttons to the widget ui <part 1/2 of extra credit for support> 

### DIFF
--- a/components/widget/Conversation.tsx
+++ b/components/widget/Conversation.tsx
@@ -1,3 +1,4 @@
+import QuickSuggestions from "./QuickSuggestions";
 import { useChat } from "@ai-sdk/react";
 import { useQuery } from "@tanstack/react-query";
 import type { Message } from "ai";
@@ -154,7 +155,7 @@ export default function Conversation({
             reactionType: message.reactionType,
             reactionFeedback: message.reactionFeedback,
             annotations: message.annotations,
-            parts: message.parts,
+	            parts: message.parts,
             experimental_attachments: message.experimental_attachments,
           })),
           allAttachments: data.allAttachments,
@@ -183,6 +184,11 @@ export default function Conversation({
       setIsEscalated(false);
     }
   }, [isNewConversation, setMessages, setConversationSlug]);
+
+  const handleSuggestionClick = (prompt: string) => {  
+  setInput(prompt);  
+  handleSubmit(prompt);  
+  };
 
   const handleSubmit = async (screenshotData?: string) => {
     if (!input.trim()) return;
@@ -261,7 +267,13 @@ export default function Conversation({
         onTalkToTeamClick={handleTalkToTeamClick}
         isEscalated={isEscalated}
       />
-      <ChatInput
+
+     <QuickSuggestions   
+       onSuggestionClick={handleSuggestionClick}   
+       isVisible={isNewConversation && messages.length === 0}   
+      />
+  
+       <ChatInput
         input={input}
         inputRef={inputRef}
         handleInputChange={handleInputChange}

--- a/components/widget/QuickSuggestions.tsx
+++ b/components/widget/QuickSuggestions.tsx
@@ -1,0 +1,55 @@
+import { useState } from "react";  
+import { Button } from "../ui/button";  
+import { AnimatePresence, motion } from "framer-motion";  
+  
+type SuggestionItem = {  
+  label: string;  
+  prompt: string;  
+};  
+  
+const SUGGESTIONS: SuggestionItem[] = [  
+  { label: "Where's my payout?", prompt: "Where's my payout?" },  
+  { label: "Publishing error", prompt: "Why won't my post publish?" },  
+  { label: "Email tools locked", prompt: "How do I unlock email tools?" },  
+  { label: "KYC help", prompt: "How do I complete verification?" },  
+];  
+  
+type Props = {  
+  onSuggestionClick: (prompt: string) => void;  
+  isVisible: boolean;  
+};  
+
+export default function QuickSuggestions({ onSuggestionClick, isVisible }: Props) {  
+  const [hasInteracted, setHasInteracted] = useState(false);  
+  
+  const handleSuggestionClick = (prompt: string) => {  
+    setHasInteracted(true);  
+    onSuggestionClick(prompt);  
+  };  
+
+if (!isVisible || hasInteracted) return null;  
+  
+  return (  
+    <AnimatePresence>  
+      <motion.div  
+        className="flex flex-wrap justify-center gap-2 py-3"  
+        initial={{ opacity: 0, y: 20 }}  
+        animate={{ opacity: 1, y: 0 }}  
+        exit={{ opacity: 0, y: 20 }}  
+        transition={{ duration: 0.3 }}  
+      >  
+        {SUGGESTIONS.map((suggestion, index) => (  
+          <Button  
+            key={index}  
+            variant="subtle"  
+            size="sm"  
+            className="text-sm"  
+            onClick={() => handleSuggestionClick(suggestion.prompt)}  
+          >  
+            {suggestion.label}  
+          </Button>  
+        ))}  
+      </motion.div>  
+    </AnimatePresence>  
+  );  
+}


### PR DESCRIPTION
**What:**

- Added a PROACTIVE_SUGGESTIONS array in ChatInput.tsx.
- Rendered quick-help buttons above the textarea for common creator pain points.
- Updated textarea placeholder to “Having trouble with payouts, publishing, or email? Ask me here…”

**Why:**

- Aligns with “support that waves first” by surfacing help before a user even types.
- Reduces friction and support tickets around frequent issues like payouts, publishing errors, and email limits.
- High-leverage UX improvement with minimal code change.

**Screenshot**
![Helper2 0](https://github.com/user-attachments/assets/b9451094-2a3b-4f37-88ec-f0983d3917c8)

**Update** to cover the changes in the repo over last few days :)