### PR TITLE
feat: add purchase information to conversation summary

### DIFF
--- a/lib/ai/generateConversationSummary.ts
+++ b/lib/ai/generateConversationSummary.ts
@@ -14,8 +14,8 @@ const constructMessagesForConversationSummary = (
   const allEmailsContent = emails
     .map((email) => {
       if (email.role === "tool") {
-        const metadata = email.metadata as ToolMetadata;
-        return `Tool called: ${metadata.tool.name}\nResult: ${JSON.stringify(metadata.result)}`;
+        const metadata = email.metadata as ToolMetadata | null;
+        return `Tool called: ${metadata?.tool?.name || "Unknown"}\nResult: ${JSON.stringify(metadata?.result)}`;
       }
       return `From: ${HELPER_TO_AI_ROLES_MAPPING[email.role]}\nContent: ${cleanUpTextForAI(email.cleanedUpText ?? "")}`;
     })

--- a/lib/ai/generateConversationSummary.ts
+++ b/lib/ai/generateConversationSummary.ts
@@ -1,21 +1,24 @@
 import { CoreMessage } from "ai";
-import { and, asc, eq, inArray, isNull, ne } from "drizzle-orm";
+import { and, asc, eq, isNull } from "drizzle-orm";
 import { z } from "zod";
 import { db } from "@/db/client";
-import { conversationMessages, conversations } from "@/db/schema";
+import { conversationMessages, conversations, ToolMetadata } from "@/db/schema";
 import { assertDefinedOrRaiseNonRetriableError } from "@/inngest/utils";
 import { runAIObjectQuery } from "@/lib/ai";
 import { HELPER_TO_AI_ROLES_MAPPING } from "@/lib/ai/constants";
 import { cleanUpTextForAI } from "@/lib/ai/core";
 
-const constructAnthropicMessagesForConversationSummary = (
-  emails: { role: (typeof conversationMessages.$inferSelect)["role"]; cleanedUpText: string | null }[],
+const constructMessagesForConversationSummary = (
+  emails: Pick<typeof conversationMessages.$inferSelect, "role" | "cleanedUpText" | "metadata">[],
 ): CoreMessage[] => {
   const allEmailsContent = emails
-    .map(
-      (email) =>
-        `From: ${HELPER_TO_AI_ROLES_MAPPING[email.role]}\nContent: ${cleanUpTextForAI(email.cleanedUpText ?? "")}`,
-    )
+    .map((email) => {
+      if (email.role === "tool") {
+        const metadata = email.metadata as ToolMetadata;
+        return `Tool called: ${metadata.tool.name}\nResult: ${JSON.stringify(metadata.result)}`;
+      }
+      return `From: ${HELPER_TO_AI_ROLES_MAPPING[email.role]}\nContent: ${cleanUpTextForAI(email.cleanedUpText ?? "")}`;
+    })
     .join("\n\n");
 
   return [{ role: "user", content: allEmailsContent }];
@@ -37,13 +40,13 @@ export const generateConversationSummary = async (conversationId: number, { forc
     where: and(
       eq(conversationMessages.conversationId, conversation.id),
       isNull(conversationMessages.deletedAt),
-      inArray(conversationMessages.role, ["user", "staff", "ai_assistant"]),
       eq(conversationMessages.status, "sent"),
     ),
     orderBy: asc(conversationMessages.createdAt),
     columns: {
       role: true,
       cleanedUpText: true,
+      metadata: true,
     },
   });
 
@@ -53,13 +56,13 @@ export const generateConversationSummary = async (conversationId: number, { forc
     'The goal is to summarize all the messages in the conversation in bullet points and output in JSON format with key "summary" and value should be list of points.',
     "Make sure to generate only JSON output. The output JSON should be in the format specified.",
     "Provide a concise summary of the main points discussed in the all the conversations in less than 5 sentences.",
-    "Do not explicitly mention sensitive or identifying information such as names, passwords, or personal details.",
     "Focus on the key issues, questions, and resolutions discussed in the conversation.",
+    "If a tool returned a highly relevant result such as purchase details, include ALL information from the tool result as a SEPARATE bullet point (this bullet point can be longer if necessary to include all the information).",
     "Create the summary in English only, regardless of the original conversation language.",
     "Avoid starting with generic descriptions like 'The conversation involves a discussion about a technical issue with a software application.' Instead, start with the most specific and relevant point from the conversation.",
   ].join("\n");
 
-  const messages = constructAnthropicMessagesForConversationSummary(emails);
+  const messages = constructMessagesForConversationSummary(emails);
 
   const { summary } = await runAIObjectQuery({
     mailbox: conversation.mailbox,


### PR DESCRIPTION
[ref](https://anti--work.slack.com/archives/C055QQCQFM1/p1748577585634329)

This is a bit specific; we should make it easier to edit these prompts so we can customize it for Gumroad.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Conversation summaries now include detailed information from tool-generated messages, with tool results presented as separate bullet points.

- **Improvements**
  - Summaries now consider all message roles, providing a more comprehensive overview of conversations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->