### PR TITLE
fix: add automatic links and word breaks on slashes in URLs

### DIFF
--- a/components/widget/MessageElement.tsx
+++ b/components/widget/MessageElement.tsx
@@ -1,8 +1,8 @@
 import { formatDuration } from "date-fns";
 import { ChevronDown, ChevronUp } from "lucide-react";
 import { useEffect, useState } from "react";
-import ReactMarkdown from "react-markdown";
 import type { MessageWithReaction } from "@/components/widget/Message";
+import MessageMarkdown from "@/components/widget/MessageMarkdown";
 import { captureExceptionAndLog } from "@/lib/shared/sentry";
 
 type Reasoning = {
@@ -92,27 +92,20 @@ export default function MessageElement({
         </button>
       )}
       {showReasoning && reasoning && (
-        <ReactMarkdown className="border-l border-gray-500 mt-2 text-sm text-gray-800 px-2 mb-4 prose-p:mb-2">
+        <MessageMarkdown className="border-l border-gray-500 mt-2 text-sm text-gray-800 px-2 mb-4 prose-p:mb-2">
           {reasoning.message}
-        </ReactMarkdown>
+        </MessageMarkdown>
       )}
       {hasContent ? (
-        <ReactMarkdown
+        <MessageMarkdown
           className={`prose prose-sm max-w-none text-sm ${message.role === "user" ? "text-primary-foreground **:text-primary-foreground" : "text-foreground **:text-foreground"}`}
-          components={{
-            a: ({ children, ...props }: any) => (
-              <a target="_blank" rel="noopener noreferrer" {...props}>
-                {children}
-              </a>
-            ),
-          }}
         >
           {message.parts?.find(
             (part) => part.type === "tool-invocation" && part.toolInvocation.toolName === "request_human_support",
           )
             ? "_Escalated to a human! You will be contacted soon by email._"
             : message.content}
-        </ReactMarkdown>
+        </MessageMarkdown>
       ) : (
         <div className="relative h-4 w-20 overflow-hidden rounded-lg">
           <div className={`${loadingClasses} ball-1`}></div>

--- a/components/widget/MessageMarkdown.tsx
+++ b/components/widget/MessageMarkdown.tsx
@@ -1,0 +1,127 @@
+import ReactMarkdown from "react-markdown";
+
+const rehypeAddWbrAfterSlash = () => {
+  return (tree: any) => {
+    const nodesToReplace: { node: any; newChildren: any[] }[] = [];
+
+    const walk = (node: any): void => {
+      if (node.type === "text" && node.value && typeof node.value === "string" && node.value.includes("/")) {
+        const parts = node.value.split(/(\/{1,})/);
+        if (parts.length > 1) {
+          const newChildren: any[] = [];
+          parts.forEach((part: string, index: number) => {
+            if (/^\/{1,}$/.test(part)) {
+              newChildren.push({ type: "text", value: part });
+              newChildren.push({ type: "element", tagName: "wbr", properties: {}, children: [] });
+            } else if (part) {
+              newChildren.push({ type: "text", value: part });
+            }
+          });
+
+          nodesToReplace.push({ node, newChildren });
+        }
+      }
+
+      if (node.children) {
+        for (const child of node.children) {
+          child.parent = node;
+          walk(child);
+        }
+      }
+    };
+
+    walk(tree);
+
+    nodesToReplace.forEach(({ node, newChildren }) => {
+      if (node.parent?.children) {
+        const nodeIndex = node.parent.children.indexOf(node);
+        node.parent.children.splice(nodeIndex, 1, ...newChildren);
+      }
+    });
+  };
+};
+
+const remarkAutolink = () => {
+  return (tree: any) => {
+    const nodesToReplace: { node: any; newChildren: any[] }[] = [];
+
+    const isInsideLink = (node: any): boolean => {
+      let parent = node.parent;
+      while (parent) {
+        if (parent.type === "link") {
+          return true;
+        }
+        parent = parent.parent;
+      }
+      return false;
+    };
+
+    const walk = (node: any): void => {
+      if (node.type === "text" && node.value && typeof node.value === "string" && !isInsideLink(node)) {
+        const urlRegex = /(https?:\/\/[^\s<>"\[\]{}|\\^`]+?)(?=[.,;:!?)\]}]*(?:\s|$))/gi;
+        const parts = node.value.split(urlRegex);
+
+        if (parts.length > 1) {
+          const newChildren: any[] = [];
+          parts.forEach((part: string) => {
+            if (urlRegex.test(part)) {
+              newChildren.push({
+                type: "link",
+                url: part,
+                children: [{ type: "text", value: part }],
+              });
+            } else if (part) {
+              newChildren.push({ type: "text", value: part });
+            }
+          });
+
+          if (newChildren.length > 0) {
+            nodesToReplace.push({ node, newChildren });
+          }
+        }
+      }
+
+      if (node.children) {
+        for (const child of node.children) {
+          child.parent = node;
+          walk(child);
+        }
+      }
+    };
+
+    walk(tree);
+
+    nodesToReplace.forEach(({ node, newChildren }) => {
+      if (node.parent?.children) {
+        const nodeIndex = node.parent.children.indexOf(node);
+        node.parent.children.splice(nodeIndex, 1, ...newChildren);
+      }
+    });
+  };
+};
+
+interface MessageMarkdownProps {
+  children: string;
+  className?: string;
+  components?: any;
+}
+
+export default function MessageMarkdown({ children, className, components }: MessageMarkdownProps) {
+  return (
+    <ReactMarkdown
+      className={className}
+      remarkPlugins={[remarkAutolink]}
+      rehypePlugins={[rehypeAddWbrAfterSlash]}
+      components={{
+        a: ({ children, ...props }: any) => (
+          <a target="_blank" rel="noopener noreferrer" {...props}>
+            {children}
+          </a>
+        ),
+        ...components,
+      }}
+    >
+      {children}
+    </ReactMarkdown>
+  );
+}

--- a/components/widget/PromptDetailsModal.tsx
+++ b/components/widget/PromptDetailsModal.tsx
@@ -1,8 +1,8 @@
 import type { Message } from "ai";
 import { ChevronDown, ChevronRight, Info, X } from "lucide-react";
 import { useState } from "react";
-import ReactMarkdown from "react-markdown";
 import { JsonView } from "@/components/jsonView";
+import MessageMarkdown from "@/components/widget/MessageMarkdown";
 import { PromptInfo } from "@/lib/ai/promptInfo";
 
 type Props = {
@@ -50,7 +50,7 @@ export default function PromptDetailsModal({ onClose, allMessages, message, prom
         <div>
           <h3 className="text-xs font-semibold mb-2">Response Text</h3>
           <div className="border border-black rounded-lg p-4">
-            <ReactMarkdown className="prose prose-sm max-w-none">{message.content}</ReactMarkdown>
+            <MessageMarkdown className="prose prose-sm max-w-none">{message.content}</MessageMarkdown>
           </div>
         </div>
 
@@ -58,24 +58,27 @@ export default function PromptDetailsModal({ onClose, allMessages, message, prom
           <div>
             <h3 className="text-xs font-semibold mb-2">Prompt</h3>
             <div className="space-y-2">
-              {promptSections.map((section) => (
-                <div key={section.key}>
-                  <button
-                    onClick={() => toggleSection(section.key)}
-                    className="w-full flex items-center gap-1 py-2 text-sm text-gray-600 hover:text-gray-900 transition-colors"
-                  >
-                    {expandedSections[section.key] ? (
-                      <ChevronDown className="h-4 w-4" />
-                    ) : (
-                      <ChevronRight className="h-4 w-4" />
-                    )}
-                    <span className="font-medium">{section.title}</span>
-                  </button>
-                  {expandedSections[section.key] && (
-                    <ReactMarkdown className="pl-5 prose prose-sm max-w-none">{section.content}</ReactMarkdown>
-                  )}
-                </div>
-              ))}
+              {promptSections.map(
+                (section) =>
+                  section.content && (
+                    <div key={section.key}>
+                      <button
+                        onClick={() => toggleSection(section.key)}
+                        className="w-full flex items-center gap-1 py-2 text-sm text-gray-600 hover:text-gray-900 transition-colors"
+                      >
+                        {expandedSections[section.key] ? (
+                          <ChevronDown className="h-4 w-4" />
+                        ) : (
+                          <ChevronRight className="h-4 w-4" />
+                        )}
+                        <span className="font-medium">{section.title}</span>
+                      </button>
+                      {expandedSections[section.key] && (
+                        <MessageMarkdown className="pl-5 prose prose-sm max-w-none">{section.content}</MessageMarkdown>
+                      )}
+                    </div>
+                  ),
+              )}
               <div>
                 <button
                   onClick={() => toggleSection("messageThread")}
@@ -92,12 +95,14 @@ export default function PromptDetailsModal({ onClose, allMessages, message, prom
                   <div className="pl-5 space-y-3">
                     {allMessages
                       .filter((msg) => msg.createdAt && message.createdAt && msg.createdAt < message.createdAt)
-                      .map((msg, index) => (
-                        <ReactMarkdown
-                          key={index}
-                          className="prose prose-sm max-w-none"
-                        >{`**${msg.role === "user" ? "User" : "Assistant"}:** ${msg.content}`}</ReactMarkdown>
-                      ))}
+                      .map((msg, index) => {
+                        const content = `**${msg.role === "user" ? "User" : "Assistant"}:** ${msg.content}`;
+                        return (
+                          <MessageMarkdown key={index} className="prose prose-sm max-w-none">
+                            {content}
+                          </MessageMarkdown>
+                        );
+                      })}
                   </div>
                 )}
               </div>


### PR DESCRIPTION
Noticed when working on #462 that long URLs in the response would not be linked and would not wrap correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced markdown rendering with automatic URL linking and improved word-breaking in long links or paths.
- **Bug Fixes**
  - Markdown links consistently open in new tabs with updated security attributes.
- **Refactor**
  - Standardized markdown rendering by replacing previous components with a unified custom markdown component across the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->