### PR TITLE
Change file path arg for seedDatabase.ts

### DIFF
--- a/db/seeds/seedDatabase.ts
+++ b/db/seeds/seedDatabase.ts
@@ -152,7 +152,7 @@ export const seedDatabase = async () => {
     }
 
     // Optionally create this file to do any additional seeding, e.g. setting up integrations with local credentials
-    if (existsSync(path.join(import.meta.dirname, "localSeeds.ts"))) {
+    if (existsSync(path.join(dirname(fileURLToPath(import.meta.url)), "localSeeds.ts"))) {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore - localSeeds.ts is optional
       await import("./localSeeds").then((module: any) => module.default());


### PR DESCRIPTION
Context: ran into `Database reset failed: TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received undefined` on indexed message 37 when running `pnpm db:reset`

Issue: `import.meta.dirname` evaluated to undefined resulting in typeerror on path.join

Resolution: swap `import.meta.dirname` for `dirname(fileURLToPath(import.meta.url))`