### PR TITLE
fix: avoid vh height for widget

### DIFF
--- a/packages/sdk/src/embed.css
+++ b/packages/sdk/src/embed.css
@@ -133,7 +133,7 @@
 @media (min-width: 640px) {
   .helper-widget-wrapper {
     width: 420px;
-    height: 95vh;
+    top: 20px;
     right: 20px;
     bottom: 20px;
     transform: translateX(120%);


### PR DESCRIPTION
Closes #360 

Chrome on tablet seems to set 100vh = height of the screen _including Chrome UI_ which means the widget ends up too tall.