### PR TITLE
Fix homepage overflow issues

### DIFF
--- a/app/(marketing)/RefundDemo.tsx
+++ b/app/(marketing)/RefundDemo.tsx
@@ -21,7 +21,7 @@ export default function RefundDemo() {
       ref={ref}
       className="relative min-h-[600px] md:min-h-[800px] flex flex-col items-center justify-center py-16 md:py-24 pb-40 md:pb-64"
     >
-      <div className="absolute top-8 left-[70%] lg:left-[50%] xl:left-[60%] -translate-x-1/2 flex flex-col items-start z-20">
+      <div className="absolute top-8 right-0 flex flex-col items-start z-20">
         <div className="border border-[#FEB81D80] rounded-t-xl rounded-bl-xl rounded-br-none px-4 md:px-5 py-3 w-[320px] md:w-[440px] text-base md:text-lg font-medium text-[#FFE6B0] bg-[#250404]">
           {!messageDone && isInView ? (
             <AnimatedTyping

--- a/app/(marketing)/ToolsDemo.tsx
+++ b/app/(marketing)/ToolsDemo.tsx
@@ -39,13 +39,10 @@ export default function ToolsDemo() {
         {tools.map((tool, i) => (
           <div key={tool.text} className={`flex ${i % 2 === 0 ? "justify-start" : "justify-end"}`}>
             <div
-              className={`flex items-center gap-3 md:gap-4 border ${tool.border} rounded-full py-2 px-3 transition-transform duration-200 bg-transparent`}
+              className={`flex items-center gap-3 md:gap-4 border ${tool.border} rounded-full py-2 px-3 transition-transform duration-200 bg-transparent max-w-full overflow-hidden`}
               style={{
                 transform: hovered === i ? `rotate(${i % 2 === 0 ? "-3deg" : "3deg"})` : undefined,
                 boxShadow: hovered === i ? `0 2px 16px 0 ${tool.color}22` : undefined,
-                width: "fit-content",
-                minWidth: 200,
-                maxWidth: "100%",
               }}
               onMouseEnter={() => setHovered(i)}
               onMouseLeave={() => setHovered(null)}
@@ -57,7 +54,7 @@ export default function ToolsDemo() {
                   <PlayCircle className="w-5 h-5 md:w-7 md:h-7" color={tool.color} fill="none" />
                 </span>
               )}
-              <span className="italic text-base md:text-xl text-[#FFE6B0] whitespace-nowrap">
+              <span className="italic text-base md:text-xl text-[#FFE6B0]">
                 {hovered === i ? tool.completed.text : tool.text}
               </span>
             </div>

--- a/app/(marketing)/page.tsx
+++ b/app/(marketing)/page.tsx
@@ -128,7 +128,7 @@ export default function Home() {
       <div className="flex-grow">
         <section className="flex items-center justify-center h-dvh pt-20">
           <div className="container mx-auto px-4">
-            <h1 className="text-6xl font-bold mb-24 text-center text-secondary dark:text-foreground">
+            <h1 className="text-5xl sm:text-6xl font-bold mb-24 text-center text-secondary dark:text-foreground">
               Helper helps customers help themselves.
             </h1>
 

--- a/app/(marketing)/page.tsx
+++ b/app/(marketing)/page.tsx
@@ -113,7 +113,7 @@ export default function Home() {
   useEffect(() => {
     if (typeof window === "undefined" || window.innerWidth >= 768) return;
     const interval = setInterval(() => {
-      setCurrentSlide((prev) => (prev === 2 ? 0 : prev + 1));
+      setCurrentSlide((prev) => (prev === 1 ? 0 : prev + 1));
     }, 4000);
     return () => clearInterval(interval);
   }, [currentSlide]);


### PR DESCRIPTION
## What



I wasn't actually able to reproduce this screenshot:
![image](https://github.com/user-attachments/assets/8275d32e-b237-4840-8cf0-7a3638edc62d)

but I cleaned up the CSS so this overflow issue should never happen anyway. 
<img width="158" alt="Screenshot 2025-05-19 at 10 16 01 PM" src="https://github.com/user-attachments/assets/97b632b3-4791-4e53-a964-9e9c5f6f47bd" />


Also fixed the message bubble which was positioned in a bizarre way that caused horizontal scroll on very small screens:
<img width="328" alt="Screenshot 2025-05-19 at 10 01 04 PM" src="https://github.com/user-attachments/assets/13d38c3f-5ba5-4970-8fe9-80f8241dd1ca" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Adjusted the position and alignment of the message box in the refund demo to appear at the top right corner.
  - Updated tool item containers to use improved width and overflow styling, allowing tool labels to wrap onto multiple lines.
  - Reduced the default font size of the main heading for better visual hierarchy.

- **Bug Fixes**
  - Fixed the mobile Slack carousel to cycle correctly between two slides instead of three.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->