### PR TITLE
feat: show helper widget for testing on the chat settings page

### DIFF
--- a/app/(dashboard)/mailboxes/[mailbox_slug]/clientLayout.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/clientLayout.tsx
@@ -1,7 +1,16 @@
 "use client";
 
 import { createContext, useContext, useMemo, useState } from "react";
+import { create } from "zustand";
 import { buildThemeCss, MailboxTheme } from "@/lib/themes";
+
+export const useShowChatWidget = create<{
+  showChatWidget: boolean;
+  setShowChatWidget: (showChatWidget: boolean) => void;
+}>((set) => ({
+  showChatWidget: false,
+  setShowChatWidget: (showChatWidget) => set({ showChatWidget }),
+}));
 
 const InboxThemeContext = createContext<{
   theme: MailboxTheme | undefined;
@@ -21,11 +30,21 @@ export default function InboxClientLayout({
   theme?: MailboxTheme;
 }) {
   const [theme, setTheme] = useState<MailboxTheme | undefined>(initialTheme);
-
+  const { showChatWidget } = useShowChatWidget();
   const themeCss = useMemo(() => buildThemeCss(theme), [theme]);
 
   return (
     <InboxThemeContext.Provider value={{ theme, setTheme }}>
+      {/* We show the widget for testing on the chat settings page. Need to improve the SDK to allow destroying the widget so we can move the provider there */}
+      {!showChatWidget && (
+        <style>
+          {`
+            .helper-widget-icon {
+              display: none !important;
+            }
+          `}
+        </style>
+      )}
       <style>{themeCss}</style>
       {children}
     </InboxThemeContext.Provider>

--- a/app/(dashboard)/mailboxes/[mailbox_slug]/layout.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/layout.tsx
@@ -1,6 +1,8 @@
 import { TRPCError } from "@trpc/server";
 import { redirect } from "next/navigation";
 import InboxClientLayout from "@/app/(dashboard)/mailboxes/[mailbox_slug]/clientLayout";
+import { env } from "@/lib/env";
+import { HelperProvider } from "@/packages/react/dist/cjs";
 import { api } from "@/trpc/server";
 
 export default async function InboxLayout({
@@ -11,11 +13,15 @@ export default async function InboxLayout({
   params: Promise<{ mailbox_slug: string }>;
 }) {
   try {
-    const { preferences } = await api.mailbox.preferences.get({
-      mailboxSlug: (await params).mailbox_slug,
-    });
+    const mailboxSlug = (await params).mailbox_slug;
+    const { preferences } = await api.mailbox.preferences.get({ mailboxSlug });
 
-    return <InboxClientLayout theme={preferences?.theme}>{children}</InboxClientLayout>;
+    return (
+      // @ts-expect-error - need to update the React type definitions
+      <HelperProvider host={env.AUTH_URL} mailbox_slug={mailboxSlug} show_toggle_button>
+        <InboxClientLayout theme={preferences?.theme}>{children}</InboxClientLayout>
+      </HelperProvider>
+    );
   } catch (e) {
     if (e instanceof TRPCError && e.code === "NOT_FOUND") {
       return redirect("/mailboxes");

--- a/app/(dashboard)/mailboxes/[mailbox_slug]/settings/chat/chatWidgetSetting.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/settings/chat/chatWidgetSetting.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { ExternalLink } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { useShowChatWidget } from "@/app/(dashboard)/mailboxes/[mailbox_slug]/clientLayout";
 import { getBaseUrl } from "@/components/constants";
 import { toast } from "@/components/hooks/use-toast";
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
@@ -37,6 +38,12 @@ const ChatWidgetSetting = ({ mailbox }: { mailbox: RouterOutputs["mailbox"]["get
   const [minValue, setMinValue] = useState(mailbox.widgetDisplayMinValue?.toString() ?? "100");
   const [autoRespond, setAutoRespond] = useState(mailbox.autoRespondEmailToChat ?? false);
   const [widgetHost, setWidgetHost] = useState(mailbox.widgetHost ?? "");
+  const { showChatWidget, setShowChatWidget } = useShowChatWidget();
+
+  useEffect(() => {
+    setShowChatWidget(mode !== "off");
+    return () => setShowChatWidget(false);
+  }, [mode]);
 
   const utils = api.useUtils();
   const { mutate: update } = api.mailbox.update.useMutation({
@@ -438,6 +445,12 @@ export default async function RootLayout({
           </div>
         )}
       </SectionWrapper>
+
+      {showChatWidget && (
+        <div className="fixed bottom-8 right-24 bg-primary text-primary-foreground px-3 py-1.5 rounded-md">
+          Try it out →
+        </div>
+      )}
     </div>
   );
 };

--- a/app/(marketing)/layout.tsx
+++ b/app/(marketing)/layout.tsx
@@ -29,13 +29,11 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     mailbox_slug: HELPER_MAILBOX_SLUG,
   };
 
-  const helperHost = env.NODE_ENV === "development" ? "https://helperai.dev" : undefined;
-
   return (
     <NuqsAdapter>
       <SentryContext />
       <TRPCReactProvider>
-        <HelperProvider host={helperHost} {...config}>
+        <HelperProvider host={env.AUTH_URL} {...config}>
           <HydrateClient>{children}</HydrateClient>
         </HelperProvider>
       </TRPCReactProvider>

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -185,8 +185,8 @@ class HelperWidget {
   }
 
   private setShowWidget(showWidget: boolean): void {
-    this.showWidget = showWidget;
-    if (showWidget) {
+    this.showWidget = showWidget || this.showToggleButton === true;
+    if (this.showWidget) {
       this.addHelperIcon();
       if (this.notificationContainer) {
         this.notificationContainer.classList.add("with-widget");


### PR DESCRIPTION
Closes #433 

![Screenshot 2025-05-21 at 00 18 18](https://github.com/user-attachments/assets/c882480c-9c96-405c-9fdb-776a7008e48b)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added the ability to toggle the visibility of the chat widget within mailbox settings, including a "Try it out →" badge for easier testing.
- **Improvements**
	- Enhanced state management for chat widget visibility, ensuring smoother user experience when adjusting settings.
	- Updated environment variable handling for consistent host configuration across environments.
- **Bug Fixes**
	- Improved logic to ensure the chat widget toggle button is reliably displayed based on settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->