### PR TITLE
Insert help articles into replies

### DIFF
--- a/components/tiptap/HelpArticleMentionPopover.tsx
+++ b/components/tiptap/HelpArticleMentionPopover.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import { createPortal } from "react-dom";
-import { ExternalLink, Search } from "lucide-react";
+import { ExternalLink, Search, X } from "lucide-react";
 import { useOnOutsideClick } from "@/components/useOnOutsideClick";
+import { Input } from "@/components/ui/input";
 
 export type HelpArticle = {
   title: string;
@@ -17,6 +18,17 @@ type HelpArticleMentionPopoverProps = {
   onClose: () => void;
 };
 
+const useIsMobile = () => {
+  const [isMobile, setIsMobile] = React.useState(false);
+  React.useEffect(() => {
+    const check = () => setIsMobile(window.innerWidth <= 640);
+    check();
+    window.addEventListener("resize", check);
+    return () => window.removeEventListener("resize", check);
+  }, []);
+  return isMobile;
+};
+
 const HelpArticleMentionPopover: React.FC<HelpArticleMentionPopoverProps> = ({
   isOpen,
   position,
@@ -27,21 +39,94 @@ const HelpArticleMentionPopover: React.FC<HelpArticleMentionPopoverProps> = ({
 }) => {
   const ref = React.useRef<HTMLDivElement | null>(null);
   useOnOutsideClick([ref], () => isOpen && onClose());
+  const isMobile = useIsMobile();
+
+  // Mobile: manage query in local state
+  const [mobileQuery, setMobileQuery] = React.useState("");
+  const inputRef = React.useRef<HTMLInputElement | null>(null);
+  React.useEffect(() => {
+    if (isMobile && isOpen) {
+      setMobileQuery("");
+      setTimeout(() => inputRef.current?.focus(), 0);
+    }
+  }, [isMobile, isOpen]);
+
+  const filterQuery = isMobile ? mobileQuery : query;
   const filtered = articles.filter((a) =>
-    a.title.toLowerCase().includes(query.toLowerCase())
+    a.title.toLowerCase().includes(filterQuery.toLowerCase())
   );
-  if (!isOpen || !position) return null;
-  const popover = (
+
+  if (!isOpen || (!position && !isMobile)) return null;
+  const popover = isMobile ? (
+    <div
+      ref={ref}
+      className="fixed inset-0 w-full h-full bg-background z-[9999] flex flex-col"
+      style={{}}
+    >
+      <div className="flex items-center justify-between px-4 pt-4 pb-2">
+        <Input
+          ref={inputRef}
+          type="text"
+          placeholder="Search articles..."
+          value={mobileQuery}
+          onChange={e => setMobileQuery(e.target.value)}
+          className="h-10 flex-1"
+        />
+        <button
+          type="button"
+          onClick={onClose}
+          className="ml-2 p-2 text-muted-foreground hover:text-primary"
+          aria-label="Close"
+        >
+          <X size={22} />
+        </button>
+      </div>
+      {filtered.length === 0 ? (
+        <div className="text-sm p-4">No articles found</div>
+      ) : (
+        <ul className="flex-1 overflow-y-auto px-2 pb-4">
+          {filtered.map((a) => (
+            <li
+              key={a.url}
+              className="flex items-center justify-between cursor-pointer px-2 py-2 rounded hover:bg-accent"
+            >
+              <div
+                className="flex-1 min-w-0"
+                onMouseDown={e => {
+                  e.preventDefault();
+                  onSelect(a);
+                }}
+              >
+                <span className="font-medium">{a.title}</span>
+                <span className="block text-xs text-muted-foreground truncate">{a.url}</span>
+              </div>
+              <a
+                href={a.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="ml-2 flex-shrink-0 text-muted-foreground hover:text-primary"
+                tabIndex={-1}
+                onMouseDown={e => e.stopPropagation()}
+                onClick={e => e.stopPropagation()}
+              >
+                <ExternalLink size={16} />
+              </a>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  ) : (
     <div
       ref={ref}
       style={{
         position: 'absolute',
-        top: position.top,
-        left: position.left,
+        top: position!.top,
+        left: position!.left,
         zIndex: 9999,
         minWidth: 320,
       }}
-      className="rounded border border-border bg-background shadow-lg p-2 pt-3 pb-3"
+      className="rounded border border-border bg-background shadow-lg p-2 pt-3 pb-3 max-h-[min(16rem,80vh)] overflow-y-auto"
     >
       <div className="flex items-center text-xs text-muted-foreground mb-2 px-2">
         <Search size={14} className="mr-2" />
@@ -50,7 +135,7 @@ const HelpArticleMentionPopover: React.FC<HelpArticleMentionPopoverProps> = ({
       {filtered.length === 0 ? (
         <div className="text-sm p-2">No articles found</div>
       ) : (
-        <ul className="max-h-64 overflow-y-auto">
+        <ul>
           {filtered.map((a) => (
             <li
               key={a.url}

--- a/components/tiptap/HelpArticleMentionPopover.tsx
+++ b/components/tiptap/HelpArticleMentionPopover.tsx
@@ -1,0 +1,89 @@
+import React from "react";
+import { createPortal } from "react-dom";
+import { ExternalLink, Search } from "lucide-react";
+import { useOnOutsideClick } from "@/components/useOnOutsideClick";
+
+export type HelpArticle = {
+  title: string;
+  url: string;
+};
+
+type HelpArticleMentionPopoverProps = {
+  isOpen: boolean;
+  position: { top: number; left: number } | null;
+  query: string;
+  articles: HelpArticle[];
+  onSelect: (article: HelpArticle) => void;
+  onClose: () => void;
+};
+
+const HelpArticleMentionPopover: React.FC<HelpArticleMentionPopoverProps> = ({
+  isOpen,
+  position,
+  query,
+  articles,
+  onSelect,
+  onClose,
+}) => {
+  const ref = React.useRef<HTMLDivElement | null>(null);
+  useOnOutsideClick([ref], () => isOpen && onClose());
+  const filtered = articles.filter((a) =>
+    a.title.toLowerCase().includes(query.toLowerCase())
+  );
+  if (!isOpen || !position) return null;
+  const popover = (
+    <div
+      ref={ref}
+      style={{
+        position: 'absolute',
+        top: position.top,
+        left: position.left,
+        zIndex: 9999,
+        minWidth: 320,
+      }}
+      className="rounded border border-border bg-background shadow-lg p-2 pt-3 pb-3"
+    >
+      <div className="flex items-center text-xs text-muted-foreground mb-2 px-2">
+        <Search size={14} className="mr-2" />
+        <span>search help center articles</span>
+      </div>
+      {filtered.length === 0 ? (
+        <div className="text-sm p-2">No articles found</div>
+      ) : (
+        <ul className="max-h-64 overflow-y-auto">
+          {filtered.map((a) => (
+            <li
+              key={a.url}
+              className="flex items-center justify-between cursor-pointer px-2 py-1 rounded hover:bg-accent"
+            >
+              <div
+                className="flex-1 min-w-0"
+                onMouseDown={e => {
+                  e.preventDefault();
+                  onSelect(a);
+                }}
+              >
+                <span className="font-medium">{a.title}</span>
+                <span className="block text-xs text-muted-foreground truncate">{a.url}</span>
+              </div>
+              <a
+                href={a.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="ml-2 flex-shrink-0 text-muted-foreground hover:text-primary"
+                tabIndex={-1}
+                onMouseDown={e => e.stopPropagation()}
+                onClick={e => e.stopPropagation()}
+              >
+                <ExternalLink size={16} />
+              </a>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+  return createPortal(popover, document.body);
+};
+
+export default HelpArticleMentionPopover; 

--- a/components/tiptap/editor.tsx
+++ b/components/tiptap/editor.tsx
@@ -19,6 +19,8 @@ import { useRefToLatest } from "@/components/useRefToLatest";
 import { cn } from "@/lib/utils";
 import HelpArticlePopover, { HelpArticle } from "./helpArticlePopover";
 import Toolbar from "./toolbar";
+import { useConversationContext } from "@/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/conversation/conversationContext";
+import { api } from "@/trpc/react";
 
 type TipTapEditorProps = {
   defaultContent: Record<string, string>;
@@ -70,33 +72,7 @@ export type TipTapEditorRef = {
   editor: Editor | null;
 };
 
-// TODO: Remove mock data and replace with real help articles from API
-const mockHelpArticles: HelpArticle[] = [
-  { title: "Why choose Gumroad?", url: "https://gumroad.com/help/article/64-is-gumroad-for-me.html" },
-  { title: "Account settings", url: "https://gumroad.com/help/article/67-the-settings-menu.html" },
-  { title: "Filling out payout settings", url: "https://gumroad.com/help/article/260-your-payout-settings-page.html" },
-  { title: "Build a website on Gumroad", url: "https://gumroad.com/help/article/124-your-gumroad-profile-page.html" },
-  { title: "Having multiple accounts", url: "https://gumroad.com/help/article/252-multiple-accounts.html" },
-  { title: "Protecting creator privacy", url: "https://gumroad.com/help/article/300-protecting-creator-privacy.html" },
-  { title: "How to get paid", url: "https://gumroad.com/help/article/301-how-to-get-paid.html" },
-  { title: "Refunds and returns", url: "https://gumroad.com/help/article/302-refunds-and-returns.html" },
-  { title: "Product delivery issues", url: "https://gumroad.com/help/article/303-product-delivery-issues.html" },
-  { title: "Tax information", url: "https://gumroad.com/help/article/304-tax-information.html" },
-  { title: "Subscription management", url: "https://gumroad.com/help/article/305-subscription-management.html" },
-  { title: "Analytics and reporting", url: "https://gumroad.com/help/article/306-analytics-and-reporting.html" },
-  { title: "Integrations", url: "https://gumroad.com/help/article/307-integrations.html" },
-  { title: "API access", url: "https://gumroad.com/help/article/308-api-access.html" },
-  { title: "Custom domains", url: "https://gumroad.com/help/article/309-custom-domains.html" },
-  { title: "Affiliate program", url: "https://gumroad.com/help/article/310-affiliate-program.html" },
-  { title: "Security best practices", url: "https://gumroad.com/help/article/311-security-best-practices.html" },
-  { title: "Mobile app", url: "https://gumroad.com/help/article/312-mobile-app.html" },
-  { title: "Notifications", url: "https://gumroad.com/help/article/313-notifications.html" },
-  { title: "User roles", url: "https://gumroad.com/help/article/314-user-roles.html" },
-  { title: "Advanced settings", url: "https://gumroad.com/help/article/315-advanced-settings.html" },
-  { title: "Troubleshooting", url: "https://gumroad.com/help/article/316-troubleshooting.html" },
-  { title: "Legal and compliance", url: "https://gumroad.com/help/article/317-legal-and-compliance.html" },
-  { title: "Open source", url: "https://gumroad.com/help/article/318-open-source.html" },
-];
+
 
 const TipTapEditor = React.forwardRef<TipTapEditorRef, TipTapEditorProps & { signature?: ReactNode }>(
   (
@@ -123,6 +99,8 @@ const TipTapEditor = React.forwardRef<TipTapEditorRef, TipTapEditorProps & { sig
     },
     ref,
   ) => {
+    const { mailboxSlug } = useConversationContext();
+    const { data: helpArticles = [] } = api.mailbox.websites.pages.useQuery({ mailboxSlug });
     const { isAboveMd } = useBreakpoint("md");
     const [isMacOS, setIsMacOS] = React.useState(false);
     const [toolbarOpen, setToolbarOpen] = React.useState(() => {
@@ -340,7 +318,7 @@ const TipTapEditor = React.forwardRef<TipTapEditorRef, TipTapEditorProps & { sig
         }
         if (event.key === "ArrowDown") {
           event.preventDefault();
-          setSelectedIndex((i) => Math.min(i + 1, mockHelpArticles.length - 1));
+          setSelectedIndex((i) => Math.min(i + 1, helpArticles.length - 1));
           return;
         }
         if (event.key === "ArrowUp") {
@@ -423,7 +401,7 @@ const TipTapEditor = React.forwardRef<TipTapEditorRef, TipTapEditorProps & { sig
       return editor.view.state.doc.textBetween(mentionState.range.from + 1, cursorPos, "", "");
     };
 
-    const filteredArticles = mockHelpArticles.filter((a) =>
+    const filteredArticles = helpArticles.filter((a) =>
       a.title.toLowerCase().includes(getMentionQuery().toLowerCase()),
     );
 

--- a/components/tiptap/editor.tsx
+++ b/components/tiptap/editor.tsx
@@ -17,8 +17,8 @@ import { Image, imageFileTypes } from "@/components/tiptap/image";
 import { useBreakpoint } from "@/components/useBreakpoint";
 import { useRefToLatest } from "@/components/useRefToLatest";
 import { cn } from "@/lib/utils";
-import Toolbar from "./toolbar";
 import HelpArticlePopover, { HelpArticle } from "./helpArticlePopover";
+import Toolbar from "./toolbar";
 
 type TipTapEditorProps = {
   defaultContent: Record<string, string>;
@@ -72,30 +72,30 @@ export type TipTapEditorRef = {
 
 // TODO: Remove mock data and replace with real help articles from API
 const mockHelpArticles: HelpArticle[] = [
-  { title: 'Why choose Gumroad?', url: 'https://gumroad.com/help/article/64-is-gumroad-for-me.html' },
-  { title: 'Account settings', url: 'https://gumroad.com/help/article/67-the-settings-menu.html' },
-  { title: 'Filling out payout settings', url: 'https://gumroad.com/help/article/260-your-payout-settings-page.html' },
-  { title: 'Build a website on Gumroad', url: 'https://gumroad.com/help/article/124-your-gumroad-profile-page.html' },
-  { title: 'Having multiple accounts', url: 'https://gumroad.com/help/article/252-multiple-accounts.html' },
-  { title: 'Protecting creator privacy', url: 'https://gumroad.com/help/article/300-protecting-creator-privacy.html' },
-  { title: 'How to get paid', url: 'https://gumroad.com/help/article/301-how-to-get-paid.html' },
-  { title: 'Refunds and returns', url: 'https://gumroad.com/help/article/302-refunds-and-returns.html' },
-  { title: 'Product delivery issues', url: 'https://gumroad.com/help/article/303-product-delivery-issues.html' },
-  { title: 'Tax information', url: 'https://gumroad.com/help/article/304-tax-information.html' },
-  { title: 'Subscription management', url: 'https://gumroad.com/help/article/305-subscription-management.html' },
-  { title: 'Analytics and reporting', url: 'https://gumroad.com/help/article/306-analytics-and-reporting.html' },
-  { title: 'Integrations', url: 'https://gumroad.com/help/article/307-integrations.html' },
-  { title: 'API access', url: 'https://gumroad.com/help/article/308-api-access.html' },
-  { title: 'Custom domains', url: 'https://gumroad.com/help/article/309-custom-domains.html' },
-  { title: 'Affiliate program', url: 'https://gumroad.com/help/article/310-affiliate-program.html' },
-  { title: 'Security best practices', url: 'https://gumroad.com/help/article/311-security-best-practices.html' },
-  { title: 'Mobile app', url: 'https://gumroad.com/help/article/312-mobile-app.html' },
-  { title: 'Notifications', url: 'https://gumroad.com/help/article/313-notifications.html' },
-  { title: 'User roles', url: 'https://gumroad.com/help/article/314-user-roles.html' },
-  { title: 'Advanced settings', url: 'https://gumroad.com/help/article/315-advanced-settings.html' },
-  { title: 'Troubleshooting', url: 'https://gumroad.com/help/article/316-troubleshooting.html' },
-  { title: 'Legal and compliance', url: 'https://gumroad.com/help/article/317-legal-and-compliance.html' },
-  { title: 'Open source', url: 'https://gumroad.com/help/article/318-open-source.html' },
+  { title: "Why choose Gumroad?", url: "https://gumroad.com/help/article/64-is-gumroad-for-me.html" },
+  { title: "Account settings", url: "https://gumroad.com/help/article/67-the-settings-menu.html" },
+  { title: "Filling out payout settings", url: "https://gumroad.com/help/article/260-your-payout-settings-page.html" },
+  { title: "Build a website on Gumroad", url: "https://gumroad.com/help/article/124-your-gumroad-profile-page.html" },
+  { title: "Having multiple accounts", url: "https://gumroad.com/help/article/252-multiple-accounts.html" },
+  { title: "Protecting creator privacy", url: "https://gumroad.com/help/article/300-protecting-creator-privacy.html" },
+  { title: "How to get paid", url: "https://gumroad.com/help/article/301-how-to-get-paid.html" },
+  { title: "Refunds and returns", url: "https://gumroad.com/help/article/302-refunds-and-returns.html" },
+  { title: "Product delivery issues", url: "https://gumroad.com/help/article/303-product-delivery-issues.html" },
+  { title: "Tax information", url: "https://gumroad.com/help/article/304-tax-information.html" },
+  { title: "Subscription management", url: "https://gumroad.com/help/article/305-subscription-management.html" },
+  { title: "Analytics and reporting", url: "https://gumroad.com/help/article/306-analytics-and-reporting.html" },
+  { title: "Integrations", url: "https://gumroad.com/help/article/307-integrations.html" },
+  { title: "API access", url: "https://gumroad.com/help/article/308-api-access.html" },
+  { title: "Custom domains", url: "https://gumroad.com/help/article/309-custom-domains.html" },
+  { title: "Affiliate program", url: "https://gumroad.com/help/article/310-affiliate-program.html" },
+  { title: "Security best practices", url: "https://gumroad.com/help/article/311-security-best-practices.html" },
+  { title: "Mobile app", url: "https://gumroad.com/help/article/312-mobile-app.html" },
+  { title: "Notifications", url: "https://gumroad.com/help/article/313-notifications.html" },
+  { title: "User roles", url: "https://gumroad.com/help/article/314-user-roles.html" },
+  { title: "Advanced settings", url: "https://gumroad.com/help/article/315-advanced-settings.html" },
+  { title: "Troubleshooting", url: "https://gumroad.com/help/article/316-troubleshooting.html" },
+  { title: "Legal and compliance", url: "https://gumroad.com/help/article/317-legal-and-compliance.html" },
+  { title: "Open source", url: "https://gumroad.com/help/article/318-open-source.html" },
 ];
 
 const TipTapEditor = React.forwardRef<TipTapEditorRef, TipTapEditorProps & { signature?: ReactNode }>(
@@ -312,7 +312,7 @@ const TipTapEditor = React.forwardRef<TipTapEditorRef, TipTapEditorProps & { sig
             top: rect.bottom + window.scrollY,
             left: rect.left + window.scrollX,
           };
-        } else if (dom && dom.getBoundingClientRect) {
+        } else if (dom?.getBoundingClientRect) {
           // fallback: use the bounding rect of the parent node
           const rect = dom.getBoundingClientRect();
           return {
@@ -334,28 +334,28 @@ const TipTapEditor = React.forwardRef<TipTapEditorRef, TipTapEditorProps & { sig
 
     const handleKeyDown = (event: React.KeyboardEvent) => {
       if (mentionState.isOpen) {
-        if (event.key === 'Escape') {
+        if (event.key === "Escape") {
           setMentionState({ isOpen: false, position: null, range: null });
           return;
         }
-        if (event.key === 'ArrowDown') {
+        if (event.key === "ArrowDown") {
           event.preventDefault();
           setSelectedIndex((i) => Math.min(i + 1, mockHelpArticles.length - 1));
           return;
         }
-        if (event.key === 'ArrowUp') {
+        if (event.key === "ArrowUp") {
           event.preventDefault();
           setSelectedIndex((i) => Math.max(i - 1, 0));
           return;
         }
-        if (event.key === 'Enter') {
+        if (event.key === "Enter") {
           event.preventDefault();
           if (filteredArticles[selectedIndex]) {
             handleSelectArticle(filteredArticles[selectedIndex]);
           }
           return;
         }
-        if (event.key === 'ArrowRight') {
+        if (event.key === "ArrowRight") {
           setMentionState({ isOpen: false, position: null, range: null });
           return;
         }
@@ -367,13 +367,8 @@ const TipTapEditor = React.forwardRef<TipTapEditorRef, TipTapEditorProps & { sig
       if (!editor) return;
       const plugin = {
         props: {
-          handleTextInput(
-            view: any,
-            from: number,
-            to: number,
-            text: string
-          ) {
-            if (text === '@') {
+          handleTextInput(view: any, from: number, to: number, text: string) {
+            if (text === "@") {
               setTimeout(() => {
                 const pos = getCaretPosition();
                 setMentionState({
@@ -386,17 +381,17 @@ const TipTapEditor = React.forwardRef<TipTapEditorRef, TipTapEditorProps & { sig
             return false;
           },
           handleKeyDown(view: any, event: KeyboardEvent) {
-            if (mentionState.isOpen && event.key === 'Backspace') {
+            if (mentionState.isOpen && event.key === "Backspace") {
               const state = view.state;
               if (mentionState.range) {
-                const docText = state.doc.textBetween(mentionState.range.from, mentionState.range.from + 1, '', '');
+                const docText = state.doc.textBetween(mentionState.range.from, mentionState.range.from + 1, "", "");
                 const cursorPos = state.selection.from;
-                const query = state.doc.textBetween(mentionState.range.from + 1, cursorPos, '', '');
-                if (query === '') {
+                const query = state.doc.textBetween(mentionState.range.from + 1, cursorPos, "", "");
+                if (query === "") {
                   setMentionState({ isOpen: false, position: null, range: null });
                   return false;
                 }
-                if (docText !== '@') {
+                if (docText !== "@") {
                   setMentionState({ isOpen: false, position: null, range: null });
                   return false;
                 }
@@ -406,8 +401,7 @@ const TipTapEditor = React.forwardRef<TipTapEditorRef, TipTapEditorProps & { sig
             return false;
           },
         },
-      };
-      // @ts-ignore: Not a real ProseMirror plugin, just for demo/mockup
+      } as const;
       editor.view.setProps({ ...editor.view.props, ...plugin.props });
       return () => {
         // No-op cleanup for mock plugin
@@ -416,38 +410,38 @@ const TipTapEditor = React.forwardRef<TipTapEditorRef, TipTapEditorProps & { sig
 
     React.useEffect(() => {
       if (!editor || !mentionState.isOpen || !mentionState.range) return;
-      const docText = editor.view.state.doc.textBetween(mentionState.range.from, mentionState.range.from + 1, '', '');
-      if (docText !== '@') {
+      const docText = editor.view.state.doc.textBetween(mentionState.range.from, mentionState.range.from + 1, "", "");
+      if (docText !== "@") {
         setMentionState({ isOpen: false, position: null, range: null });
       }
     }, [editor, mentionState.isOpen, mentionState.range, editor?.view.state]);
 
     const getMentionQuery = () => {
-      if (!editor || !mentionState.isOpen || !mentionState.range) return '';
+      if (!editor || !mentionState.isOpen || !mentionState.range) return "";
       const cursorPos = editor.view.state.selection.from;
-      if (cursorPos < mentionState.range.from + 1) return '';
-      return editor.view.state.doc.textBetween(mentionState.range.from + 1, cursorPos, '', '');
+      if (cursorPos < mentionState.range.from + 1) return "";
+      return editor.view.state.doc.textBetween(mentionState.range.from + 1, cursorPos, "", "");
     };
 
     const filteredArticles = mockHelpArticles.filter((a) =>
-      a.title.toLowerCase().includes(getMentionQuery().toLowerCase())
+      a.title.toLowerCase().includes(getMentionQuery().toLowerCase()),
     );
 
     const handleSelectArticle = (article: { title: string; url: string }) => {
       if (!editor || !mentionState.range) return;
       const cursorPos = editor.view.state.selection.from;
-      editor.chain().focus()
+      editor
+        .chain()
+        .focus()
         .deleteRange({ from: mentionState.range.from, to: cursorPos })
-        .insertContent(
-          `<a href="${article.url}" target="_blank" rel="noopener noreferrer">${article.title}</a> `
-        )
+        .insertContent(`<a href="${article.url}" target="_blank" rel="noopener noreferrer">${article.title}</a> `)
         .run();
       setMentionState({ isOpen: false, position: null, range: null });
     };
 
     React.useEffect(() => {
       setSelectedIndex(0);
-    }, [mentionState.isOpen, getMentionQuery(), filteredArticles.map(a => a.url).join(",")]);
+    }, [mentionState.isOpen, getMentionQuery(), filteredArticles.map((a) => a.url).join(",")]);
 
     if (!editor) {
       return null;

--- a/components/tiptap/editor.tsx
+++ b/components/tiptap/editor.tsx
@@ -309,14 +309,28 @@ const TipTapEditor = React.forwardRef<TipTapEditorRef, TipTapEditorProps & { sig
         if (rects.length > 0) {
           const rect = rects[0];
           if (!rect) return null;
-          // Use viewport coordinates for portal popover
+          return {
+            top: rect.bottom + window.scrollY,
+            left: rect.left + window.scrollX,
+          };
+        } else if (dom && dom.getBoundingClientRect) {
+          // fallback: use the bounding rect of the parent node
+          const rect = dom.getBoundingClientRect();
           return {
             top: rect.bottom + window.scrollY,
             left: rect.left + window.scrollX,
           };
         }
       }
-      return null;
+      // fallback: top left of the editor
+      const containerRect = editorContentContainerRef.current?.getBoundingClientRect();
+      if (containerRect) {
+        return {
+          top: containerRect.top + window.scrollY + 24,
+          left: containerRect.left + window.scrollX + 8,
+        };
+      }
+      return { top: 40, left: 40 };
     };
 
     const handleKeyDown = (event: React.KeyboardEvent) => {

--- a/components/tiptap/editor.tsx
+++ b/components/tiptap/editor.tsx
@@ -9,6 +9,7 @@ import StarterKit from "@tiptap/starter-kit";
 import partition from "lodash/partition";
 import React, { ReactNode, useEffect, useImperativeHandle, useRef } from "react";
 import UAParser from "ua-parser-js";
+import { useConversationContext } from "@/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/conversation/conversationContext";
 import { isEmptyContent } from "@/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/conversation/messageActions";
 import { UnsavedFileInfo, useFileUpload } from "@/components/fileUploadContext";
 import { toast } from "@/components/hooks/use-toast";
@@ -17,10 +18,9 @@ import { Image, imageFileTypes } from "@/components/tiptap/image";
 import { useBreakpoint } from "@/components/useBreakpoint";
 import { useRefToLatest } from "@/components/useRefToLatest";
 import { cn } from "@/lib/utils";
+import { api } from "@/trpc/react";
 import HelpArticlePopover, { HelpArticle } from "./helpArticlePopover";
 import Toolbar from "./toolbar";
-import { useConversationContext } from "@/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/conversation/conversationContext";
-import { api } from "@/trpc/react";
 
 type TipTapEditorProps = {
   defaultContent: Record<string, string>;
@@ -71,8 +71,6 @@ export type TipTapEditorRef = {
   scrollTo: (y: number) => void;
   editor: Editor | null;
 };
-
-
 
 const TipTapEditor = React.forwardRef<TipTapEditorRef, TipTapEditorProps & { signature?: ReactNode }>(
   (

--- a/components/tiptap/editor.tsx
+++ b/components/tiptap/editor.tsx
@@ -18,6 +18,10 @@ import { useBreakpoint } from "@/components/useBreakpoint";
 import { useRefToLatest } from "@/components/useRefToLatest";
 import { cn } from "@/lib/utils";
 import Toolbar from "./toolbar";
+import { createPortal } from "react-dom";
+import { useOnOutsideClick } from "@/components/useOnOutsideClick";
+import { ExternalLink, Search } from "lucide-react";
+import HelpArticleMentionPopover, { HelpArticle } from "./HelpArticleMentionPopover";
 
 type TipTapEditorProps = {
   defaultContent: Record<string, string>;
@@ -68,6 +72,33 @@ export type TipTapEditorRef = {
   scrollTo: (y: number) => void;
   editor: Editor | null;
 };
+
+const mockHelpArticles: HelpArticle[] = [
+  { title: 'Why choose Gumroad?', url: 'https://gumroad.com/help/article/64-is-gumroad-for-me.html' },
+  { title: 'Account settings', url: 'https://gumroad.com/help/article/67-the-settings-menu.html' },
+  { title: 'Filling out payout settings', url: 'https://gumroad.com/help/article/260-your-payout-settings-page.html' },
+  { title: 'Build a website on Gumroad', url: 'https://gumroad.com/help/article/124-your-gumroad-profile-page.html' },
+  { title: 'Having multiple accounts', url: 'https://gumroad.com/help/article/252-multiple-accounts.html' },
+  { title: 'Protecting creator privacy', url: 'https://gumroad.com/help/article/300-protecting-creator-privacy.html' },
+  { title: 'How to get paid', url: 'https://gumroad.com/help/article/301-how-to-get-paid.html' },
+  { title: 'Refunds and returns', url: 'https://gumroad.com/help/article/302-refunds-and-returns.html' },
+  { title: 'Product delivery issues', url: 'https://gumroad.com/help/article/303-product-delivery-issues.html' },
+  { title: 'Tax information', url: 'https://gumroad.com/help/article/304-tax-information.html' },
+  { title: 'Subscription management', url: 'https://gumroad.com/help/article/305-subscription-management.html' },
+  { title: 'Analytics and reporting', url: 'https://gumroad.com/help/article/306-analytics-and-reporting.html' },
+  { title: 'Integrations', url: 'https://gumroad.com/help/article/307-integrations.html' },
+  { title: 'API access', url: 'https://gumroad.com/help/article/308-api-access.html' },
+  { title: 'Custom domains', url: 'https://gumroad.com/help/article/309-custom-domains.html' },
+  { title: 'Affiliate program', url: 'https://gumroad.com/help/article/310-affiliate-program.html' },
+  { title: 'Security best practices', url: 'https://gumroad.com/help/article/311-security-best-practices.html' },
+  { title: 'Mobile app', url: 'https://gumroad.com/help/article/312-mobile-app.html' },
+  { title: 'Notifications', url: 'https://gumroad.com/help/article/313-notifications.html' },
+  { title: 'User roles', url: 'https://gumroad.com/help/article/314-user-roles.html' },
+  { title: 'Advanced settings', url: 'https://gumroad.com/help/article/315-advanced-settings.html' },
+  { title: 'Troubleshooting', url: 'https://gumroad.com/help/article/316-troubleshooting.html' },
+  { title: 'Legal and compliance', url: 'https://gumroad.com/help/article/317-legal-and-compliance.html' },
+  { title: 'Open source', url: 'https://gumroad.com/help/article/318-open-source.html' },
+];
 
 const TipTapEditor = React.forwardRef<TipTapEditorRef, TipTapEditorProps & { signature?: ReactNode }>(
   (
@@ -206,6 +237,11 @@ const TipTapEditor = React.forwardRef<TipTapEditorRef, TipTapEditorProps & { sig
     }, [editor]);
 
     const editorContentContainerRef = useRef<HTMLDivElement | null>(null);
+    const [mentionState, setMentionState] = React.useState<{
+      isOpen: boolean;
+      position: { top: number; left: number } | null;
+      range: { from: number; to: number } | null;
+    }>({ isOpen: false, position: null, range: null });
 
     useImperativeHandle(ref, () => ({
       focus: () => editorRef.current?.commands.focus(),
@@ -259,6 +295,126 @@ const TipTapEditor = React.forwardRef<TipTapEditorRef, TipTapEditorProps & { sig
     });
     const attachments = unsavedFiles.filter((f) => !f.inline);
 
+    const getCaretPosition = () => {
+      if (!editor) return null;
+      const view = editor.view;
+      const { from } = view.state.selection;
+      const dom = view.domAtPos(from).node as HTMLElement;
+      if (!dom) return null;
+      const selection = window.getSelection();
+      if (!selection || selection.rangeCount === 0) return null;
+      const range = selection.getRangeAt(0).cloneRange();
+      if (range.getClientRects) {
+        const rects = range.getClientRects();
+        if (rects.length > 0) {
+          const rect = rects[0];
+          if (!rect) return null;
+          // Use viewport coordinates for portal popover
+          return {
+            top: rect.bottom + window.scrollY,
+            left: rect.left + window.scrollX,
+          };
+        }
+      }
+      return null;
+    };
+
+    const handleKeyDown = (event: React.KeyboardEvent) => {
+      if (mentionState.isOpen) {
+        if (event.key === 'Escape') {
+          setMentionState({ isOpen: false, position: null, range: null });
+          return;
+        }
+        if (event.key === 'ArrowDown' || event.key === 'ArrowUp' || event.key === 'Enter') {
+          event.preventDefault();
+          return;
+        }
+        if (event.key === 'ArrowRight') {
+          setMentionState({ isOpen: false, position: null, range: null });
+          return;
+        }
+      }
+      handleModEnter(event);
+    };
+
+    React.useEffect(() => {
+      if (!editor) return;
+      const plugin = {
+        props: {
+          handleTextInput(
+            view: any,
+            from: number,
+            to: number,
+            text: string
+          ) {
+            if (text === '@') {
+              setTimeout(() => {
+                const pos = getCaretPosition();
+                setMentionState({
+                  isOpen: true,
+                  position: pos,
+                  range: { from, to: from + 1 },
+                });
+              }, 0);
+            }
+            return false;
+          },
+          handleKeyDown(view: any, event: KeyboardEvent) {
+            if (mentionState.isOpen && event.key === 'Backspace') {
+              const state = view.state;
+              if (mentionState.range) {
+                const docText = state.doc.textBetween(mentionState.range.from, mentionState.range.from + 1, '', '');
+                const cursorPos = state.selection.from;
+                const query = state.doc.textBetween(mentionState.range.from + 1, cursorPos, '', '');
+                if (query === '') {
+                  setMentionState({ isOpen: false, position: null, range: null });
+                  return false;
+                }
+                if (docText !== '@') {
+                  setMentionState({ isOpen: false, position: null, range: null });
+                  return false;
+                }
+                return false;
+              }
+            }
+            return false;
+          },
+        },
+      };
+      // @ts-ignore: Not a real ProseMirror plugin, just for demo/mockup
+      editor.view.setProps({ ...editor.view.props, ...plugin.props });
+      return () => {
+        // No-op cleanup for mock plugin
+      };
+    }, [editor, mentionState.isOpen, mentionState.range]);
+
+    React.useEffect(() => {
+      if (!editor || !mentionState.isOpen || !mentionState.range) return;
+      const docText = editor.view.state.doc.textBetween(mentionState.range.from, mentionState.range.from + 1, '', '');
+      if (docText !== '@') {
+        setMentionState({ isOpen: false, position: null, range: null });
+      }
+    }, [editor, mentionState.isOpen, mentionState.range, editor?.view.state]);
+
+    const getMentionQuery = () => {
+      if (!editor || !mentionState.isOpen || !mentionState.range) return '';
+      const cursorPos = editor.view.state.selection.from;
+      if (cursorPos < mentionState.range.from + 1) return '';
+      return editor.view.state.doc.textBetween(mentionState.range.from + 1, cursorPos, '', '');
+    };
+
+    const handleSelectArticle = (article: { title: string; url: string }) => {
+      if (!editor || !mentionState.range) return;
+      const cursorPos = editor.view.state.selection.from;
+      editor.chain().focus()
+        .deleteRange({ from: mentionState.range.from, to: cursorPos })
+        .insertContent(
+          `<a href="${article.url}" target="_blank" rel="noopener noreferrer">${article.title}</a> `
+        )
+        .run();
+      setMentionState({ isOpen: false, position: null, range: null });
+    };
+
     if (!editor) {
       return null;
     }
@@ -273,7 +429,7 @@ const TipTapEditor = React.forwardRef<TipTapEditorRef, TipTapEditorProps & { sig
           aria-label={ariaLabel}
         >
           <div
-            className="flex-1 flex flex-col min-h-0 overflow-y-auto rounded-b p-3 text-sm text-foreground"
+            className="flex-1 flex flex-col min-h-0 overflow-y-auto rounded-b p-3 text-sm text-foreground relative"
             onClick={focusEditor}
             onDragOver={(e) => e.preventDefault()}
             onDrop={(event) => {
@@ -283,10 +439,19 @@ const TipTapEditor = React.forwardRef<TipTapEditorRef, TipTapEditorProps & { sig
               uploadFiles.current(files);
             }}
             ref={editorContentContainerRef}
+            onKeyDown={handleKeyDown}
           >
             <div className="grow">
-              <EditorContent editor={editor} onKeyDown={handleModEnter} />
+              <EditorContent editor={editor} />
             </div>
+            <HelpArticleMentionPopover
+              isOpen={mentionState.isOpen}
+              position={mentionState.position}
+              query={getMentionQuery()}
+              articles={mockHelpArticles}
+              onSelect={handleSelectArticle}
+              onClose={() => setMentionState({ isOpen: false, position: null, range: null })}
+            />
             {signature}
             {attachments.length > 0 ? (
               <div className="flex w-full flex-wrap gap-2 pt-4">

--- a/components/tiptap/editorUtils.ts
+++ b/components/tiptap/editorUtils.ts
@@ -1,0 +1,40 @@
+import { EditorView } from "@tiptap/pm/view";
+
+export const getCaretPosition = (
+  view: EditorView,
+  editorContentContainerRef: React.RefObject<HTMLDivElement | null>,
+) => {
+  const { from } = view.state.selection;
+  const dom = view.domAtPos(from).node as HTMLElement;
+  if (!dom) return null;
+  const selection = window.getSelection();
+  if (!selection || selection.rangeCount === 0) return null;
+  const range = selection.getRangeAt(0).cloneRange();
+  if (range.getClientRects) {
+    const rects = range.getClientRects();
+    if (rects.length > 0) {
+      const rect = rects[0];
+      if (!rect) return null;
+      return {
+        top: rect.bottom + window.scrollY,
+        left: rect.left + window.scrollX,
+      };
+    } else if (dom?.getBoundingClientRect) {
+      // fallback: use the bounding rect of the parent node
+      const rect = dom.getBoundingClientRect();
+      return {
+        top: rect.bottom + window.scrollY,
+        left: rect.left + window.scrollX,
+      };
+    }
+  }
+  // fallback: top left of the editor
+  const containerRect = editorContentContainerRef.current?.getBoundingClientRect();
+  if (containerRect) {
+    return {
+      top: containerRect.top + window.scrollY + 24,
+      left: containerRect.left + window.scrollX + 8,
+    };
+  }
+  return { top: 40, left: 40 };
+};

--- a/components/tiptap/helpArticlePopover.tsx
+++ b/components/tiptap/helpArticlePopover.tsx
@@ -2,6 +2,7 @@ import { ExternalLink, Search, X } from "lucide-react";
 import React from "react";
 import { createPortal } from "react-dom";
 import { Input } from "@/components/ui/input";
+import { useBreakpoint } from "@/components/useBreakpoint";
 import { useOnOutsideClick } from "@/components/useOnOutsideClick";
 
 export type HelpArticle = {
@@ -20,17 +21,6 @@ type HelpArticleMentionPopoverProps = {
   onClose: () => void;
 };
 
-const useIsMobile = () => {
-  const [isMobile, setIsMobile] = React.useState(false);
-  React.useEffect(() => {
-    const check = () => setIsMobile(window.innerWidth <= 640);
-    check();
-    window.addEventListener("resize", check);
-    return () => window.removeEventListener("resize", check);
-  }, []);
-  return isMobile;
-};
-
 const HelpArticleMentionPopover: React.FC<HelpArticleMentionPopoverProps> = ({
   isOpen,
   position,
@@ -43,7 +33,7 @@ const HelpArticleMentionPopover: React.FC<HelpArticleMentionPopoverProps> = ({
 }) => {
   const ref = React.useRef<HTMLDivElement | null>(null);
   useOnOutsideClick([ref], () => isOpen && onClose());
-  const isMobile = useIsMobile();
+  const { isBelowMd: isMobile } = useBreakpoint("md");
 
   const [mobileQuery, setMobileQuery] = React.useState("");
   const inputRef = React.useRef<HTMLInputElement | null>(null);

--- a/components/tiptap/helpArticlePopover.tsx
+++ b/components/tiptap/helpArticlePopover.tsx
@@ -1,8 +1,8 @@
+import { ExternalLink, Search, X } from "lucide-react";
 import React from "react";
 import { createPortal } from "react-dom";
-import { ExternalLink, Search, X } from "lucide-react";
-import { useOnOutsideClick } from "@/components/useOnOutsideClick";
 import { Input } from "@/components/ui/input";
+import { useOnOutsideClick } from "@/components/useOnOutsideClick";
 
 export type HelpArticle = {
   title: string;
@@ -55,9 +55,7 @@ const HelpArticleMentionPopover: React.FC<HelpArticleMentionPopoverProps> = ({
   }, [isMobile, isOpen]);
 
   const filterQuery = isMobile ? mobileQuery : query;
-  const filtered = articles.filter((a) =>
-    a.title.toLowerCase().includes(filterQuery.toLowerCase())
-  );
+  const filtered = articles.filter((a) => a.title.toLowerCase().includes(filterQuery.toLowerCase()));
 
   if (!isOpen || (!position && !isMobile)) return null;
 
@@ -65,7 +63,7 @@ const HelpArticleMentionPopover: React.FC<HelpArticleMentionPopoverProps> = ({
   let popoverTop = position?.top ?? 80;
   let popoverLeft = position?.left ?? 40;
   let maxHeight = 320;
-  if (!isMobile && typeof window !== 'undefined') {
+  if (!isMobile && typeof window !== "undefined") {
     const margin = 8;
     const availableBelow = window.innerHeight - popoverTop - margin;
     if (availableBelow < maxHeight) {
@@ -79,13 +77,13 @@ const HelpArticleMentionPopover: React.FC<HelpArticleMentionPopoverProps> = ({
       popoverLeft = window.innerWidth / 2 - 160;
     }
     popoverStyle = {
-      position: 'absolute',
+      position: "absolute",
       top: popoverTop,
       left: popoverLeft,
       zIndex: 9999,
       minWidth: 320,
       maxHeight,
-      overflowY: 'auto',
+      overflowY: "auto",
     };
   }
 
@@ -94,11 +92,9 @@ const HelpArticleMentionPopover: React.FC<HelpArticleMentionPopoverProps> = ({
       {filtered.map((a, i) => (
         <li
           key={a.url}
-          className={
-            `${itemClass} ${i === selectedIndex ? "bg-accent text-accent-foreground" : ""}`
-          }
+          className={`${itemClass} ${i === selectedIndex ? "bg-accent text-accent-foreground" : ""}`}
           onMouseEnter={() => setSelectedIndex(i)}
-          onMouseDown={e => {
+          onMouseDown={(e) => {
             e.preventDefault();
             onSelect(a);
           }}
@@ -113,8 +109,8 @@ const HelpArticleMentionPopover: React.FC<HelpArticleMentionPopoverProps> = ({
             rel="noopener noreferrer"
             className="ml-2 flex-shrink-0 text-muted-foreground hover:text-primary"
             tabIndex={-1}
-            onMouseDown={e => e.stopPropagation()}
-            onClick={e => e.stopPropagation()}
+            onMouseDown={(e) => e.stopPropagation()}
+            onClick={(e) => e.stopPropagation()}
           >
             <ExternalLink size={16} />
           </a>
@@ -124,18 +120,14 @@ const HelpArticleMentionPopover: React.FC<HelpArticleMentionPopoverProps> = ({
   );
 
   const popover = isMobile ? (
-    <div
-      ref={ref}
-      className="fixed inset-0 w-full h-full bg-background z-[9999] flex flex-col"
-      style={{}}
-    >
+    <div ref={ref} className="fixed inset-0 w-full h-full bg-background z-[9999] flex flex-col" style={{}}>
       <div className="flex items-center justify-between px-4 pt-4 pb-2">
         <Input
           ref={inputRef}
           type="text"
           placeholder="Search help center articles..."
           value={mobileQuery}
-          onChange={e => setMobileQuery(e.target.value)}
+          onChange={(e) => setMobileQuery(e.target.value)}
           className="h-10 flex-1"
         />
         <button
@@ -150,15 +142,14 @@ const HelpArticleMentionPopover: React.FC<HelpArticleMentionPopoverProps> = ({
       {filtered.length === 0 ? (
         <div className="text-sm p-4">No articles found</div>
       ) : (
-        renderList("flex-1 overflow-y-auto px-2 pb-4", "flex items-center justify-between cursor-pointer px-2 py-2 rounded hover:bg-accent")
+        renderList(
+          "flex-1 overflow-y-auto px-2 pb-4",
+          "flex items-center justify-between cursor-pointer px-2 py-2 rounded hover:bg-accent",
+        )
       )}
     </div>
   ) : (
-    <div
-      ref={ref}
-      style={popoverStyle}
-      className="rounded border border-border bg-background shadow-lg p-2 pt-3 pb-3"
-    >
+    <div ref={ref} style={popoverStyle} className="rounded border border-border bg-background shadow-lg p-2 pt-3 pb-3">
       <div className="flex items-center text-xs text-muted-foreground mb-2 px-2">
         <Search size={14} className="mr-2" />
         <span>Search help center articles</span>
@@ -173,4 +164,4 @@ const HelpArticleMentionPopover: React.FC<HelpArticleMentionPopoverProps> = ({
   return createPortal(popover, document.body);
 };
 
-export default HelpArticleMentionPopover; 
+export default HelpArticleMentionPopover;

--- a/components/tiptap/linkModal.tsx
+++ b/components/tiptap/linkModal.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from "react";
 import { Input } from "@/components/ui/input";
 import { useOnOutsideClick } from "@/components/useOnOutsideClick";
+import { ExternalLink } from "lucide-react";
 
 type LinkModalProps = {
   isLinkModalOpen: boolean;
@@ -23,21 +24,39 @@ const LinkModal = ({ isLinkModalOpen, linkData, setLinkData, setLinkModalOpen, s
     }
   };
 
+  const isValid = linkData.url && /^https?:\/\//.test(linkData.url);
+
   return (
     <div
       ref={containerRef}
       className="flex w-full sm:w-96 flex-col gap-2 rounded-lg border border-border bg-background p-4 shadow-lg"
     >
-      <Input
-        ref={inputRef}
-        type="url"
-        placeholder="URL"
-        autoFocus
-        value={linkData.url}
-        onChange={(e) => setLinkData({ ...linkData, url: e.target.value })}
-        onKeyDown={handleKeyDown}
-        className="h-10"
-      />
+      <div className="relative flex items-center">
+        <Input
+          ref={inputRef}
+          type="url"
+          placeholder="URL"
+          autoFocus
+          value={linkData.url}
+          onChange={(e) => setLinkData({ ...linkData, url: e.target.value })}
+          onKeyDown={handleKeyDown}
+          className="h-10 pr-10"
+        />
+        {linkData.url ? (
+          <a
+            href={isValid ? linkData.url : undefined}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={`absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-primary ${!isValid ? 'pointer-events-none opacity-40' : ''}`}
+            tabIndex={-1}
+            aria-label="Open link in new tab"
+            onMouseDown={e => e.stopPropagation()}
+            onClick={e => !isValid && e.preventDefault()}
+          >
+            <ExternalLink size={18} />
+          </a>
+        ) : null}
+      </div>
       <Input
         type="text"
         placeholder="Link text"

--- a/components/tiptap/linkModal.tsx
+++ b/components/tiptap/linkModal.tsx
@@ -1,7 +1,7 @@
+import { ExternalLink } from "lucide-react";
 import { useEffect, useRef } from "react";
 import { Input } from "@/components/ui/input";
 import { useOnOutsideClick } from "@/components/useOnOutsideClick";
-import { ExternalLink } from "lucide-react";
 
 type LinkModalProps = {
   isLinkModalOpen: boolean;
@@ -47,11 +47,11 @@ const LinkModal = ({ isLinkModalOpen, linkData, setLinkData, setLinkModalOpen, s
             href={isValid ? linkData.url : undefined}
             target="_blank"
             rel="noopener noreferrer"
-            className={`absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-primary ${!isValid ? 'pointer-events-none opacity-40' : ''}`}
+            className={`absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-primary ${!isValid ? "pointer-events-none opacity-40" : ""}`}
             tabIndex={-1}
             aria-label="Open link in new tab"
-            onMouseDown={e => e.stopPropagation()}
-            onClick={e => !isValid && e.preventDefault()}
+            onMouseDown={(e) => e.stopPropagation()}
+            onClick={(e) => !isValid && e.preventDefault()}
           >
             <ExternalLink size={18} />
           </a>

--- a/trpc/router/mailbox/websites.ts
+++ b/trpc/router/mailbox/websites.ts
@@ -177,4 +177,24 @@ export const websitesRouter = {
 
       return crawl;
     }),
+
+  pages: mailboxProcedure.query(async ({ ctx }) => {
+    const pages = await db
+      .select({
+        url: websitePages.url,
+        title: websitePages.pageTitle,
+      })
+      .from(websitePages)
+      .innerJoin(websites, eq(websites.id, websitePages.websiteId))
+      .where(
+        and(
+          eq(websites.mailboxId, ctx.mailbox.id),
+          isNull(websites.deletedAt),
+          isNull(websitePages.deletedAt)
+        )
+      )
+      .orderBy(asc(websitePages.pageTitle));
+
+    return pages;
+  }),
 } satisfies TRPCRouterRecord;

--- a/trpc/router/mailbox/websites.ts
+++ b/trpc/router/mailbox/websites.ts
@@ -186,13 +186,7 @@ export const websitesRouter = {
       })
       .from(websitePages)
       .innerJoin(websites, eq(websites.id, websitePages.websiteId))
-      .where(
-        and(
-          eq(websites.mailboxId, ctx.mailbox.id),
-          isNull(websites.deletedAt),
-          isNull(websitePages.deletedAt)
-        )
-      )
+      .where(and(eq(websites.mailboxId, ctx.mailbox.id), isNull(websites.deletedAt), isNull(websitePages.deletedAt)))
       .orderBy(asc(websitePages.pageTitle));
 
     return pages;


### PR DESCRIPTION
## What

Front-end implementation for #418 , UX to allow users to insert help center articles into messages


https://github.com/user-attachments/assets/36b453aa-6ccb-4854-82b6-86ad32791ea3

Mobile takeover:

<img width="250" alt="Screenshot 2025-06-01 at 12 02 51 AM" src="https://github.com/user-attachments/assets/cf0c0922-5529-479f-8b05-cdc7f0f38041" />


## Why
Faster replies

## To-do
Replace mock data with actual help center articles

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced "@" mention/autocomplete in the editor for quickly inserting help article links, with keyboard and mouse navigation.
  - Added a popover UI for searching and selecting help articles, adapting to desktop and mobile layouts.
  - Implemented a new query to retrieve website pages for the current mailbox.

- **UI Improvements**
  - Added an external link icon next to the URL input in the link modal for easier link validation and quick access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->