### PR TITLE
docs: fix link to optional integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Copy `.env.local.sample` to `.env.local`, then fill in values for:
 
 </details>
 
-_The app will start with placeholder values for other services - you can follow the instructions in [development.md](docs/services.md#optional-integrations) to enable them later._
+_The app will start with placeholder values for other services - you can follow the instructions in [development.md](docs/development.md#optional-integrations) to enable them later._
 
 ### Install dependencies
 


### PR DESCRIPTION
The current link 404s. This fixes that :)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the documentation link for enabling optional integrations to direct users to the correct section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->