### PR TITLE
feat(multi-llm): add initial Gemini integration

### DIFF
--- a/.env.local.sample
+++ b/.env.local.sample
@@ -7,7 +7,8 @@ GOOGLE_CLIENT_ID="set_me"
 GOOGLE_CLIENT_SECRET="set_me"
 GOOGLE_PUBSUB_CLAIM_EMAIL="set_me@example.com"
 GOOGLE_PUBSUB_TOPIC_NAME="set_me"
-
+AI_PROVIDER= "set_me"   #example = google:gemini-1.5-flash / openai:gpt-4o
+AI_API_KEY= "set_me"
 # -- Required in production
 # ENCRYPT_COLUMN_SECRET="set_me"
 # RESEND_API_KEY="set_me"

--- a/app/api/guide/action/route.ts
+++ b/app/api/guide/action/route.ts
@@ -1,8 +1,10 @@
-import { openai } from "@ai-sdk/openai";
+// import { openai } from "@ai-sdk/openai";
 import { appendClientMessage, createDataStreamResponse, generateText, Message, streamText, tool } from "ai";
 import { z } from "zod";
 import { authenticateWidget, corsResponse } from "@/app/api/widget/utils";
+import { registry } from "@/lib/ai/provider";
 import { getGuideSessionActions, getGuideSessionByUuid } from "@/lib/data/guide";
+import { env } from "@/lib/env";
 import { captureExceptionAndLogIfDevelopment } from "@/lib/shared/sentry";
 import { assertDefined } from "../../../../components/utils/assert";
 
@@ -212,7 +214,8 @@ export async function POST(request: Request) {
     }),
   };
 
-  const model = openai("gpt-4.1", { parallelToolCalls: false });
+  // const model = openai("gpt-4.1", { parallelToolCalls: false });
+  const model = registry.languageModel(env.AI_PROVIDER);
 
   return createDataStreamResponse({
     execute: (dataStream) => {

--- a/lib/ai/core.ts
+++ b/lib/ai/core.ts
@@ -6,6 +6,8 @@ import { z } from "zod";
 import { assertDefined } from "@/components/utils/assert";
 import openai from "@/lib/ai/openai";
 import { cacheFor } from "@/lib/cache";
+import { env } from "../env";
+import { registry } from "./provider";
 
 export const GPT_4O_MODEL = "gpt-4o";
 export const GPT_4_1_MODEL = "gpt-4.1";
@@ -40,7 +42,8 @@ export const generateEmbedding = async (
   }
 
   const { embedding } = await embed({
-    model: openai.embedding(EMBEDDING_MODEL),
+    // model: openai.embedding(EMBEDDING_MODEL),
+    model: registry.textEmbeddingModel("google:text-embedding-004"), //should also come from a central source
     value: input,
     experimental_telemetry: {
       isEnabled: true,
@@ -77,7 +80,8 @@ export const generateCompletion = ({
 } & ({ prompt: string; messages?: never } | { messages: CoreMessage[]; prompt?: never })) =>
   retryOnPromptLengthError(shortenPromptBy, { system, prompt, messages }, (prompt) =>
     generateText({
-      model: openai(model),
+      // model: openai(model),
+      model: registry.languageModel(env.AI_PROVIDER),
       temperature,
       ...options,
       ...prompt,
@@ -108,7 +112,8 @@ export const generateStructuredObject = <T>({
 } & ({ prompt: string; messages?: never } | { messages: CoreMessage[]; prompt?: never })) =>
   retryOnPromptLengthError(options.shortenPromptBy, { system, prompt, messages }, (prompt) =>
     generateObject<T>({
-      model: openai(model),
+      // model: openai(model),
+      model: registry.languageModel(env.AI_PROVIDER),
       temperature,
       ...options,
       ...prompt,

--- a/lib/ai/guide.ts
+++ b/lib/ai/guide.ts
@@ -4,6 +4,8 @@ import { z } from "zod";
 import { Mailbox } from "@/lib/data/mailbox";
 import { fetchPromptRetrievalData } from "@/lib/data/retrieval";
 import { captureExceptionAndLog } from "@/lib/shared/sentry";
+import { env } from "../env";
+import { registry } from "./provider";
 
 const PLAN_PROMPT = `You are a planning agent that helps break down tasks into smaller steps and reason about the current state. Your role is to:
 
@@ -53,7 +55,8 @@ export async function generateGuidePlan(title: string, instructions: string, mai
 
   try {
     const result = await generateObject({
-      model: openai("gpt-4.1"),
+      // model: openai("gpt-4.1"),
+      model: registry.languageModel(env.AI_PROVIDER),
       system: PLAN_PROMPT,
       prompt,
       schema: PlanResultSchema,

--- a/lib/ai/provider.ts
+++ b/lib/ai/provider.ts
@@ -1,0 +1,17 @@
+import { createGoogleGenerativeAI } from "@ai-sdk/google";
+import { createOpenAI } from "@ai-sdk/openai";
+import { createProviderRegistry } from "ai";
+import { env } from "../env";
+
+// import { createXai } from "@ai-sdk/xai";
+export const registry = createProviderRegistry({
+  google: createGoogleGenerativeAI({
+    apiKey: env.AI_API_KEY,
+  }),
+  openai: createOpenAI({
+    apiKey: env.AI_API_KEY,
+  }),
+  //   xai: createXai({
+  //     apiKey: env.AI_API_KEY,
+  //   }),
+});

--- a/lib/data/aiUsageEvents.ts
+++ b/lib/data/aiUsageEvents.ts
@@ -13,6 +13,8 @@ const MODEL_TOKEN_COST = {
   "gpt-4.1": { input: 0.000002, cachedInput: 0.0000005, output: 0.000008 },
   "gpt-4.1-mini": { input: 0.0000004, cachedInput: 0.0000001, output: 0.0000016 },
   "fireworks/deepseek-r1": { input: 0.000003, cachedInput: 0.000003, output: 0.000008 },
+  "google/gemini-1.5-flash": { input: 0.000001, cachedInput: 0.000001, output: 0.000002 },
+  "google/text-embedding-004": { input: 0.00002, cachedInput: 0.00002, output: 0.000004 },
 };
 
 const getPlaceholderMailbox = async () => {

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -26,6 +26,12 @@ export const env = createEnv({
   server: {
     // Set this for both local development and when deploying
     OPENAI_API_KEY: z.string().min(1), // API key from https://platform.openai.com for AI models
+    AI_PROVIDER: z
+      .custom<`${string}:${string}`>((val) => typeof val === "string" && val.includes(":"), {
+        message: "AI_PROVIDER must be in format 'provider:model'",
+      })
+      .default("openai:gpt-4o") as unknown as z.ZodType<`${string}:${string}`>,
+    AI_API_KEY: z.string().min(1),
 
     // Set this before deploying
     ENCRYPT_COLUMN_SECRET: defaultUnlessDeployed(

--- a/lib/tools/apiTool.ts
+++ b/lib/tools/apiTool.ts
@@ -5,13 +5,15 @@ import { z } from "zod";
 import { db } from "@/db/client";
 import { conversationEvents, conversationMessages, conversations, ToolMetadata } from "@/db/schema";
 import type { Tool } from "@/db/schema/tools";
-import openai from "@/lib/ai/openai";
+// import openai from "@/lib/ai/openai";
 import { ConversationMessage, createToolEvent } from "@/lib/data/conversationMessage";
 import { getMetadataApiByMailbox } from "@/lib/data/mailboxMetadataApi";
 import { fetchMetadata, findSimilarConversations } from "@/lib/data/retrieval";
 import { cleanUpTextForAI, GPT_4O_MINI_MODEL, isWithinTokenLimit } from "../ai/core";
+import { registry } from "../ai/provider";
 import type { Conversation } from "../data/conversation";
 import type { Mailbox } from "../data/mailbox";
+import { env } from "../env";
 
 export class ToolApiError extends Error {
   constructor(
@@ -167,7 +169,8 @@ export const generateSuggestedActions = async (conversation: Conversation, mailb
   const aiTools = buildAITools(mailboxTools, conversation.emailFrom);
 
   const { toolCalls } = await generateText({
-    model: openai(GPT_4O_MINI_MODEL),
+    // model: openai(GPT_4O_MINI_MODEL),
+    model: registry.languageModel(env.AI_PROVIDER),
     tools: {
       close: {
         description: "Close the conversation",

--- a/package.json
+++ b/package.json
@@ -41,8 +41,10 @@
   },
   "dependencies": {
     "@ai-sdk/fireworks": "^0.1.10",
+    "@ai-sdk/google": "^1.2.19",
     "@ai-sdk/openai": "^1.1.12",
     "@ai-sdk/react": "^1.2.10",
+    "@ai-sdk/xai": "^1.2.16",
     "@helperai/react": "workspace:*",
     "@helperai/sdk": "workspace:*",
     "@inngest/middleware-sentry": "^0.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,12 +16,18 @@ importers:
       '@ai-sdk/fireworks':
         specifier: ^0.1.10
         version: 0.1.18(zod@3.24.3)
+      '@ai-sdk/google':
+        specifier: ^1.2.19
+        version: 1.2.19(zod@3.24.3)
       '@ai-sdk/openai':
         specifier: ^1.1.12
         version: 1.3.21(zod@3.24.3)
       '@ai-sdk/react':
         specifier: ^1.2.10
         version: 1.2.10(react@19.1.0)(zod@3.24.3)
+      '@ai-sdk/xai':
+        specifier: ^1.2.16
+        version: 1.2.16(zod@3.24.3)
       '@helperai/react':
         specifier: workspace:*
         version: link:packages/react
@@ -746,8 +752,20 @@ packages:
     peerDependencies:
       zod: ^3.0.0
 
+  '@ai-sdk/google@1.2.19':
+    resolution: {integrity: sha512-Xgl6eftIRQ4srUdCzxM112JuewVMij5q4JLcNmHcB68Bxn9dpr3MVUSPlJwmameuiQuISIA8lMB+iRiRbFsaqA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.0.0
+
   '@ai-sdk/openai-compatible@0.1.17':
     resolution: {integrity: sha512-e60+yxQ29e8RlsTWBW4kLuQJMpVJzH5+cpOeUXLXU6M9wc8BOQCyYg4jYh2ldnfvYCKXYxb2kYeLW7L9fqhhMw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.0.0
+
+  '@ai-sdk/openai-compatible@0.2.14':
+    resolution: {integrity: sha512-icjObfMCHKSIbywijaoLdZ1nSnuRnWgMEMLgwoxPJgxsUHMx0aVORnsLUid4SPtdhHI3X2masrt6iaEQLvOSFw==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.0.0
@@ -782,6 +800,12 @@ packages:
     peerDependencies:
       zod: ^3.23.8
 
+  '@ai-sdk/provider-utils@2.2.8':
+    resolution: {integrity: sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.23.8
+
   '@ai-sdk/provider@0.0.26':
     resolution: {integrity: sha512-dQkfBDs2lTYpKM8389oopPdQgIU007GQyCbuPPrV+K6MtSII3HBfE0stUIMXUb44L+LK1t6GXPP7wjSzjO6uKg==}
     engines: {node: '>=18'}
@@ -809,6 +833,12 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.23.8
+
+  '@ai-sdk/xai@1.2.16':
+    resolution: {integrity: sha512-UOZT8td9PWwMi2dF9a0U44t/Oltmf6QmIJdSvrOcLG4mvpRc1UJn6YJaR0HtXs3YnW6SvY1zRdIDrW4GFpv4NA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.0.0
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -10553,6 +10583,7 @@ packages:
 
   path-match@1.2.4:
     resolution: {integrity: sha512-UWlehEdqu36jmh4h5CWJ7tARp1OEVKGHKm6+dg9qMq5RKUTV5WJrGgaZ3dN2m7WFAXDbjlHzvJvL/IUpy84Ktw==}
+    deprecated: This package is archived and no longer maintained. For support, visit https://github.com/expressjs/express/discussions
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
@@ -13036,10 +13067,22 @@ snapshots:
       '@ai-sdk/provider-utils': 2.1.15(zod@3.24.3)
       zod: 3.24.3
 
+  '@ai-sdk/google@1.2.19(zod@3.24.3)':
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      '@ai-sdk/provider-utils': 2.2.8(zod@3.24.3)
+      zod: 3.24.3
+
   '@ai-sdk/openai-compatible@0.1.17(zod@3.24.3)':
     dependencies:
       '@ai-sdk/provider': 1.0.12
       '@ai-sdk/provider-utils': 2.1.15(zod@3.24.3)
+      zod: 3.24.3
+
+  '@ai-sdk/openai-compatible@0.2.14(zod@3.24.3)':
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      '@ai-sdk/provider-utils': 2.2.8(zod@3.24.3)
       zod: 3.24.3
 
   '@ai-sdk/openai@1.3.21(zod@3.24.3)':
@@ -13067,6 +13110,13 @@ snapshots:
       zod: 3.24.3
 
   '@ai-sdk/provider-utils@2.2.7(zod@3.24.3)':
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      nanoid: 3.3.11
+      secure-json-parse: 2.7.0
+      zod: 3.24.3
+
+  '@ai-sdk/provider-utils@2.2.8(zod@3.24.3)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
       nanoid: 3.3.11
@@ -13101,6 +13151,13 @@ snapshots:
       '@ai-sdk/provider-utils': 2.2.7(zod@3.24.3)
       zod: 3.24.3
       zod-to-json-schema: 3.24.5(zod@3.24.3)
+
+  '@ai-sdk/xai@1.2.16(zod@3.24.3)':
+    dependencies:
+      '@ai-sdk/openai-compatible': 0.2.14(zod@3.24.3)
+      '@ai-sdk/provider': 1.1.3
+      '@ai-sdk/provider-utils': 2.2.8(zod@3.24.3)
+      zod: 3.24.3
 
   '@alloc/quick-lru@5.2.0': {}
 


### PR DESCRIPTION
## Multiple LLM support

This PR adds initial integration for Gemini AI models(tested gemini-flash-1.5 and gemini-2.5-pro)

### Changes Made
 - Created a central `provider.ts` file for defining models (using `createProviderRegistry` as discussed)
 - replaced hardcoded openai usage at most places
 - added ai-sdk/google 
 - Mocked AI usage tracking cost for Gemini to avoid breaking inserts
 - Commented out the previous code for diffs

**Open to changes as required, happy to iterate**

#### Screenshot of the draft reply
<img width="902" alt="Screenshot 2025-06-19 at 3 03 29 PM" src="https://github.com/user-attachments/assets/353494a0-5aab-4ac6-a355-7510f09a85d7" />

