### PR TITLE
Conversation header visual updates

### DIFF
--- a/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/conversation/conversation.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/conversation/conversation.tsx
@@ -9,6 +9,8 @@ import {
   PanelRightClose,
   PanelRightOpen,
   X,
+  ChevronLeft,
+  ChevronRight,
 } from "lucide-react";
 import Link from "next/link";
 import { useEffect, useLayoutEffect, useState } from "react";
@@ -232,49 +234,57 @@ const ConversationHeader = ({
   return (
     <div
       className={cn(
-        "min-w-0 flex items-center gap-1 border-b border-border p-2 pl-4 md:p-3",
+        "relative flex items-center border-b border-border h-12 px-2 md:px-4",
         !conversationInfo && "hidden",
       )}
+      style={{ minHeight: 48 }}
     >
-      <Button variant="ghost" size="sm" iconOnly onClick={minimize} className="text-primary hover:text-foreground">
-        <X className="h-4 w-4" />
-      </Button>
-      <Button variant="subtle" size="sm" iconOnly onClick={moveToPreviousConversation}>
-        <ArrowLeft className="h-4 w-4" />
-      </Button>
-      <Button variant="subtle" size="sm" iconOnly onClick={moveToNextConversation}>
-        <ArrowRight className="h-4 w-4" />
-      </Button>
-      <div className="ml-4">
-        <div className="text-xs text-muted-foreground">
-          {currentIndex + 1} of {currentTotal}
-          {hasNextPage ? "+" : ""}
+      {/* Far left: Close */}
+      <div className="flex items-center min-w-0">
+        <Button variant="ghost" size="sm" iconOnly onClick={minimize} className="text-primary hover:text-foreground">
+          <X className="h-4 w-4" />
+        </Button>
+        <div className="flex items-center ml-2">
+          <Button variant="ghost" size="sm" iconOnly onClick={moveToPreviousConversation}>
+            <ChevronLeft className="h-4 w-4" />
+          </Button>
+          <span className="text-sm text-muted-foreground whitespace-nowrap text-center mx-1">
+            {currentIndex + 1} of {currentTotal}
+            {hasNextPage ? "+" : ""}
+          </span>
+          <Button variant="ghost" size="sm" iconOnly onClick={moveToNextConversation}>
+            <ChevronRight className="h-4 w-4" />
+          </Button>
         </div>
-        <div className="truncate text-sm sm:text-base font-medium">
+      </div>
+      {/* Centered title */}
+      <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-full flex justify-center pointer-events-none">
+        <div className="truncate text-base font-semibold text-foreground max-w-[70vw] md:max-w-[40vw] pointer-events-auto">
           {conversationMetadata.subject ?? "(no subject)"}
         </div>
       </div>
-      <CopyLinkButton />
-      <div className="flex-1" />
-      {conversationInfo?.id && <Viewers mailboxSlug={mailboxSlug} conversationSlug={conversationInfo.slug} />}
-      <Button
-        variant={!isAboveSm && sidebarVisible ? "subtle" : "ghost"}
-        size="sm"
-        className="ml-4"
-        iconOnly
-        onClick={() => setSidebarVisible(!sidebarVisible)}
-      >
-        {isAboveSm ? (
-          sidebarVisible ? (
-            <PanelRightClose className="h-4 w-4" />
+      {/* Far right: viewers, copy link, panel close */}
+      <div className="flex items-center gap-2 ml-auto">
+        <CopyLinkButton />
+        {conversationInfo?.id && <Viewers mailboxSlug={mailboxSlug} conversationSlug={conversationInfo.slug} />}
+        <Button
+          variant={!isAboveSm && sidebarVisible ? "subtle" : "ghost"}
+          size="sm"
+          iconOnly
+          onClick={() => setSidebarVisible(!sidebarVisible)}
+        >
+          {isAboveSm ? (
+            sidebarVisible ? (
+              <PanelRightClose className="h-4 w-4" />
+            ) : (
+              <PanelRightOpen className="h-4 w-4" />
+            )
           ) : (
-            <PanelRightOpen className="h-4 w-4" />
-          )
-        ) : (
-          <Info className="h-5 w-5" />
-        )}
-        <span className="sr-only">{sidebarVisible ? "Hide sidebar" : "Show sidebar"}</span>
-      </Button>
+            <Info className="h-4 w-4" />
+          )}
+          <span className="sr-only">{sidebarVisible ? "Hide sidebar" : "Show sidebar"}</span>
+        </Button>
+      </div>
     </div>
   );
 };

--- a/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/conversation/conversation.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/conversation/conversation.tsx
@@ -234,13 +234,13 @@ const ConversationHeader = ({
   return (
     <div
       className={cn(
-        "relative flex items-center border-b border-border h-12 px-2 md:px-4",
+        "flex items-center border-b border-border h-12 px-2 md:px-4 gap-x-2",
         !conversationInfo && "hidden",
       )}
       style={{ minHeight: 48 }}
     >
-      {/* Far left: Close */}
-      <div className="flex items-center min-w-0">
+      {/* Left: Close, chevrons, count */}
+      <div className="flex items-center min-w-0 flex-shrink-0 z-10 lg:w-44">
         <Button variant="ghost" size="sm" iconOnly onClick={minimize} className="text-primary hover:text-foreground">
           <X className="h-4 w-4" />
         </Button>
@@ -257,14 +257,14 @@ const ConversationHeader = ({
           </Button>
         </div>
       </div>
-      {/* Centered title */}
-      <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-full flex justify-center pointer-events-none">
-        <div className="truncate text-base font-semibold text-foreground max-w-[70vw] md:max-w-[40vw] pointer-events-auto">
+      {/* Center: Title */}
+      <div className="flex-1 min-w-0 flex justify-center">
+        <div className="truncate text-base font-semibold text-foreground text-center max-w-full">
           {conversationMetadata.subject ?? "(no subject)"}
         </div>
       </div>
-      {/* Far right: viewers, copy link, panel close */}
-      <div className="flex items-center gap-2 ml-auto">
+      {/* Right: viewers, copy link, panel close */}
+      <div className="flex items-center gap-2 min-w-0 flex-shrink-0 z-10 lg:w-44 justify-end">
         <CopyLinkButton />
         {conversationInfo?.id && <Viewers mailboxSlug={mailboxSlug} conversationSlug={conversationInfo.slug} />}
         <Button

--- a/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/conversation/conversation.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/conversation/conversation.tsx
@@ -239,7 +239,6 @@ const ConversationHeader = ({
       )}
       style={{ minHeight: 48 }}
     >
-      {/* Left: Close, chevrons, count */}
       <div className="flex items-center min-w-0 flex-shrink-0 z-10 lg:w-44">
         <Button variant="ghost" size="sm" iconOnly onClick={minimize} className="text-primary hover:text-foreground">
           <X className="h-4 w-4" />
@@ -257,13 +256,11 @@ const ConversationHeader = ({
           </Button>
         </div>
       </div>
-      {/* Center: Title */}
       <div className="flex-1 min-w-0 flex justify-center">
         <div className="truncate text-base font-semibold text-foreground text-center max-w-full">
           {conversationMetadata.subject ?? "(no subject)"}
         </div>
       </div>
-      {/* Right: viewers, copy link, panel close */}
       <div className="flex items-center gap-2 min-w-0 flex-shrink-0 z-10 lg:w-44 justify-end">
         <CopyLinkButton />
         {conversationInfo?.id && <Viewers mailboxSlug={mailboxSlug} conversationSlug={conversationInfo.slug} />}


### PR DESCRIPTION
## What

Minor styling updates to the conversation header
<img width="903" alt="Screenshot 2025-06-12 at 11 38 24 PM" src="https://github.com/user-attachments/assets/30ef31fd-53c8-48b5-b262-12f3a3790173" />

## Why

Visual balance

@binary-koan Small styling suggestion, lmk what you think!