### PR TITLE
feat: add agent prompt for widget installation

### DIFF
--- a/app/(dashboard)/mailboxes/[mailbox_slug]/settings/chat/chatWidgetSetting.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/settings/chat/chatWidgetSetting.tsx
@@ -169,7 +169,6 @@ export default async function RootLayout({ children }: { children: React.ReactNo
 Then, ask if I want to do either of the following:
 
 - Customize the widget title or icon color
-- Add contextual help buttons
 - Authenticate my users
 
 DO NOT do any of the following until I have confirmed that I want to do them.
@@ -250,7 +249,7 @@ ${NODE_HMAC_SAMPLE_CODE}
           <TabsContent value="vanilla" className="space-y-4">
             <h3 className="flex items-center justify-between text-lg font-semibold">
               Get started
-              <TooltipProvider>
+              <TooltipProvider delayDuration={0}>
                 <Tooltip>
                   <TooltipTrigger>
                     <Button
@@ -392,7 +391,7 @@ ${widgetSampleCode}
           <TabsContent value="react" className="space-y-4">
             <h3 className="flex items-center justify-between text-lg font-semibold">
               Get started
-              <TooltipProvider>
+              <TooltipProvider delayDuration={0}>
                 <Tooltip>
                   <TooltipTrigger>
                     <Button

--- a/app/(dashboard)/mailboxes/[mailbox_slug]/settings/chat/chatWidgetSetting.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/settings/chat/chatWidgetSetting.tsx
@@ -1,15 +1,17 @@
 "use client";
 
-import { ExternalLink } from "lucide-react";
+import { ExternalLink, Sparkles } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useShowChatWidget } from "@/app/(dashboard)/mailboxes/[mailbox_slug]/clientLayout";
 import { getBaseUrl, getDocsUrl } from "@/components/constants";
 import { toast } from "@/components/hooks/use-toast";
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
+import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { useDebouncedCallback } from "@/components/useDebouncedCallback";
 import { useOnChange } from "@/components/useOnChange";
 import { mailboxes } from "@/db/schema";
@@ -40,6 +42,7 @@ const ChatWidgetSetting = ({ mailbox }: { mailbox: RouterOutputs["mailbox"]["get
     mailbox.preferences?.autoRespondEmailToChat ?? "off",
   );
   const [widgetHost, setWidgetHost] = useState(mailbox.widgetHost ?? "");
+  const [isCopied, setIsCopied] = useState(false);
   const { showChatWidget, setShowChatWidget } = useShowChatWidget();
 
   useEffect(() => {
@@ -83,6 +86,144 @@ const ChatWidgetSetting = ({ mailbox }: { mailbox: RouterOutputs["mailbox"]["get
 
   const widgetSampleCode = WIDGET_SAMPLE_CODE.replace("{{DATA_ATTRIBUTES}}", `data-mailbox="${mailbox.slug}"`);
 
+  const plainJSPrompt = `
+Integrate the helper.ai widget into my app.
+
+First, add the following code snippet in my HTML layout before the closing </body> tag:
+
+\`\`\`
+${widgetSampleCode}
+\`\`\`
+
+Then, ask if I want to do either of the following:
+
+- Customize the widget title or icon color
+- Authenticate my users
+
+DO NOT do any of the following until I have confirmed that I want to do them.
+
+If I want to customize the widget, add the following code snippet *immediately above* the widget script tag:
+
+\`\`\`
+<script>
+  window.helperWidgetConfig = {
+    title: "<widget title>",
+    iconColor: "<hex color>",
+  }
+</script>
+\`\`\`
+
+Omit the other property if I don't want to customize it.
+
+If I want to authenticate my users, add code to generate an HMAC hash on the server side. Adapt this Node.js code as appropriate for my backend technology:
+
+\`\`\`
+${NODE_HMAC_SAMPLE_CODE}
+\`\`\`
+
+Store the HMAC secret separately, for example in an environment variable or secret. The secret to store is: ${mailbox.widgetHMACSecret}
+
+Then, add the generated hash, customer email, and timestamp to the widget config. Add the script tag *immediately above* the widget script tag if it doesn't exist, or reuse the existing script tag if it does.
+
+Make sure to inject the placeholder values based on what was generated on the server side.
+
+\`\`\`
+<script>
+  window.helperWidgetConfig = {
+    email: "<customer email>",
+    emailHash: "<generated HMAC hash>",
+    timestamp: "<generated timestamp>",
+  }
+</script>
+\`\`\`
+  `.trim();
+
+  const reactPrompt = `
+Integrate the Helper widget into my React/Next.js app.
+
+First, install the React package (use yarn, pnpm, etc instead if the current project uses it):
+
+\`\`\`
+npm install @helperai/react
+\`\`\`
+
+Then, add the HelperProvider at the root of my app:
+
+\`\`\`
+// app/layout.tsx or similar
+import { HelperProvider } from '@helperai/react';
+
+export default async function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>
+        <HelperProvider host="${getBaseUrl()}" mailboxSlug="${mailbox.slug}">
+          {children}
+        </HelperProvider>
+      </body>
+    </html>
+  );
+}
+\`\`\`
+
+Then, ask if I want to do either of the following:
+
+- Customize the widget title or icon color
+- Add contextual help buttons
+- Authenticate my users
+
+DO NOT do any of the following until I have confirmed that I want to do them.
+
+If I want to customize the widget, add props to the HelperProvider:
+
+\`\`\`
+<HelperProvider
+  host="${getBaseUrl()}"
+  mailboxSlug="${mailbox.slug}"
+  title="<widget title>"
+  iconColor="<hex color>"
+>
+  {children}
+</HelperProvider>
+\`\`\`
+
+If I want to authenticate my users add a call to generateHelperAuth and pass the result to the HelperProvider. This is a Next.js example using server components. Adapt it as appropriate for my backend technology:
+
+\`\`\`
+// app/layout.tsx or similar
+import { HelperProvider, generateHelperAuth } from '@helperai/react';
+
+export default async function RootLayout({ children }: { children: React.ReactNode }) {
+  const session = await auth(); // Your auth solution
+  if (!session?.user?.email) return children;
+
+  const helperAuth = await generateHelperAuth({
+    email: session.user.email,
+    hmacSecret: "YOUR_HMAC_SECRET",
+    mailboxSlug: "${mailbox.slug}",
+  });
+
+  return (
+    <html>
+      <body>
+        <HelperProvider host="${getBaseUrl()}" {...helperAuth}>
+          {children}
+        </HelperProvider>
+      </body>
+    </html>
+  );
+}
+\`\`\`
+
+Store the HMAC secret separately, for example in an environment variable or secret. The secret to store is: ${mailbox.widgetHMACSecret}
+
+If my backend technology is not Node.js, generate the HMAC hash manually by adapting this Node.js example:
+
+\`\`\`
+${NODE_HMAC_SAMPLE_CODE}
+\`\`\`
+  `.trim();
+
   return (
     <div>
       <SectionWrapper
@@ -107,7 +248,27 @@ const ChatWidgetSetting = ({ mailbox }: { mailbox: RouterOutputs["mailbox"]["get
           </TabsList>
 
           <TabsContent value="vanilla" className="space-y-4">
-            <h3 className="text-lg font-semibold">Get started</h3>
+            <h3 className="flex items-center justify-between text-lg font-semibold">
+              Get started
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger>
+                    <Button
+                      variant="subtle"
+                      onClick={() => {
+                        navigator.clipboard.writeText(plainJSPrompt);
+                        setIsCopied(true);
+                        setTimeout(() => setIsCopied(false), 2000);
+                      }}
+                    >
+                      <Sparkles className="size-4 text-bright mr-2" />
+                      {isCopied ? "Copied!" : "Copy AI agent prompt"}
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>Paste into Cursor, Copilot or other AI coding agents</TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            </h3>
             <p className="text-sm">Copy and paste this code into your website:</p>
             <CodeBlock code={widgetSampleCode} language="html" />
             <h3 className="mt-8 text-lg font-semibold">Optional: Next steps</h3>
@@ -137,10 +298,10 @@ ${widgetSampleCode}
                       <code>title</code> - The title of the widget.
                     </li>
                     <li>
-                      <code>icon_color</code> - A custom color for the widget icon.
+                      <code>iconColor</code> - A custom color for the widget icon.
                     </li>
                     <li>
-                      <code>show_toggle_button</code> - Override the "Chat Icon Visibility" setting. Set to{" "}
+                      <code>showToggleButton</code> - Override the "Chat Icon Visibility" setting. Set to{" "}
                       <code>true</code> to show the button or <code>false</code> to hide the button.
                     </li>
                   </ul>
@@ -191,7 +352,7 @@ ${widgetSampleCode}
   window.helperWidgetConfig = {
     // ... any existing config ...
     email: 'customer@example.com',
-    email_hash: 'GENERATED_HMAC',
+    emailHash: 'GENERATED_HMAC',
     timestamp: GENERATED_TIMESTAMP_IN_MILLISECONDS
   }
 </script>
@@ -229,7 +390,27 @@ ${widgetSampleCode}
           </TabsContent>
 
           <TabsContent value="react" className="space-y-4">
-            <h3 className="text-lg font-semibold">Get started</h3>
+            <h3 className="flex items-center justify-between text-lg font-semibold">
+              Get started
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger>
+                    <Button
+                      variant="subtle"
+                      onClick={() => {
+                        navigator.clipboard.writeText(reactPrompt);
+                        setIsCopied(true);
+                        setTimeout(() => setIsCopied(false), 2000);
+                      }}
+                    >
+                      <Sparkles className="size-4 text-bright mr-2" />
+                      {isCopied ? "Copied!" : "Copy AI agent prompt"}
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>Paste into Cursor, Copilot or other AI coding agents</TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            </h3>
             <p className="text-sm">Install the React package:</p>
             <CodeBlock code="npm install @helperai/react" language="bash" />
 
@@ -279,10 +460,10 @@ export default async function RootLayout({ children }: { children: React.ReactNo
                       <code>title</code> - The title of the widget.
                     </li>
                     <li>
-                      <code>icon_color</code> - A custom color for the widget icon.
+                      <code>iconColor</code> - A custom color for the widget icon.
                     </li>
                     <li>
-                      <code>show_toggle_button</code> - Override the "Chat Icon Visibility" setting. Set to{" "}
+                      <code>showToggleButton</code> - Override the "Chat Icon Visibility" setting. Set to{" "}
                       <code>true</code> to show the button or <code>false</code> to hide the button.
                     </li>
                   </ul>
@@ -343,7 +524,7 @@ HELPER_MAILBOX_SLUG=${mailbox.slug}`}
                     />
                     <p className="text-sm">
                       Then call <code>generateHelperAuth</code> in your root layout and pass the result to the{" "}
-                      <code>HelperProvider</code>:
+                      <code>HelperProvider</code>. Refer to the HTML/JavaScript guide if your backend is not in Node.js.
                     </p>
                     <CodeBlock
                       code={`// app/layout.tsx or similar

--- a/app/(dashboard)/mailboxes/[mailbox_slug]/settings/chat/chatWidgetSetting.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/settings/chat/chatWidgetSetting.tsx
@@ -194,13 +194,14 @@ import { HelperProvider, generateHelperAuth } from '@helperai/react';
 
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
   const session = await auth(); // Your auth solution
-  if (!session?.user?.email) return children;
 
-  const helperAuth = await generateHelperAuth({
-    email: session.user.email,
-    hmacSecret: "YOUR_HMAC_SECRET",
-    mailboxSlug: "${mailbox.slug}",
-  });
+  const helperAuth = session.user.email
+    ? await generateHelperAuth({
+        email: session.user.email,
+        hmacSecret: "YOUR_HMAC_SECRET",
+        mailboxSlug: "${mailbox.slug}",
+      })
+    : {};
 
   return (
     <html>
@@ -535,18 +536,14 @@ export default async function RootLayout({
   children: React.ReactNode;
 }) {
   const session = await auth(); // Your auth solution
-  if (!session?.user?.email) return children;
 
-  const helperAuth = await generateHelperAuth({
-    email: session.user.email,
-    metadata: {
-      value: "CUSTOMER_VALUE", // Optional: Revenue value
-      name: "CUSTOMER_NAME",   // Optional: Customer name
-      links: {
-        "Profile": "https://example.com/profile"
-      }
-    }
-  });
+  const helperAuth = session.user.email
+    ? await generateHelperAuth({
+        email: session.user.email,
+        hmacSecret: "YOUR_HMAC_SECRET",
+        mailboxSlug: "${mailbox.slug}",
+      })
+    : {};
   
   return (
     <html>

--- a/app/(dashboard)/mailboxes/[mailbox_slug]/settings/chat/chatWidgetSetting.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/settings/chat/chatWidgetSetting.tsx
@@ -121,7 +121,7 @@ If I want to authenticate my users, add code to generate an HMAC hash on the ser
 ${NODE_HMAC_SAMPLE_CODE}
 \`\`\`
 
-Store the HMAC secret separately, for example in an environment variable or secret. The secret to store is: ${mailbox.widgetHMACSecret}
+Store the HMAC secret separately, for example in an environment variable or secret. It MUST NOT be exposed to the client side or committed to version control. The secret to store is: ${mailbox.widgetHMACSecret}
 
 Then, add the generated hash, customer email, and timestamp to the widget config. Add the script tag *immediately above* the widget script tag if it doesn't exist, or reuse the existing script tag if it does.
 
@@ -215,7 +215,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
 }
 \`\`\`
 
-Store the HMAC secret separately, for example in an environment variable or secret. The secret to store is: ${mailbox.widgetHMACSecret}
+Store the HMAC secret separately, for example in an environment variable or secret. It MUST NOT be exposed to the client side or committed to version control. The secret to store is: ${mailbox.widgetHMACSecret}
 
 If my backend technology is not Node.js, generate the HMAC hash manually by adapting this Node.js example:
 

--- a/packages/marketing/content/docs/widget/02-javascript-integration.mdx
+++ b/packages/marketing/content/docs/widget/02-javascript-integration.mdx
@@ -31,8 +31,8 @@ You can customize the widget by adding a `helperWidgetConfig` object above the w
 <script>
   window.helperWidgetConfig = {
     title: "My Helper Widget",
-    icon_color: "#ff0000",
-    show_toggle_button: true,
+    iconColor: "#ff0000",
+    showToggleButton: true,
   };
 </script>
 <!-- The script you added earlier -->
@@ -41,17 +41,17 @@ You can customize the widget by adding a `helperWidgetConfig` object above the w
 
 The `helperWidgetConfig` object accepts the following options:
 
-| Option               | Type    | Required | Description                                      |
-| -------------------- | ------- | -------- | ------------------------------------------------ |
-| `title`              | string  | No       | Custom title for the chat widget                 |
-| `icon_color`         | string  | No       | A custom color for the widget icon               |
-| `show_toggle_button` | boolean | No       | Override the "Chat Icon Visibility" setting      |
-| `email`              | string  | Yes\*    | Email address of the authenticated customer      |
-| `email_hash`         | string  | Yes\*    | HMAC hash generated on the server                |
-| `timestamp`          | number  | Yes\*    | Timestamp used in HMAC generation                |
-| `metadata.value`     | number  | No       | Revenue value of the customer                    |
-| `metadata.name`      | string  | No       | Name of the customer                             |
-| `metadata.links`     | object  | No       | Key-value pairs of links related to the customer |
+| Option             | Type    | Required | Description                                      |
+| ------------------ | ------- | -------- | ------------------------------------------------ |
+| `title`            | string  | No       | Custom title for the chat widget                 |
+| `iconColor`        | string  | No       | A custom color for the widget icon               |
+| `showToggleButton` | boolean | No       | Override the "Chat Icon Visibility" setting      |
+| `email`            | string  | Yes\*    | Email address of the authenticated customer      |
+| `emailHash`        | string  | Yes\*    | HMAC hash generated on the server                |
+| `timestamp`        | number  | Yes\*    | Timestamp used in HMAC generation                |
+| `metadata.value`   | number  | No       | Revenue value of the customer                    |
+| `metadata.name`    | string  | No       | Name of the customer                             |
+| `metadata.links`   | object  | No       | Key-value pairs of links related to the customer |
 
 \* Required only if you want to authenticate users
 
@@ -99,7 +99,7 @@ Add the generated HMAC hash, customer email, and timestamp to your widget config
   window.helperWidgetConfig = {
     // ... any existing config ...
     email: "customer@example.com",
-    email_hash: "GENERATED_HMAC",
+    emailHash: "GENERATED_HMAC",
     timestamp: GENERATED_TIMESTAMP_IN_MILLISECONDS,
   };
 </script>

--- a/packages/marketing/content/docs/widget/03-react-integration.mdx
+++ b/packages/marketing/content/docs/widget/03-react-integration.mdx
@@ -133,16 +133,13 @@ export default async function RootLayout({ children }: { children: React.ReactNo
   const session = await auth(); // Your auth solution
   if (!session?.user?.email) return children;
 
-  const helperAuth = await generateHelperAuth({
-    email: session.user.email,
-    metadata: {
-      value: "CUSTOMER_VALUE", // Optional: Revenue value
-      name: "CUSTOMER_NAME", // Optional: Customer name
-      links: {
-        Profile: "https://example.com/profile",
-      },
-    },
-  });
+  const helperAuth = session.user.email
+    ? await generateHelperAuth({
+        email: session.user.email,
+        hmacSecret: "YOUR_HMAC_SECRET",
+        mailboxSlug: "YOUR_MAILBOX_SLUG",
+      })
+    : {};
 
   return (
     <html>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added detailed AI agent prompts for integrating the chat widget into HTML/JavaScript and React/Next.js apps, including step-by-step instructions and code examples.
	- Introduced a "Copy AI agent prompt" button with a sparkle icon and tooltip, allowing users to easily copy integration prompts with confirmation feedback.

- **Bug Fixes**
	- Corrected property names in widget configuration examples from snake_case to camelCase for consistency.

- **Documentation**
	- Updated integration guides and code snippets to use camelCase property names and clarified authentication setup in React/Next.js examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->