### PR TITLE
feat: add reset button for theme color inputs

### DIFF
--- a/app/(dashboard)/mailboxes/[mailbox_slug]/settings/preferences/themeSetting.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/settings/preferences/themeSetting.tsx
@@ -121,8 +121,11 @@ const ThemeSetting = ({ mailbox }: { mailbox: RouterOutputs["mailbox"]["get"] })
                   size="sm"
                   onClick={() => {
                     const value = "#2b0808";
-                     setTheme(prev => ({ ...prev, background: value }));
-                     debouncedSetWindowTheme({ ...theme, background: value });
+                    setTheme(prev => {
+                      const next = { ...prev, background: value };
+                      debouncedSetWindowTheme(next);
+                      return next;
+                    });
                   }}
                   className="absolute top-1/2 right-0 -translate-y-1/2 rounded hover:bg-transparent"
                 >
@@ -153,8 +156,11 @@ const ThemeSetting = ({ mailbox }: { mailbox: RouterOutputs["mailbox"]["get"] })
                   size="sm"
                   onClick={() => {
                     const value = "#ffffff";
-                    setTheme(prev => ({ ...prev, foreground: value }));
-                    debouncedSetWindowTheme({ ...theme, foreground: value });
+                    setTheme(prev => {
+                      const next = { ...prev, foreground: value };
+                      debouncedSetWindowTheme(next);
+                      return next;
+                    });
                   }}
                   className="absolute top-1/2 right-0 -translate-y-1/2 rounded hover:bg-transparent"
                 >
@@ -185,8 +191,11 @@ const ThemeSetting = ({ mailbox }: { mailbox: RouterOutputs["mailbox"]["get"] })
                   size="sm"
                   onClick={() => {
                     const value ='#ffffff'
-                    setTheme(prev => ({ ...prev, primary: value }));
-                    debouncedSetWindowTheme({ ...theme, primary: value });
+                    setTheme(prev =>{
+                      const next = { ...prev, primary: value };
+                      debouncedSetWindowTheme(next);
+                      return next;
+                    });
                   }}
                   className="absolute top-1/2 right-0 -translate-y-1/2 rounded hover:bg-transparent"
                 >
@@ -217,8 +226,11 @@ const ThemeSetting = ({ mailbox }: { mailbox: RouterOutputs["mailbox"]["get"] })
                   size="sm"
                   onClick={() => {
                     const value = '#feb61b'
-                    setTheme(prev => ({ ...prev, accent: value }));
-                    debouncedSetWindowTheme({ ...theme, accent: value });
+                    setTheme(prev => {
+                      const next = { ...prev, accent: value };
+                      debouncedSetWindowTheme(next);
+                      return next;
+                    });
                   }}
                   className="absolute top-1/2 right-0 -translate-y-1/2 rounded hover:bg-transparent"
                 >
@@ -249,8 +261,11 @@ const ThemeSetting = ({ mailbox }: { mailbox: RouterOutputs["mailbox"]["get"] })
                   size="sm"
                   onClick={() => {
                     const value = '#2b0808'
-                    setTheme(prev => ({ ...prev, sidebarBackground: value }));
-                    debouncedSetWindowTheme({ ...theme, sidebarBackground: value });
+                    setTheme(prev => {
+                      const next = { ...prev, sidebarBackground: value };
+                      debouncedSetWindowTheme(next);
+                      return next;
+                    });
                   }}
                   className="absolute top-1/2 right-0 -translate-y-1/2 rounded hover:bg-transparent"
                 >

--- a/app/(dashboard)/mailboxes/[mailbox_slug]/settings/preferences/themeSetting.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/settings/preferences/themeSetting.tsx
@@ -120,13 +120,13 @@ const ThemeSetting = ({ mailbox }: { mailbox: RouterOutputs["mailbox"]["get"] })
                   variant="ghost"
                   size="sm"
                   onClick={() => {
-                    handleColorChange("background")({
-                      target: { value: "#2b0808" },
-                    } as React.ChangeEvent<HTMLInputElement>);
+                    const value = "#2b0808";
+                     setTheme(prev => ({ ...prev, background: value }));
+                     debouncedSetWindowTheme({ ...theme, background: value });
                   }}
                   className="absolute top-1/2 right-0 -translate-y-1/2 rounded hover:bg-transparent"
                 >
-                  <RotateCcw className="w-4 h-4 text-primary" />
+                  <RotateCcw className="w-4 h-4 text-foreground" />
                 </Button>
               </div>
             </div>
@@ -152,13 +152,13 @@ const ThemeSetting = ({ mailbox }: { mailbox: RouterOutputs["mailbox"]["get"] })
                   variant="ghost"
                   size="sm"
                   onClick={() => {
-                    handleColorChange("foreground")({
-                      target: { value: "#ffffff" },
-                    } as React.ChangeEvent<HTMLInputElement>);
+                    const value = "#ffffff";
+                    setTheme(prev => ({ ...prev, foreground: value }));
+                    debouncedSetWindowTheme({ ...theme, foreground: value });
                   }}
                   className="absolute top-1/2 right-0 -translate-y-1/2 rounded hover:bg-transparent"
                 >
-                  <RotateCcw className="w-4 h-4 text-primary" />
+                  <RotateCcw className="w-4 h-4 text-foreground" />
                 </Button>
               </div>
             </div>
@@ -184,13 +184,13 @@ const ThemeSetting = ({ mailbox }: { mailbox: RouterOutputs["mailbox"]["get"] })
                   variant="ghost"
                   size="sm"
                   onClick={() => {
-                    handleColorChange("primary")({
-                      target: { value: "#ffffff" },
-                    } as React.ChangeEvent<HTMLInputElement>);
+                    const value ='#ffffff'
+                    setTheme(prev => ({ ...prev, primary: value }));
+                    debouncedSetWindowTheme({ ...theme, primary: value });
                   }}
                   className="absolute top-1/2 right-0 -translate-y-1/2 rounded hover:bg-transparent"
                 >
-                  <RotateCcw className="w-4 h-4 text-primary" />
+                  <RotateCcw className="w-4 h-4 text-foreground" />
                 </Button>
               </div>
             </div>
@@ -216,13 +216,13 @@ const ThemeSetting = ({ mailbox }: { mailbox: RouterOutputs["mailbox"]["get"] })
                   variant="ghost"
                   size="sm"
                   onClick={() => {
-                    handleColorChange("accent")({
-                      target: { value: "#feb61b" },
-                    } as React.ChangeEvent<HTMLInputElement>);
+                    const value = '#feb61b'
+                    setTheme(prev => ({ ...prev, accent: value }));
+                    debouncedSetWindowTheme({ ...theme, accent: value });
                   }}
                   className="absolute top-1/2 right-0 -translate-y-1/2 rounded hover:bg-transparent"
                 >
-                  <RotateCcw className="w-4 h-4 text-primary" />
+                  <RotateCcw className="w-4 h-4 text-foreground" />
                 </Button>
               </div>
             </div>
@@ -248,13 +248,13 @@ const ThemeSetting = ({ mailbox }: { mailbox: RouterOutputs["mailbox"]["get"] })
                   variant="ghost"
                   size="sm"
                   onClick={() => {
-                    handleColorChange("sidebarBackground")({
-                      target: { value: "#2b0808" },
-                    } as React.ChangeEvent<HTMLInputElement>);
+                    const value = '#2b0808'
+                    setTheme(prev => ({ ...prev, sidebarBackground: value }));
+                    debouncedSetWindowTheme({ ...theme, sidebarBackground: value });
                   }}
                   className="absolute top-1/2 right-0 -translate-y-1/2 rounded hover:bg-transparent"
                 >
-                  <RotateCcw className="w-4 h-4 text-primary" />
+                  <RotateCcw className="w-4 h-4 text-foreground" />
                 </Button>
               </div>
             </div>

--- a/app/(dashboard)/mailboxes/[mailbox_slug]/settings/preferences/themeSetting.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/settings/preferences/themeSetting.tsx
@@ -6,11 +6,13 @@ import { useInboxTheme } from "@/app/(dashboard)/mailboxes/[mailbox_slug]/client
 import { toast } from "@/components/hooks/use-toast";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button"
 import { useDebouncedCallback } from "@/components/useDebouncedCallback";
 import { useOnChange } from "@/components/useOnChange";
 import { normalizeHex } from "@/lib/themes";
 import { RouterOutputs } from "@/trpc";
 import { api } from "@/trpc/react";
+import { RotateCcw } from "lucide-react";
 import { SwitchSectionWrapper } from "../sectionWrapper";
 
 export type ThemeUpdates = {
@@ -107,12 +109,26 @@ const ThemeSetting = ({ mailbox }: { mailbox: RouterOutputs["mailbox"]["get"] })
                 onChange={handleColorChange("background")}
                 className="h-10 w-20 p-1"
               />
-              <Input
-                type="text"
-                value={theme.background}
-                onChange={handleColorChange("background")}
-                className="w-[200px]"
-              />
+              <div className="relative w-[200px]">
+                <Input
+                  type="text"
+                  value={theme.background}
+                  onChange={handleColorChange("background")}
+                  className="h-10 w-full pr-10 pl-2 py-1 border"
+                />
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => {
+                    handleColorChange("background")({
+                      target: { value: "#2b0808" },
+                    } as React.ChangeEvent<HTMLInputElement>);
+                  }}
+                  className="absolute top-1/2 right-0 -translate-y-1/2 rounded hover:bg-transparent"
+                >
+                  <RotateCcw className="w-4 h-4 text-primary" />
+                </Button>
+              </div>
             </div>
           </div>
 
@@ -125,12 +141,26 @@ const ThemeSetting = ({ mailbox }: { mailbox: RouterOutputs["mailbox"]["get"] })
                 onChange={handleColorChange("foreground")}
                 className="h-10 w-20 p-1"
               />
-              <Input
-                type="text"
-                value={theme.foreground}
-                onChange={handleColorChange("foreground")}
-                className="w-[200px]"
-              />
+              <div className="relative w-[200px]">
+                <Input
+                  type="text"
+                  value={theme.foreground}
+                  onChange={handleColorChange("foreground")}
+                  className="h-10 w-full pr-10 pl-2 py-1 border"
+                />
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => {
+                    handleColorChange("foreground")({
+                      target: { value: "#ffffff" },
+                    } as React.ChangeEvent<HTMLInputElement>);
+                  }}
+                  className="absolute top-1/2 right-0 -translate-y-1/2 rounded hover:bg-transparent"
+                >
+                  <RotateCcw className="w-4 h-4 text-primary" />
+                </Button>
+              </div>
             </div>
           </div>
 
@@ -143,7 +173,26 @@ const ThemeSetting = ({ mailbox }: { mailbox: RouterOutputs["mailbox"]["get"] })
                 onChange={handleColorChange("primary")}
                 className="h-10 w-20 p-1"
               />
-              <Input type="text" value={theme.primary} onChange={handleColorChange("primary")} className="w-[200px]" />
+              <div className="relative w-[200px]">
+                <Input
+                  type="text"
+                  value={theme.primary} 
+                  onChange={handleColorChange("primary")} 
+                  className="w-[200px]" 
+                />
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => {
+                    handleColorChange("primary")({
+                      target: { value: "#ffffff" },
+                    } as React.ChangeEvent<HTMLInputElement>);
+                  }}
+                  className="absolute top-1/2 right-0 -translate-y-1/2 rounded hover:bg-transparent"
+                >
+                  <RotateCcw className="w-4 h-4 text-primary" />
+                </Button>
+              </div>
             </div>
           </div>
 
@@ -156,7 +205,26 @@ const ThemeSetting = ({ mailbox }: { mailbox: RouterOutputs["mailbox"]["get"] })
                 onChange={handleColorChange("accent")}
                 className="h-10 w-20 p-1"
               />
-              <Input type="text" value={theme.accent} onChange={handleColorChange("accent")} className="w-[200px]" />
+              <div className="relative w-[200px]">
+                <Input 
+                  type="text"
+                  value={theme.accent} 
+                  onChange={handleColorChange("accent")} 
+                  className="w-[200px]"
+                />
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => {
+                    handleColorChange("accent")({
+                      target: { value: "#feb61b" },
+                    } as React.ChangeEvent<HTMLInputElement>);
+                  }}
+                  className="absolute top-1/2 right-0 -translate-y-1/2 rounded hover:bg-transparent"
+                >
+                  <RotateCcw className="w-4 h-4 text-primary" />
+                </Button>
+              </div>
             </div>
           </div>
 
@@ -169,12 +237,26 @@ const ThemeSetting = ({ mailbox }: { mailbox: RouterOutputs["mailbox"]["get"] })
                 onChange={handleColorChange("sidebarBackground")}
                 className="h-10 w-20 p-1"
               />
-              <Input
-                type="text"
-                value={theme.sidebarBackground}
-                onChange={handleColorChange("sidebarBackground")}
-                className="w-[200px]"
-              />
+              <div className="relative w-[200px]">
+                <Input
+                  type="text"
+                  value={theme.sidebarBackground}
+                  onChange={handleColorChange("sidebarBackground")}
+                  className="w-[200px]"
+                />
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => {
+                    handleColorChange("sidebarBackground")({
+                      target: { value: "#2b0808" },
+                    } as React.ChangeEvent<HTMLInputElement>);
+                  }}
+                  className="absolute top-1/2 right-0 -translate-y-1/2 rounded hover:bg-transparent"
+                >
+                  <RotateCcw className="w-4 h-4 text-primary" />
+                </Button>
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
### Add reset buttons to reset theme colours
need some suggestions on this :- 
- Instead of resetting one by one we can also create a single reset button to reset the theme to default.
- Instead of multiple inputs for different theme properties we can make single component and pass the theme, onChange, onClick for optimal and clean code
 
- After Changes

https://github.com/user-attachments/assets/4cb35a0a-8ae2-48d1-971b-8e89fe0c0f8d

 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added reset buttons next to each theme color input, allowing users to quickly revert colors to their default values.

- **Style**
  - Improved layout of theme color inputs by grouping each input with its corresponding reset button for a cleaner interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->