### PR TITLE
Remove cursor pointer from non-interactive elements on marketing page

### DIFF
--- a/app/(marketing)/CitationsDemo.tsx
+++ b/app/(marketing)/CitationsDemo.tsx
@@ -19,7 +19,7 @@ export default function CitationsDemo() {
           <li>
             <a
               href="#"
-              className="underline"
+              className="underline cursor-default"
               onClick={(e) => e.preventDefault()}
               onMouseEnter={() => setTilt("refund")}
               onMouseLeave={() => setTilt(null)}
@@ -32,7 +32,7 @@ export default function CitationsDemo() {
           <li>
             <a
               href="#"
-              className="underline"
+              className="underline cursor-default"
               onClick={(e) => e.preventDefault()}
               onMouseEnter={() => setTilt("account")}
               onMouseLeave={() => setTilt(null)}

--- a/app/(marketing)/RefundDemo.tsx
+++ b/app/(marketing)/RefundDemo.tsx
@@ -45,21 +45,13 @@ export default function RefundDemo() {
           </div>
           <div className="flex h-[calc(100%-3rem)]">
             <aside className="flex flex-col gap-2 py-12 pl-4 md:pl-8 pr-2 md:pr-4 w-32 md:w-48 min-w-[100px] md:min-w-[140px] bg-transparent">
-              <span className="text-[#FFE6B0] text-sm md:text-base font-semibold px-2 py-1 rounded transition-colors hover:bg-[#2B0808]/60">
-                Dashboard
-              </span>
+              <span className="text-[#FFE6B0] text-sm md:text-base font-semibold px-2 py-1 rounded">Dashboard</span>
               <span className="text-[#FFE6B0] text-sm md:text-base font-semibold px-2 py-1 rounded transition-colors border-l-4 border-[#FEB81D] bg-[#3B1B1B]">
                 Orders
               </span>
-              <span className="text-[#FFE6B0] text-sm md:text-base font-semibold px-2 py-1 rounded transition-colors hover:bg-[#2B0808]/60">
-                Profile
-              </span>
-              <span className="text-[#FFE6B0] text-sm md:text-base font-semibold px-2 py-1 rounded transition-colors hover:bg-[#2B0808]/60">
-                Wishlist
-              </span>
-              <span className="text-[#FFE6B0] text-sm md:text-base font-semibold px-2 py-1 rounded transition-colors hover:bg-[#2B0808]/60">
-                Settings
-              </span>
+              <span className="text-[#FFE6B0] text-sm md:text-base font-semibold px-2 py-1 rounded">Profile</span>
+              <span className="text-[#FFE6B0] text-sm md:text-base font-semibold px-2 py-1 rounded">Wishlist</span>
+              <span className="text-[#FFE6B0] text-sm md:text-base font-semibold px-2 py-1 rounded">Settings</span>
             </aside>
             <main className="flex-1 flex flex-col gap-8 py-12 pr-4 md:pr-8 relative">
               <div className="relative">

--- a/app/(marketing)/SlackInterface.tsx
+++ b/app/(marketing)/SlackInterface.tsx
@@ -79,8 +79,12 @@ export function SlackInterface() {
               Sarah"
             </div>
             <div className="flex mt-2 space-x-2">
-              <button className="bg-[#FEB81D] text-black text-xs px-3 py-1 rounded font-bold cursor-default">Send</button>
-              <button className="bg-[#2B0808] text-white text-xs px-3 py-1 rounded font-bold cursor-default">edit</button>
+              <button className="bg-[#FEB81D] text-black text-xs px-3 py-1 rounded font-bold cursor-default">
+                Send
+              </button>
+              <button className="bg-[#2B0808] text-white text-xs px-3 py-1 rounded font-bold cursor-default">
+                edit
+              </button>
             </div>
           </div>
         </div>

--- a/app/(marketing)/SlackInterface.tsx
+++ b/app/(marketing)/SlackInterface.tsx
@@ -79,8 +79,8 @@ export function SlackInterface() {
               Sarah"
             </div>
             <div className="flex mt-2 space-x-2">
-              <button className="bg-[#FEB81D] text-black text-xs px-3 py-1 rounded font-bold">Send</button>
-              <button className="bg-[#2B0808] text-white text-xs px-3 py-1 rounded font-bold">edit</button>
+              <button className="bg-[#FEB81D] text-black text-xs px-3 py-1 rounded font-bold cursor-default">Send</button>
+              <button className="bg-[#2B0808] text-white text-xs px-3 py-1 rounded font-bold cursor-default">edit</button>
             </div>
           </div>
         </div>

--- a/app/(marketing)/SlackNotification.tsx
+++ b/app/(marketing)/SlackNotification.tsx
@@ -32,7 +32,9 @@ export function SlackNotification() {
               This is outside my capabilities.
             </div>
             <div className="flex mt-2">
-              <button className="bg-[#FEB81D] text-black text-xs px-3 py-1 rounded font-bold cursor-default">View conversation</button>
+              <button className="bg-[#FEB81D] text-black text-xs px-3 py-1 rounded font-bold cursor-default">
+                View conversation
+              </button>
             </div>
           </div>
         </div>

--- a/app/(marketing)/SlackNotification.tsx
+++ b/app/(marketing)/SlackNotification.tsx
@@ -32,7 +32,7 @@ export function SlackNotification() {
               This is outside my capabilities.
             </div>
             <div className="flex mt-2">
-              <button className="bg-[#FEB81D] text-black text-xs px-3 py-1 rounded font-bold">View conversation</button>
+              <button className="bg-[#FEB81D] text-black text-xs px-3 py-1 rounded font-bold cursor-default">View conversation</button>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Why

These buttons and links are presentational, not interactive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
	- Updated several buttons and links to display the default cursor instead of the pointer when hovered, clarifying their non-interactive status in the CitationsDemo, SlackInterface, and SlackNotification components.
	- Simplified sidebar navigation by removing hover background and color transition effects from most items, except the active "Orders" item.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->