### PR TITLE
feat: add more details prompt if the first message didn't help

### DIFF
--- a/components/widget/ChatInput.tsx
+++ b/components/widget/ChatInput.tsx
@@ -18,6 +18,7 @@ type Props = {
   handleSubmit: (screenshotData?: string) => void;
   isLoading: boolean;
   isGumroadTheme: boolean;
+  placeholder?: string;
 };
 
 const SCREENSHOT_KEYWORDS = [
@@ -65,6 +66,7 @@ export default function ChatInput({
   handleSubmit,
   isLoading,
   isGumroadTheme,
+  placeholder,
 }: Props) {
   const [showScreenshot, setShowScreenshot] = useState(false);
   const [includeScreenshot, setIncludeScreenshot] = useState(false);
@@ -178,7 +180,7 @@ export default function ChatInput({
                 submit();
               }
             }}
-            placeholder="Ask a question..."
+            placeholder={placeholder}
             className="self-stretch max-w-md placeholder:text-muted-foreground text-foreground flex-1 resize-none border-none bg-white p-0 pr-3 outline-hidden focus:border-none focus:outline-hidden focus:ring-0 min-h-[24px] max-h-[200px]"
             disabled={isLoading}
           />

--- a/components/widget/Conversation.tsx
+++ b/components/widget/Conversation.tsx
@@ -1,6 +1,7 @@
 import { useChat } from "@ai-sdk/react";
 import { useQuery } from "@tanstack/react-query";
 import type { Message } from "ai";
+import { AnimatePresence } from "motion/react";
 import { useEffect, useRef, useState } from "react";
 import { ReadPageToolConfig } from "@helperai/sdk";
 import { assertDefined } from "@/components/utils/assert";
@@ -253,14 +254,16 @@ export default function Conversation({
         resumeGuide={resumeGuide}
         status={status}
       />
-      <SupportButtons
-        conversationSlug={conversationSlug}
-        token={token}
-        messageStatus={status}
-        lastMessage={lastAIMessage}
-        onTalkToTeamClick={handleTalkToTeamClick}
-        isEscalated={isEscalated}
-      />
+      <AnimatePresence>
+        <SupportButtons
+          conversationSlug={conversationSlug}
+          token={token}
+          messageStatus={status}
+          lastMessage={lastAIMessage}
+          onTalkToTeamClick={handleTalkToTeamClick}
+          isEscalated={isEscalated}
+        />
+      </AnimatePresence>
       <ChatInput
         input={input}
         inputRef={inputRef}

--- a/components/widget/Conversation.tsx
+++ b/components/widget/Conversation.tsx
@@ -49,6 +49,7 @@ export default function Conversation({
   const { conversationSlug, setConversationSlug, createConversation } = useNewConversation(token);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const [isEscalated, setIsEscalated] = useState(false);
+  const [isProvidingDetails, setIsProvidingDetails] = useState(false);
   const { setIsNewConversation } = useWidgetView();
 
   useEffect(() => {
@@ -231,9 +232,18 @@ export default function Conversation({
     };
   }, [token]);
 
+  useEffect(() => {
+    setIsProvidingDetails(false);
+  }, [lastAIMessage]);
+
   const handleTalkToTeamClick = () => {
     setIsEscalated(true);
     append({ role: "user", content: "I need to talk to a human" }, { body: { conversationSlug } });
+  };
+
+  const handleAddDetailsClick = () => {
+    inputRef.current?.focus();
+    setIsProvidingDetails(true);
   };
 
   if (isLoadingConversation && !isNewConversation && selectedConversationSlug) {
@@ -261,6 +271,8 @@ export default function Conversation({
           messageStatus={status}
           lastMessage={lastAIMessage}
           onTalkToTeamClick={handleTalkToTeamClick}
+          onAddDetailsClick={handleAddDetailsClick}
+          isGumroadTheme={isGumroadTheme}
           isEscalated={isEscalated}
         />
       </AnimatePresence>
@@ -271,6 +283,7 @@ export default function Conversation({
         handleSubmit={handleSubmit}
         isLoading={isLoading}
         isGumroadTheme={isGumroadTheme}
+        placeholder={isProvidingDetails ? "Provide additional details..." : "Ask a question..."}
       />
     </>
   );

--- a/components/widget/SupportButtons.tsx
+++ b/components/widget/SupportButtons.tsx
@@ -1,8 +1,9 @@
-import { ChatBubbleLeftRightIcon, HandThumbDownIcon, HandThumbUpIcon } from "@heroicons/react/24/outline";
+import { ChatBubbleLeftRightIcon, HandThumbDownIcon, HandThumbUpIcon, XMarkIcon } from "@heroicons/react/24/outline";
 import { UIMessage } from "ai";
 import { motion } from "motion/react";
 import { useEffect, useState } from "react";
 import { captureExceptionAndLog } from "@/lib/shared/sentry";
+import { cn } from "@/lib/utils";
 
 type Props = {
   conversationSlug: string | null;
@@ -11,6 +12,7 @@ type Props = {
   lastMessage: UIMessage | undefined;
   onTalkToTeamClick: () => void;
   onAddDetailsClick: () => void;
+  isGumroadTheme: boolean;
   isEscalated?: boolean;
 };
 
@@ -21,6 +23,7 @@ export default function SupportButtons({
   lastMessage,
   onTalkToTeamClick,
   onAddDetailsClick,
+  isGumroadTheme,
   isEscalated = false,
 }: Props) {
   const [isHelpfulAnimating, setIsHelpfulAnimating] = useState(false);
@@ -29,6 +32,7 @@ export default function SupportButtons({
   const [isVisible, setIsVisible] = useState(true);
   const [hasClickedTalkToHuman, setHasClickedTalkToHuman] = useState(false);
   const [clickedAddDetailsOnMessageId, setClickedAddDetailsOnMessageId] = useState<string | null>(null);
+  const [dismissedAddDetails, setDismissedAddDetails] = useState(false);
 
   useEffect(() => {
     setClickedAddDetailsOnMessageId(null);
@@ -96,15 +100,27 @@ export default function SupportButtons({
     return null;
   }
   if (lastMessage.id === clickedAddDetailsOnMessageId) {
+    if (dismissedAddDetails) return null;
+    const arrowBase =
+      "absolute -bottom-2 left-6 -translate-x-1/2 w-0 h-0 border-l-[8px] border-l-transparent border-r-[8px] border-r-transparent border-t-[8px]";
     return (
       <motion.div
-        className="text-xs text-gray-600 p-3"
+        className={cn("-mb-px relative text-sm h-10", isGumroadTheme ? "bg-gumroad-bg" : "bg-background")}
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
         exit={{ opacity: 0, y: 20 }}
         transition={{ duration: 0.3 }}
       >
-        Why didn't this help? Be as specific as you can.
+        <div className={cn("absolute inset-0 bg-black/5")} />
+        <div className="absolute inset-0 flex items-center gap-2 px-3">
+          <HandThumbDownIcon className="h-4 w-4 text-red-500" />
+          Why didn't this help? Be as specific as you can.
+          <button className="ml-auto" onClick={() => setDismissedAddDetails(true)}>
+            <XMarkIcon className="h-4 w-4" />
+          </button>
+        </div>
+        <div className={cn(arrowBase, isGumroadTheme ? "border-t-gumroad-bg" : "border-t-background")} />
+        <div className={cn(arrowBase, "border-t-black/5")} />
       </motion.div>
     );
   }
@@ -147,7 +163,7 @@ export default function SupportButtons({
       {clickedAddDetailsOnMessageId ? (
         <button
           onClick={handleTalkToTeamClick}
-          className="flex items-center gap-2 rounded-full border border-border px-4 py-2 text-sm hover:bg-muted transition-colors duration-200 text-foreground"
+          className="flex items-center gap-2 rounded-full border border-gray-400 text-black px-4 py-2 text-sm hover:bg-gray-100 transition-colors duration-200"
         >
           <motion.div
             className="w-4 h-4 origin-center"
@@ -174,7 +190,7 @@ export default function SupportButtons({
       ) : (
         <button
           onClick={handleAddDetailsClick}
-          className="flex items-center gap-2 rounded-full border border-border px-4 py-2 text-sm hover:bg-muted transition-colors duration-200 text-foreground"
+          className="flex items-center gap-2 rounded-full border border-gray-400 text-black px-4 py-2 text-sm hover:bg-gray-100 transition-colors duration-200"
         >
           <motion.div
             className="w-4 h-4 origin-center"


### PR DESCRIPTION
Closes #388 

Note this keeps the prompt to ask for more details before escalating, so the AI may ask for details extra times if the customer hasn't said anything meaningful yet.

Quick fix > perfect UI, we need to work out a better solution for theming in the widget as part of single tenant anyway.

https://github.com/user-attachments/assets/5e0fd92e-81f8-4d70-a086-7aa415c36b06

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an "Add Details" feedback option, allowing users to provide more specific feedback when a response is unhelpful.
  - The chat input dynamically updates its placeholder text to guide users when providing additional details.
- **Improvements**
  - Enhanced support buttons with new animations and adaptive styling.
  - Improved feedback flow for users seeking further assistance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->