### PR TITLE
fix: add new items immediately to the knowledge bank UI

### DIFF
--- a/app/(dashboard)/mailboxes/[mailbox_slug]/settings/knowledge/knowledgeBankSetting.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/settings/knowledge/knowledgeBankSetting.tsx
@@ -37,8 +37,10 @@ const KnowledgeBankSetting = () => {
   );
 
   const createMutation = api.mailbox.faqs.create.useMutation({
-    onSuccess: () => {
-      utils.mailbox.faqs.list.invalidate({ mailboxSlug: params.mailbox_slug });
+    onSuccess: (data) => {
+      utils.mailbox.faqs.list.setData({ mailboxSlug: params.mailbox_slug }, (old) =>
+        old ? [...old, data].sort((a, b) => a.content.localeCompare(b.content)) : [data],
+      );
       setShowNewFaqForm(false);
       setNewFaqContent("");
     },


### PR DESCRIPTION
Invaliding the query takes time to reload - confusing if the added item doesn't show up immediately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved FAQ creation experience: newly added FAQs now appear instantly in the list, sorted alphabetically, without needing a full refresh.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->