### PR TITLE
fix: update current tab title on load

### DIFF
--- a/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/tabBar.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/tabBar.tsx
@@ -123,6 +123,8 @@ export const TabBar = () => {
       subtree: true,
     });
 
+    updateCurrentTabTitle();
+
     return () => titleObserver.disconnect();
   }, []);
 


### PR DESCRIPTION
Fixes a bug where the title would restore from localStorage and not be updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured the current tab's title updates immediately when the tab is opened, providing more accurate and timely information to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->