### PR TITLE
Invalidate preferences fetch on save

### DIFF
--- a/app/(dashboard)/mailboxes/[mailbox_slug]/settings/settings.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/settings/settings.tsx
@@ -18,6 +18,7 @@ import { PageHeader } from "@/components/pageHeader";
 import { Button } from "@/components/ui/button";
 import { mailboxes } from "@/db/schema";
 import { RouterOutputs } from "@/trpc";
+import { api } from "@/trpc/react";
 import { SidebarInfo } from "../getSidebarInfo";
 import ChatWidgetSetting from "./chat/chatWidgetSetting";
 import AutoCloseSetting, { AutoCloseUpdates } from "./customers/autoCloseSetting";
@@ -60,6 +61,7 @@ const Settings = ({ onUpdateSettings, mailbox, supportAccount }: SettingsProps) 
   const [isTransitionPending, startTransition] = useTransition();
   const [isUpdating, setIsUpdating] = useState(false);
   const [pendingUpdates, setPendingUpdates] = useState<PendingUpdates>({});
+  const utils = api.useUtils();
 
   const handleUpdateSettings = async () => {
     if (!hasPendingUpdates) return;
@@ -68,6 +70,8 @@ const Settings = ({ onUpdateSettings, mailbox, supportAccount }: SettingsProps) 
     try {
       await onUpdateSettings(pendingUpdates);
       setPendingUpdates({});
+      utils.mailbox.preferences.get.invalidate({ mailboxSlug: mailbox.slug });
+      utils.mailbox.get.invalidate({ mailboxSlug: mailbox.slug });
       toast({
         title: "Settings updated!",
         variant: "success",


### PR DESCRIPTION
Issue: On making a change in preferences (mailbox name, confetti, theme) and saving, next cache does not force a refetch when navigating to another tab and back to preferences unless a hard refresh is done. 

Resolution: invalidate mailbox fetch on saved changes in preferences

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Ensured mailbox settings and preferences are refreshed immediately after updates, providing up-to-date information in the dashboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->