### PR TITLE
perf: improved search performance by caching key derivation

### DIFF
--- a/db/lib/djangoCrypto.ts
+++ b/db/lib/djangoCrypto.ts
@@ -261,6 +261,7 @@ export class PickleJS {
 export class DjangoCryptoCompat {
   private secret_key: string;
   private pickle: PickleJS;
+  private _derivedKey?: Buffer;
 
   constructor(secret_key: string) {
     this.secret_key = secret_key;
@@ -336,7 +337,10 @@ export class DjangoCryptoCompat {
   }
 
   deriveKey() {
-    // Django uses PBKDF2 to derive the encryption key
-    return crypto.pbkdf2Sync(this.secret_key, "django-cryptography", 30000, 32, "sha256");
+    if (!this._derivedKey) {
+      // Django uses PBKDF2 to derive the encryption key
+      this._derivedKey = crypto.pbkdf2Sync(this.secret_key, "django-cryptography", 30000, 32, "sha256");
+    }
+    return this._derivedKey;
   }
 }

--- a/db/lib/encryptedField.ts
+++ b/db/lib/encryptedField.ts
@@ -5,6 +5,7 @@ import { env } from "@/lib/env";
 
 const secretKey = env.CRYPTO_SECRET;
 const nativeEncryptColumnSecret = env.ENCRYPT_COLUMN_SECRET;
+const djangoCrypto = new DjangoCryptoCompat(secretKey);
 
 export const encryptedField = customType<{ data: string }>({
   dataType() {
@@ -12,9 +13,7 @@ export const encryptedField = customType<{ data: string }>({
   },
 
   toDriver(value: string): Buffer {
-    const crypto = new DjangoCryptoCompat(secretKey);
-    const encrypted = crypto.encrypt(value);
-    return encrypted;
+    return djangoCrypto.encrypt(value);
   },
 
   fromDriver(value: unknown): string {
@@ -27,8 +26,7 @@ export const encryptedField = customType<{ data: string }>({
       throw new Error(`Unexpected value type: ${typeof value}`);
     }
 
-    const crypto = new DjangoCryptoCompat(secretKey);
-    const decrypted = crypto.decrypt(bufferValue);
+    const decrypted = djangoCrypto.decrypt(bufferValue);
     return decrypted.toString("utf-8");
   },
 });


### PR DESCRIPTION
refs https://github.com/antiwork/helper/issues/404

- when searching, the slowest part of the flow is decrypting the `cleanedUpText`, which is encrypted using a lib we have locally
- instead of deriving the key for every decryption (which happens a lot during searching), we can just calculate this once
- this makes searching 10x faster on my local dev env

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved performance by caching encryption keys and reusing cryptographic instances internally, resulting in faster encryption and decryption operations. No changes to user-facing interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->