### PR TITLE
fix: auto-save pattern with manual save controls across all settings

### DIFF
--- a/app/(dashboard)/mailboxes/[mailbox_slug]/settings/chat/chatWidgetSetting.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/settings/chat/chatWidgetSetting.tsx
@@ -4,16 +4,15 @@ import { ExternalLink, Sparkles } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useShowChatWidget } from "@/app/(dashboard)/mailboxes/[mailbox_slug]/clientLayout";
 import { getBaseUrl, getMarketingSiteUrl } from "@/components/constants";
-import { toast } from "@/components/hooks/use-toast";
+import { useManualSave } from "@/components/hooks/useManualSave";
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { SaveableForm } from "@/components/ui/saveableForm";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { useDebouncedCallback } from "@/components/useDebouncedCallback";
-import { useOnChange } from "@/components/useOnChange";
 import { mailboxes } from "@/db/schema";
 import { RouterOutputs } from "@/trpc";
 import { api } from "@/trpc/react";
@@ -36,52 +35,76 @@ const hmac = crypto.createHmac('sha256', hmacSecret)
 const WIDGET_SAMPLE_CODE = `<script src="${getBaseUrl()}/widget/sdk.js" {{DATA_ATTRIBUTES}} async></script>`;
 
 const ChatWidgetSetting = ({ mailbox }: { mailbox: RouterOutputs["mailbox"]["get"] }) => {
-  const [mode, setMode] = useState<WidgetMode>(mailbox.widgetDisplayMode ?? "off");
-  const [minValue, setMinValue] = useState(mailbox.widgetDisplayMinValue?.toString() ?? "100");
-  const [autoRespond, setAutoRespond] = useState<"off" | "draft" | "reply">(
-    mailbox.preferences?.autoRespondEmailToChat ?? "off",
-  );
-  const [widgetHost, setWidgetHost] = useState(mailbox.widgetHost ?? "");
   const [isCopied, setIsCopied] = useState(false);
   const { showChatWidget, setShowChatWidget } = useShowChatWidget();
 
-  useEffect(() => {
-    setShowChatWidget(mode !== "off");
-    return () => setShowChatWidget(false);
-  }, [mode]);
-
   const utils = api.useUtils();
-  const { mutate: update } = api.mailbox.update.useMutation({
-    onSuccess: () => {
-      utils.mailbox.get.invalidate({ mailboxSlug: mailbox.slug });
-    },
-    onError: (error) => {
-      toast({
-        title: "Error updating chat widget settings",
-        description: error.message,
-      });
-    },
-  });
+  const { mutate: update } = api.mailbox.update.useMutation();
 
-  const save = useDebouncedCallback(() => {
-    update({
-      mailboxSlug: mailbox.slug,
-      widgetDisplayMode: mode,
-      widgetDisplayMinValue: mode === "revenue_based" && /^\d+$/.test(minValue) ? Number(minValue) : null,
-      preferences: {
-        autoRespondEmailToChat: autoRespond === "off" ? null : autoRespond,
+  const { currentData, isDirty, isLoading, updateData, handleSave, handleCancel, handleReset } = useManualSave(
+    {
+      mode: mailbox.widgetDisplayMode ?? "off",
+      minValue: mailbox.widgetDisplayMinValue?.toString() ?? "100",
+      autoRespond: mailbox.preferences?.autoRespondEmailToChat ?? "off",
+      widgetHost: mailbox.widgetHost ?? "",
+    },
+    {
+      onSave: async (data: {
+        mode: string;
+        minValue: string;
+        autoRespond: string | null | undefined;
+        widgetHost: any;
+      }) => {
+        await new Promise<void>((resolve, reject) => {
+          update(
+            {
+              mailboxSlug: mailbox.slug,
+              widgetDisplayMode: data.mode as WidgetMode,
+              widgetDisplayMinValue:
+                data.mode === "revenue_based" && /^\d+$/.test(data.minValue) ? Number(data.minValue) : null,
+              preferences: {
+                autoRespondEmailToChat: data.autoRespond === "off" ? null : (data.autoRespond as "draft" | "reply"),
+              },
+              widgetHost: data.widgetHost || null,
+            },
+            {
+              onSuccess: () => {
+                utils.mailbox.get.invalidate({ mailboxSlug: mailbox.slug });
+                resolve();
+              },
+              onError: reject,
+            },
+          );
+        });
       },
-      widgetHost: widgetHost || null,
-    });
-  }, 2000);
+      successMessage: "Chat widget settings updated successfully",
+      errorMessage: "Failed to update chat widget settings",
+    },
+  );
 
-  useOnChange(() => {
-    save();
-  }, [mode, minValue, autoRespond, widgetHost]);
+  useEffect(() => {
+    handleReset({
+      mode: mailbox.widgetDisplayMode ?? "off",
+      minValue: mailbox.widgetDisplayMinValue?.toString() ?? "100",
+      autoRespond: mailbox.preferences?.autoRespondEmailToChat ?? "off",
+      widgetHost: mailbox.widgetHost ?? "",
+    });
+  }, [
+    mailbox.widgetDisplayMode,
+    mailbox.widgetDisplayMinValue,
+    mailbox.preferences?.autoRespondEmailToChat,
+    mailbox.widgetHost,
+    handleReset,
+  ]);
+
+  useEffect(() => {
+    setShowChatWidget(currentData.mode !== "off");
+    return () => setShowChatWidget(false);
+  }, [currentData.mode, setShowChatWidget]);
 
   const handleSwitchChange = (checked: boolean) => {
     const newMode = checked ? "always" : "off";
-    setMode(newMode);
+    updateData({ mode: newMode });
   };
 
   const widgetSampleCode = WIDGET_SAMPLE_CODE.replace("{{DATA_ATTRIBUTES}}", `data-mailbox="${mailbox.slug}"`);
@@ -564,75 +587,80 @@ export default async function RootLayout({
           </TabsContent>
         </Tabs>
       </SectionWrapper>
-      <SwitchSectionWrapper
-        title="Chat Icon Visibility"
-        description="Choose when your customers can see the chat widget on your website or app"
-        initialSwitchChecked={mode !== "off"}
-        onSwitchChange={handleSwitchChange}
-      >
-        {mode !== "off" && (
-          <div className="space-y-4">
-            <div className="flex flex-col space-y-2">
-              <Label>Show chat icon for</Label>
-              <Select value={mode} onValueChange={(mode) => setMode(mode as WidgetMode)}>
-                <SelectTrigger className="w-[350px]">
-                  <SelectValue placeholder="Select when to show chat icon" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="always">All customers</SelectItem>
-                  <SelectItem value="revenue_based">Customers with value greater than</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-
-            {mode === "revenue_based" && (
-              <div className="flex items-center space-x-4">
-                <Input
-                  id="min-value"
-                  type="number"
-                  value={minValue}
-                  onChange={(e) => setMinValue(e.target.value)}
-                  className="max-w-[200px]"
-                  min="0"
-                  step="1"
-                />
+      <SaveableForm isDirty={isDirty} isLoading={isLoading} onSave={handleSave} onCancel={handleCancel}>
+        <SwitchSectionWrapper
+          title="Chat Icon Visibility"
+          description="Choose when your customers can see the chat widget on your website or app"
+          initialSwitchChecked={currentData.mode !== "off"}
+          onSwitchChange={handleSwitchChange}
+        >
+          {currentData.mode !== "off" && (
+            <div className="space-y-4">
+              <div className="flex flex-col space-y-2">
+                <Label>Show chat icon for</Label>
+                <Select value={currentData.mode} onValueChange={(mode) => updateData({ mode: mode as WidgetMode })}>
+                  <SelectTrigger className="w-[350px]">
+                    <SelectValue placeholder="Select when to show chat icon" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="always">All customers</SelectItem>
+                    <SelectItem value="revenue_based">Customers with value greater than</SelectItem>
+                  </SelectContent>
+                </Select>
               </div>
-            )}
+
+              {currentData.mode === "revenue_based" && (
+                <div className="flex items-center space-x-4">
+                  <Input
+                    id="min-value"
+                    type="number"
+                    value={currentData.minValue}
+                    onChange={(e) => updateData({ minValue: e.target.value })}
+                    className="max-w-[200px]"
+                    min="0"
+                    step="1"
+                  />
+                </div>
+              )}
+            </div>
+          )}
+        </SwitchSectionWrapper>
+
+        <SectionWrapper
+          title="Chat widget host URL"
+          description="The URL where your chat widget is installed. If set, customers will be able to continue email conversations in the chat widget."
+        >
+          <div className="flex flex-col space-y-2">
+            <Label htmlFor="widgetHost">Host URL</Label>
+            <Input
+              id="widgetHost"
+              type="url"
+              value={currentData.widgetHost}
+              onChange={(e) => updateData({ widgetHost: e.target.value })}
+              placeholder="https://example.com"
+              className="max-w-[350px]"
+            />
           </div>
-        )}
-      </SwitchSectionWrapper>
+        </SectionWrapper>
 
-      <SectionWrapper
-        title="Chat widget host URL"
-        description="The URL where your chat widget is installed. If set, customers will be able to continue email conversations in the chat widget."
-      >
-        <div className="flex flex-col space-y-2">
-          <Label htmlFor="widgetHost">Host URL</Label>
-          <Input
-            id="widgetHost"
-            type="url"
-            value={widgetHost}
-            onChange={(e) => setWidgetHost(e.target.value)}
-            placeholder="https://example.com"
-            className="max-w-[350px]"
-          />
-        </div>
-      </SectionWrapper>
-
-      <SectionWrapper
-        title="Respond to email inquiries with chat"
-        description="Automatically respond to emails as if the customer was using the chat widget."
-      >
-        <div className="space-y-4">
-          <Tabs value={autoRespond} onValueChange={(value) => setAutoRespond(value as "off" | "draft" | "reply")}>
-            <TabsList className="grid w-full grid-cols-3">
-              <TabsTrigger value="off">Off</TabsTrigger>
-              <TabsTrigger value="draft">Draft</TabsTrigger>
-              <TabsTrigger value="reply">Reply</TabsTrigger>
-            </TabsList>
-          </Tabs>
-        </div>
-      </SectionWrapper>
+        <SectionWrapper
+          title="Respond to email inquiries with chat"
+          description="Automatically respond to emails as if the customer was using the chat widget."
+        >
+          <div className="space-y-4">
+            <Tabs
+              value={currentData.autoRespond}
+              onValueChange={(value) => updateData({ autoRespond: value as "off" | "draft" | "reply" })}
+            >
+              <TabsList className="grid w-full grid-cols-3">
+                <TabsTrigger value="off">Off</TabsTrigger>
+                <TabsTrigger value="draft">Draft</TabsTrigger>
+                <TabsTrigger value="reply">Reply</TabsTrigger>
+              </TabsList>
+            </Tabs>
+          </div>
+        </SectionWrapper>
+      </SaveableForm>
 
       {showChatWidget && (
         <div className="fixed bottom-8 right-24 bg-primary text-primary-foreground px-3 py-1.5 rounded-md">

--- a/app/(dashboard)/mailboxes/[mailbox_slug]/settings/customers/autoCloseSetting.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/settings/customers/autoCloseSetting.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect } from "react";
 import { toast } from "@/components/hooks/use-toast";
+import { useManualSave } from "@/components/hooks/useManualSave";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { SaveableForm } from "@/components/ui/saveableForm";
 import { Switch } from "@/components/ui/switch";
-import { useDebouncedCallback } from "@/components/useDebouncedCallback";
-import { useOnChange } from "@/components/useOnChange";
 import { RouterOutputs } from "@/trpc";
 import { api } from "@/trpc/react";
 import SectionWrapper from "../sectionWrapper";
@@ -18,32 +18,44 @@ export type AutoCloseUpdates = {
 };
 
 export default function AutoCloseSetting({ mailbox }: { mailbox: RouterOutputs["mailbox"]["get"] }) {
-  const [isEnabled, setIsEnabled] = useState(mailbox.autoCloseEnabled);
-  const [daysOfInactivity, setDaysOfInactivity] = useState(mailbox.autoCloseDaysOfInactivity?.toString() ?? "30");
   const utils = api.useUtils();
-  const { mutate: update } = api.mailbox.update.useMutation({
-    onSuccess: () => {
-      utils.mailbox.get.invalidate({ mailboxSlug: mailbox.slug });
-    },
-    onError: (error) => {
-      toast({
-        title: "Error updating auto-close settings",
-        description: error.message,
-      });
-    },
-  });
+  const { mutate: update } = api.mailbox.update.useMutation();
 
-  const save = useDebouncedCallback(() => {
-    update({
-      mailboxSlug: mailbox.slug,
-      autoCloseEnabled: isEnabled,
-      autoCloseDaysOfInactivity: Number(daysOfInactivity),
+  const { currentData, isDirty, isLoading, updateData, handleSave, handleCancel, handleReset } = useManualSave(
+    {
+      isEnabled: mailbox.autoCloseEnabled,
+      daysOfInactivity: mailbox.autoCloseDaysOfInactivity?.toString() ?? "30",
+    },
+    {
+      onSave: async (data) => {
+        await new Promise<void>((resolve, reject) => {
+          update(
+            {
+              mailboxSlug: mailbox.slug,
+              autoCloseEnabled: data.isEnabled,
+              autoCloseDaysOfInactivity: Number(data.daysOfInactivity),
+            },
+            {
+              onSuccess: () => {
+                utils.mailbox.get.invalidate({ mailboxSlug: mailbox.slug });
+                resolve();
+              },
+              onError: reject,
+            },
+          );
+        });
+      },
+      successMessage: "Auto-close settings updated successfully",
+      errorMessage: "Failed to update auto-close settings",
+    },
+  );
+
+  useEffect(() => {
+    handleReset({
+      isEnabled: mailbox.autoCloseEnabled,
+      daysOfInactivity: mailbox.autoCloseDaysOfInactivity?.toString() ?? "30",
     });
-  }, 2000);
-
-  useOnChange(() => {
-    save();
-  }, [isEnabled, daysOfInactivity]);
+  }, [mailbox.autoCloseEnabled, mailbox.autoCloseDaysOfInactivity, handleReset]);
 
   const { mutate: runAutoClose, isPending: isAutoClosePending } = api.mailbox.autoClose.useMutation({
     onSuccess: () => {
@@ -66,47 +78,55 @@ export default function AutoCloseSetting({ mailbox }: { mailbox: RouterOutputs["
       title="Auto-close Inactive Tickets"
       description="Automatically close tickets that have been inactive for a specified period of time."
     >
-      <div className="space-y-6">
-        <div className="flex items-center justify-between">
-          <div className="space-y-0.5">
-            <Label htmlFor="auto-close-toggle">Enable auto-close</Label>
-            <p className="text-sm text-muted-foreground">
-              When enabled, tickets with no activity will be automatically closed.
-            </p>
-          </div>
-          <Switch id="auto-close-toggle" checked={isEnabled} onCheckedChange={setIsEnabled} />
-        </div>
-
-        {isEnabled && (
-          <div className="space-y-2">
-            <Label htmlFor="days-of-inactivity">Days of inactivity before auto-close</Label>
-            <div className="flex items-center gap-2 w-fit">
-              <Input
-                id="days-of-inactivity"
-                type="number"
-                min="1"
-                value={daysOfInactivity}
-                onChange={(e) => setDaysOfInactivity(e.target.value)}
-                className="w-24"
-              />
-              <span className="text-sm text-muted-foreground">{daysOfInactivity === "1" ? "day" : "days"}</span>
+      <SaveableForm isDirty={isDirty} isLoading={isLoading} onSave={handleSave} onCancel={handleCancel}>
+        <div className="space-y-6">
+          <div className="flex items-center justify-between">
+            <div className="space-y-0.5">
+              <Label htmlFor="auto-close-toggle">Enable auto-close</Label>
+              <p className="text-sm text-muted-foreground">
+                When enabled, tickets with no activity will be automatically closed.
+              </p>
             </div>
-            <p className="text-sm text-muted-foreground">
-              Tickets with no activity for this many days will be automatically closed.
-            </p>
+            <Switch
+              id="auto-close-toggle"
+              checked={currentData.isEnabled}
+              onCheckedChange={(enabled) => updateData({ isEnabled: enabled })}
+            />
           </div>
-        )}
 
-        <div className="flex justify-between">
-          <Button
-            variant="outlined"
-            onClick={() => runAutoClose({ mailboxSlug: mailbox.slug })}
-            disabled={!isEnabled || isAutoClosePending}
-          >
-            {isAutoClosePending ? "Running..." : "Run auto-close now"}
-          </Button>
+          {currentData.isEnabled && (
+            <div className="space-y-2">
+              <Label htmlFor="days-of-inactivity">Days of inactivity before auto-close</Label>
+              <div className="flex items-center gap-2 w-fit">
+                <Input
+                  id="days-of-inactivity"
+                  type="number"
+                  min="1"
+                  value={currentData.daysOfInactivity}
+                  onChange={(e) => updateData({ daysOfInactivity: e.target.value })}
+                  className="w-24"
+                />
+                <span className="text-sm text-muted-foreground">
+                  {currentData.daysOfInactivity === "1" ? "day" : "days"}
+                </span>
+              </div>
+              <p className="text-sm text-muted-foreground">
+                Tickets with no activity for this many days will be automatically closed.
+              </p>
+            </div>
+          )}
+
+          <div className="flex justify-between">
+            <Button
+              variant="outlined"
+              onClick={() => runAutoClose({ mailboxSlug: mailbox.slug })}
+              disabled={!currentData.isEnabled || isAutoClosePending}
+            >
+              {isAutoClosePending ? "Running..." : "Run auto-close now"}
+            </Button>
+          </div>
         </div>
-      </div>
+      </SaveableForm>
     </SectionWrapper>
   );
 }

--- a/app/(dashboard)/mailboxes/[mailbox_slug]/settings/customers/customerSetting.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/settings/customers/customerSetting.tsx
@@ -1,13 +1,12 @@
 "use client";
 
-import { useState } from "react";
-import { toast } from "@/components/hooks/use-toast";
+import { useEffect } from "react";
+import { useManualSave } from "@/components/hooks/useManualSave";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { SaveableForm } from "@/components/ui/saveableForm";
 import { Separator } from "@/components/ui/separator";
-import { useDebouncedCallback } from "@/components/useDebouncedCallback";
-import { useOnChange } from "@/components/useOnChange";
 import { RouterOutputs } from "@/trpc";
 import { api } from "@/trpc/react";
 import { SlackChannels } from "../integrations/slackSetting";
@@ -20,123 +19,147 @@ export type CustomerUpdates = {
 };
 
 const CustomerSetting = ({ mailbox }: { mailbox: RouterOutputs["mailbox"]["get"] }) => {
-  const [isEnabled, setIsEnabled] = useState(mailbox.vipThreshold !== null);
-  const [threshold, setThreshold] = useState(mailbox.vipThreshold?.toString() ?? "100");
-  const [responseHours, setResponseHours] = useState(mailbox.vipExpectedResponseHours?.toString() ?? "");
   const utils = api.useUtils();
-  const { mutate: update } = api.mailbox.update.useMutation({
-    onSuccess: () => {
-      utils.mailbox.get.invalidate({ mailboxSlug: mailbox.slug });
-    },
-    onError: (error) => {
-      toast({
-        title: "Error updating VIP settings",
-        description: error.message,
-      });
-    },
-  });
+  const { mutate: update } = api.mailbox.update.useMutation();
 
-  const save = useDebouncedCallback(() => {
-    if (isEnabled) {
-      update({
-        mailboxSlug: mailbox.slug,
-        vipThreshold: Number(threshold),
-        vipExpectedResponseHours: responseHours ? Number(responseHours) : null,
-      });
-    } else {
-      update({
-        mailboxSlug: mailbox.slug,
-        vipThreshold: null,
-        vipChannelId: null,
-        vipExpectedResponseHours: null,
-      });
-    }
-  }, 2000);
+  const { currentData, isDirty, isLoading, updateData, handleSave, handleCancel, handleReset } = useManualSave(
+    {
+      isEnabled: mailbox.vipThreshold !== null,
+      threshold: mailbox.vipThreshold?.toString() ?? "100",
+      responseHours: mailbox.vipExpectedResponseHours?.toString() ?? "",
+    },
+    {
+      onSave: async (data) => {
+        await new Promise<void>((resolve, reject) => {
+          if (data.isEnabled) {
+            update(
+              {
+                mailboxSlug: mailbox.slug,
+                vipThreshold: Number(data.threshold),
+                vipExpectedResponseHours: data.responseHours ? Number(data.responseHours) : null,
+              },
+              {
+                onSuccess: () => {
+                  utils.mailbox.get.invalidate({ mailboxSlug: mailbox.slug });
+                  resolve();
+                },
+                onError: reject,
+              },
+            );
+          } else {
+            update(
+              {
+                mailboxSlug: mailbox.slug,
+                vipThreshold: null,
+                vipChannelId: null,
+                vipExpectedResponseHours: null,
+              },
+              {
+                onSuccess: () => {
+                  utils.mailbox.get.invalidate({ mailboxSlug: mailbox.slug });
+                  resolve();
+                },
+                onError: reject,
+              },
+            );
+          }
+        });
+      },
+      successMessage: "VIP customer settings updated successfully",
+      errorMessage: "Failed to update VIP customer settings",
+    },
+  );
 
-  useOnChange(() => {
-    save();
-  }, [isEnabled, threshold, responseHours]);
+  useEffect(() => {
+    handleReset({
+      isEnabled: mailbox.vipThreshold !== null,
+      threshold: mailbox.vipThreshold?.toString() ?? "100",
+      responseHours: mailbox.vipExpectedResponseHours?.toString() ?? "",
+    });
+  }, [mailbox.vipThreshold, mailbox.vipExpectedResponseHours, handleReset]);
 
   return (
     <SwitchSectionWrapper
       title="VIP Customers"
       description="Configure settings for high-value customers"
-      initialSwitchChecked={isEnabled}
-      onSwitchChange={setIsEnabled}
+      initialSwitchChecked={currentData.isEnabled}
+      onSwitchChange={(enabled) => updateData({ isEnabled: enabled })}
     >
-      {isEnabled && (
-        <div className="space-y-8">
-          <div className="space-y-4">
-            <div className="max-w-2xl">
-              <Label htmlFor="vipThreshold" className="text-base font-medium">
-                Customer Value Threshold
-              </Label>
-              <p className="mt-2 text-sm text-muted-foreground">
-                Customers with a value above this threshold will be marked as VIP
-              </p>
-              <Input
-                id="vipThreshold"
-                type="number"
-                min="0"
-                step="0.01"
-                placeholder="Enter threshold value"
-                value={threshold}
-                onChange={(e) => setThreshold(e.target.value)}
-                className="mt-2 max-w-sm"
-              />
-            </div>
-
-            <div className="max-w-2xl">
-              <Label htmlFor="responseHours" className="text-base font-medium">
-                Response Time Target
-              </Label>
-              <p className="mt-2 text-sm text-muted-foreground">
-                Set a target response time for VIP customers. You'll be alerted if responses exceed this timeframe.
-              </p>
-              <div className="mt-2 flex items-center gap-2 w-36">
+      {currentData.isEnabled && (
+        <SaveableForm isDirty={isDirty} isLoading={isLoading} onSave={handleSave} onCancel={handleCancel}>
+          <div className="space-y-8">
+            <div className="space-y-4">
+              <div className="max-w-2xl">
+                <Label htmlFor="vipThreshold" className="text-base font-medium">
+                  Customer Value Threshold
+                </Label>
+                <p className="mt-2 text-sm text-muted-foreground">
+                  Customers with a value above this threshold will be marked as VIP
+                </p>
                 <Input
-                  id="responseHours"
+                  id="vipThreshold"
                   type="number"
-                  min="1"
-                  step="1"
-                  value={responseHours}
-                  onChange={(e) => setResponseHours(e.target.value)}
+                  min="0"
+                  step="0.01"
+                  placeholder="Enter threshold value"
+                  value={currentData.threshold}
+                  onChange={(e) => updateData({ threshold: e.target.value })}
+                  className="mt-2 max-w-sm"
                 />
-                <span className="text-sm text-muted-foreground whitespace-nowrap">hours</span>
               </div>
-            </div>
-          </div>
 
-          <Separator />
-
-          <div className="space-y-4">
-            <div className="max-w-2xl">
-              <Label htmlFor="vipChannel" className="text-base font-medium">
-                Slack Notifications
-              </Label>
-              <p className="mt-2 text-sm text-muted-foreground">
-                Choose a Slack channel to receive notifications about VIP customer messages
-              </p>
-              <div className="mt-4">
-                {mailbox.slackConnected ? (
-                  <SlackChannels
-                    id="vipChannel"
-                    selectedChannelId={mailbox.vipChannelId ?? undefined}
-                    mailbox={mailbox}
-                    onChange={(vipChannelId) => update({ mailboxSlug: mailbox.slug, vipChannelId })}
+              <div className="max-w-2xl">
+                <Label htmlFor="responseHours" className="text-base font-medium">
+                  Response Time Target
+                </Label>
+                <p className="mt-2 text-sm text-muted-foreground">
+                  Set a target response time for VIP customers. You'll be alerted if responses exceed this timeframe.
+                </p>
+                <div className="mt-2 flex items-center gap-2 w-36">
+                  <Input
+                    id="responseHours"
+                    type="number"
+                    min="1"
+                    step="1"
+                    value={currentData.responseHours}
+                    onChange={(e) => updateData({ responseHours: e.target.value })}
                   />
-                ) : (
-                  <Alert>
-                    <AlertDescription>
-                      Slack integration is required for VIP channel notifications. Please configure Slack in the
-                      Integrations tab.
-                    </AlertDescription>
-                  </Alert>
-                )}
+                  <span className="text-sm text-muted-foreground whitespace-nowrap">hours</span>
+                </div>
+              </div>
+            </div>
+
+            <Separator />
+
+            <div className="space-y-4">
+              <div className="max-w-2xl">
+                <Label htmlFor="vipChannel" className="text-base font-medium">
+                  Slack Notifications
+                </Label>
+                <p className="mt-2 text-sm text-muted-foreground">
+                  Choose a Slack channel to receive notifications about VIP customer messages
+                </p>
+                <div className="mt-4">
+                  {mailbox.slackConnected ? (
+                    <SlackChannels
+                      id="vipChannel"
+                      selectedChannelId={mailbox.vipChannelId ?? undefined}
+                      mailbox={mailbox}
+                      onChange={(vipChannelId) => update({ mailboxSlug: mailbox.slug, vipChannelId })}
+                    />
+                  ) : (
+                    <Alert>
+                      <AlertDescription>
+                        Slack integration is required for VIP channel notifications. Please configure Slack in the
+                        Integrations tab.
+                      </AlertDescription>
+                    </Alert>
+                  )}
+                </div>
               </div>
             </div>
           </div>
-        </div>
+        </SaveableForm>
       )}
     </SwitchSectionWrapper>
   );

--- a/app/(dashboard)/mailboxes/[mailbox_slug]/settings/preferences/mailboxNameSetting.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/settings/preferences/mailboxNameSetting.tsx
@@ -1,42 +1,54 @@
 "use client";
 
-import { useState } from "react";
-import { toast } from "@/components/hooks/use-toast";
+import { useEffect } from "react";
+import { useManualSave } from "@/components/hooks/useManualSave";
 import { Input } from "@/components/ui/input";
-import { useDebouncedCallback } from "@/components/useDebouncedCallback";
-import { useOnChange } from "@/components/useOnChange";
+import { SaveableForm } from "@/components/ui/saveableForm";
 import { RouterOutputs } from "@/trpc";
 import { api } from "@/trpc/react";
 import SectionWrapper from "../sectionWrapper";
 
 const MailboxNameSetting = ({ mailbox }: { mailbox: RouterOutputs["mailbox"]["get"] }) => {
-  const [name, setName] = useState(mailbox.name);
   const utils = api.useUtils();
-  const { mutate: update } = api.mailbox.update.useMutation({
-    onSuccess: () => {
-      utils.mailbox.get.invalidate({ mailboxSlug: mailbox.slug });
-    },
-    onError: (error) => {
-      toast({
-        title: "Error updating preferences",
-        description: error.message,
-      });
-    },
-  });
+  const { mutate: update } = api.mailbox.update.useMutation();
 
-  const save = useDebouncedCallback(() => {
-    update({ mailboxSlug: mailbox.slug, name });
-  }, 2000);
+  const { currentData, isDirty, isLoading, updateData, handleSave, handleCancel, handleReset } = useManualSave(
+    { name: mailbox.name },
+    {
+      onSave: async (data) => {
+        await new Promise<void>((resolve, reject) => {
+          update(
+            { mailboxSlug: mailbox.slug, name: data.name },
+            {
+              onSuccess: () => {
+                utils.mailbox.get.invalidate({ mailboxSlug: mailbox.slug });
+                resolve();
+              },
+              onError: reject,
+            },
+          );
+        });
+      },
+      successMessage: "Mailbox name updated successfully",
+      errorMessage: "Failed to update mailbox name",
+    },
+  );
 
-  useOnChange(() => {
-    save();
-  }, [name]);
+  useEffect(() => {
+    handleReset({ name: mailbox.name });
+  }, [mailbox.name, handleReset]);
 
   return (
     <SectionWrapper title="Mailbox name" description="Change the name of your mailbox">
-      <div className="max-w-sm">
-        <Input value={name} onChange={(e) => setName(e.target.value)} placeholder="Enter mailbox name" />
-      </div>
+      <SaveableForm isDirty={isDirty} isLoading={isLoading} onSave={handleSave} onCancel={handleCancel}>
+        <div className="max-w-sm">
+          <Input
+            value={currentData.name}
+            onChange={(e) => updateData({ name: e.target.value })}
+            placeholder="Enter mailbox name"
+          />
+        </div>
+      </SaveableForm>
     </SectionWrapper>
   );
 };

--- a/app/(dashboard)/mailboxes/[mailbox_slug]/settings/preferences/themeSetting.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/settings/preferences/themeSetting.tsx
@@ -1,13 +1,11 @@
 "use client";
 
-import { mapValues } from "lodash-es";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect } from "react";
 import { useInboxTheme } from "@/app/(dashboard)/mailboxes/[mailbox_slug]/clientLayout";
-import { toast } from "@/components/hooks/use-toast";
+import { useManualSave } from "@/components/hooks/useManualSave";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { useDebouncedCallback } from "@/components/useDebouncedCallback";
-import { useOnChange } from "@/components/useOnChange";
+import { SaveableForm } from "@/components/ui/saveableForm";
 import { normalizeHex } from "@/lib/themes";
 import { RouterOutputs } from "@/trpc";
 import { api } from "@/trpc/react";
@@ -26,160 +24,204 @@ export type ThemeUpdates = {
 const ThemeSetting = ({ mailbox }: { mailbox: RouterOutputs["mailbox"]["get"] }) => {
   const { setTheme: setWindowTheme } = useInboxTheme();
 
-  const [isEnabled, setIsEnabled] = useState(!!mailbox.preferences?.theme);
-  const [theme, setTheme] = useState(
-    mailbox.preferences?.theme ?? {
-      background: "#ffffff",
-      foreground: "#000000",
-      primary: "#000000",
-      accent: "#000000",
-      sidebarBackground: "#ffffff",
+  const utils = api.useUtils();
+  const { mutate: update } = api.mailbox.update.useMutation();
+
+  const { currentData, isDirty, isLoading, updateData, handleSave, handleCancel, handleReset } = useManualSave(
+    {
+      isEnabled: !!mailbox.preferences?.theme,
+      theme: mailbox.preferences?.theme ?? {
+        background: "#ffffff",
+        foreground: "#000000",
+        primary: "#000000",
+        accent: "#000000",
+        sidebarBackground: "#ffffff",
+      },
+    },
+    {
+      onSave: async (data: { isEnabled: boolean; theme: ThemeUpdates["theme"] }) => {
+        if (!data.isEnabled && !mailbox.preferences?.theme) return;
+
+        await new Promise<void>((resolve, reject) => {
+          update(
+            {
+              mailboxSlug: mailbox.slug,
+              preferences: {
+                theme:
+                  data.isEnabled && data.theme
+                    ? {
+                        background: `#${normalizeHex(data.theme.background)}`,
+                        foreground: `#${normalizeHex(data.theme.foreground)}`,
+                        primary: `#${normalizeHex(data.theme.primary)}`,
+                        accent: `#${normalizeHex(data.theme.accent)}`,
+                        sidebarBackground: `#${normalizeHex(data.theme.sidebarBackground)}`,
+                      }
+                    : null,
+              },
+            },
+            {
+              onSuccess: () => {
+                utils.mailbox.get.invalidate({ mailboxSlug: mailbox.slug });
+                resolve();
+              },
+              onError: reject,
+            },
+          );
+        });
+      },
+      successMessage: "Theme settings updated successfully",
+      errorMessage: "Failed to update theme settings",
     },
   );
 
-  const utils = api.useUtils();
-  const { mutate: update } = api.mailbox.update.useMutation({
-    onSuccess: () => {
-      utils.mailbox.get.invalidate({ mailboxSlug: mailbox.slug });
-    },
-    onError: (error) => {
-      toast({
-        title: "Error updating theme",
-        description: error.message,
-        variant: "destructive",
-      });
-    },
-  });
-
-  const save = useDebouncedCallback(() => {
-    if (!isEnabled && !mailbox.preferences?.theme) return;
-    update({
-      mailboxSlug: mailbox.slug,
-      preferences: { theme: isEnabled ? mapValues(theme, (value) => `#${normalizeHex(value)}`) : null },
+  useEffect(() => {
+    handleReset({
+      isEnabled: !!mailbox.preferences?.theme,
+      theme: mailbox.preferences?.theme ?? {
+        background: "#ffffff",
+        foreground: "#000000",
+        primary: "#000000",
+        accent: "#000000",
+        sidebarBackground: "#ffffff",
+      },
     });
-  }, 2000);
-
-  useOnChange(() => {
-    save();
-  }, [isEnabled, theme]);
+  }, [mailbox.preferences?.theme, handleReset]);
 
   useEffect(() => {
     const root = document.documentElement;
-    if (!isEnabled) {
-      setTheme({
-        background: getComputedStyle(root).getPropertyValue("--background").trim() || "#ffffff",
-        foreground: getComputedStyle(root).getPropertyValue("--foreground").trim() || "#000000",
-        primary: getComputedStyle(root).getPropertyValue("--primary").trim() || "#000000",
-        accent: getComputedStyle(root).getPropertyValue("--bright").trim() || "#000000",
-        sidebarBackground: getComputedStyle(root).getPropertyValue("--sidebar-background").trim() || "#ffffff",
+    if (!currentData.isEnabled) {
+      updateData({
+        theme: {
+          background: getComputedStyle(root).getPropertyValue("--background").trim() || "#ffffff",
+          foreground: getComputedStyle(root).getPropertyValue("--foreground").trim() || "#000000",
+          primary: getComputedStyle(root).getPropertyValue("--primary").trim() || "#000000",
+          accent: getComputedStyle(root).getPropertyValue("--bright").trim() || "#000000",
+          sidebarBackground: getComputedStyle(root).getPropertyValue("--sidebar-background").trim() || "#ffffff",
+        },
       });
     }
-  }, []);
+  }, [currentData.isEnabled, updateData]);
 
-  const debouncedSetWindowTheme = useDebouncedCallback(setWindowTheme, 200);
-
-  const handleColorChange =
+  const handleColorChange = useCallback(
     (color: keyof NonNullable<ThemeUpdates["theme"]>) => (e: React.ChangeEvent<HTMLInputElement>) => {
-      setTheme({ ...theme, [color]: e.target.value });
+      const newTheme = { ...currentData.theme, [color]: e.target.value };
+      updateData({ theme: newTheme });
+
       const normalized = /#([0-9a-f]{3})$/i.test(e.target.value) ? `#${normalizeHex(e.target.value)}` : e.target.value;
-      if (/#([0-9a-f]{6})$/i.test(normalized)) debouncedSetWindowTheme({ ...theme, [color]: normalized });
-    };
+      if (/#([0-9a-f]{6})$/i.test(normalized)) {
+        setWindowTheme({ ...newTheme, [color]: normalized });
+      }
+    },
+    [currentData.theme, updateData, setWindowTheme],
+  );
 
   const handleSwitchChange = (checked: boolean) => {
-    setIsEnabled(checked);
+    updateData({ isEnabled: checked });
   };
 
   return (
-    <SwitchSectionWrapper
-      title="Custom Theme"
-      description="Choose the appearance of your mailbox with custom colors"
-      initialSwitchChecked={isEnabled}
-      onSwitchChange={handleSwitchChange}
-    >
-      {isEnabled && (
-        <div className="space-y-4">
-          <div className="flex flex-col space-y-2">
-            <Label>Background Color</Label>
-            <div className="grid grid-cols-[auto_1fr] gap-2">
-              <Input
-                type="color"
-                value={theme.background}
-                onChange={handleColorChange("background")}
-                className="h-10 w-20 p-1"
-              />
-              <Input
-                type="text"
-                value={theme.background}
-                onChange={handleColorChange("background")}
-                className="w-[200px]"
-              />
+    <SaveableForm isDirty={isDirty} isLoading={isLoading} onSave={handleSave} onCancel={handleCancel}>
+      <SwitchSectionWrapper
+        title="Custom Theme"
+        description="Choose the appearance of your mailbox with custom colors"
+        initialSwitchChecked={currentData.isEnabled}
+        onSwitchChange={handleSwitchChange}
+      >
+        {currentData.isEnabled && (
+          <div className="space-y-4">
+            <div className="flex flex-col space-y-2">
+              <Label>Background Color</Label>
+              <div className="grid grid-cols-[auto_1fr] gap-2">
+                <Input
+                  type="color"
+                  value={currentData.theme.background}
+                  onChange={handleColorChange("background")}
+                  className="h-10 w-20 p-1"
+                />
+                <Input
+                  type="text"
+                  value={currentData.theme.background}
+                  onChange={handleColorChange("background")}
+                  className="w-[200px]"
+                />
+              </div>
             </div>
-          </div>
 
-          <div className="flex flex-col space-y-2">
-            <Label>Foreground Color</Label>
-            <div className="grid grid-cols-[auto_1fr] gap-2">
-              <Input
-                type="color"
-                value={theme.foreground}
-                onChange={handleColorChange("foreground")}
-                className="h-10 w-20 p-1"
-              />
-              <Input
-                type="text"
-                value={theme.foreground}
-                onChange={handleColorChange("foreground")}
-                className="w-[200px]"
-              />
+            <div className="flex flex-col space-y-2">
+              <Label>Foreground Color</Label>
+              <div className="grid grid-cols-[auto_1fr] gap-2">
+                <Input
+                  type="color"
+                  value={currentData.theme.foreground}
+                  onChange={handleColorChange("foreground")}
+                  className="h-10 w-20 p-1"
+                />
+                <Input
+                  type="text"
+                  value={currentData.theme.foreground}
+                  onChange={handleColorChange("foreground")}
+                  className="w-[200px]"
+                />
+              </div>
             </div>
-          </div>
 
-          <div className="flex flex-col space-y-2">
-            <Label>Primary Color</Label>
-            <div className="grid grid-cols-[auto_1fr] gap-2">
-              <Input
-                type="color"
-                value={theme.primary}
-                onChange={handleColorChange("primary")}
-                className="h-10 w-20 p-1"
-              />
-              <Input type="text" value={theme.primary} onChange={handleColorChange("primary")} className="w-[200px]" />
+            <div className="flex flex-col space-y-2">
+              <Label>Primary Color</Label>
+              <div className="grid grid-cols-[auto_1fr] gap-2">
+                <Input
+                  type="color"
+                  value={currentData.theme.primary}
+                  onChange={handleColorChange("primary")}
+                  className="h-10 w-20 p-1"
+                />
+                <Input
+                  type="text"
+                  value={currentData.theme.primary}
+                  onChange={handleColorChange("primary")}
+                  className="w-[200px]"
+                />
+              </div>
             </div>
-          </div>
 
-          <div className="flex flex-col space-y-2">
-            <Label>Accent Color</Label>
-            <div className="grid grid-cols-[auto_1fr] gap-2">
-              <Input
-                type="color"
-                value={theme.accent}
-                onChange={handleColorChange("accent")}
-                className="h-10 w-20 p-1"
-              />
-              <Input type="text" value={theme.accent} onChange={handleColorChange("accent")} className="w-[200px]" />
+            <div className="flex flex-col space-y-2">
+              <Label>Accent Color</Label>
+              <div className="grid grid-cols-[auto_1fr] gap-2">
+                <Input
+                  type="color"
+                  value={currentData.theme.accent}
+                  onChange={handleColorChange("accent")}
+                  className="h-10 w-20 p-1"
+                />
+                <Input
+                  type="text"
+                  value={currentData.theme.accent}
+                  onChange={handleColorChange("accent")}
+                  className="w-[200px]"
+                />
+              </div>
             </div>
-          </div>
 
-          <div className="flex flex-col space-y-2">
-            <Label>Sidebar Color</Label>
-            <div className="grid grid-cols-[auto_1fr] gap-2">
-              <Input
-                type="color"
-                value={theme.sidebarBackground}
-                onChange={handleColorChange("sidebarBackground")}
-                className="h-10 w-20 p-1"
-              />
-              <Input
-                type="text"
-                value={theme.sidebarBackground}
-                onChange={handleColorChange("sidebarBackground")}
-                className="w-[200px]"
-              />
+            <div className="flex flex-col space-y-2">
+              <Label>Sidebar Color</Label>
+              <div className="grid grid-cols-[auto_1fr] gap-2">
+                <Input
+                  type="color"
+                  value={currentData.theme.sidebarBackground}
+                  onChange={handleColorChange("sidebarBackground")}
+                  className="h-10 w-20 p-1"
+                />
+                <Input
+                  type="text"
+                  value={currentData.theme.sidebarBackground}
+                  onChange={handleColorChange("sidebarBackground")}
+                  className="w-[200px]"
+                />
+              </div>
             </div>
           </div>
-        </div>
-      )}
-    </SwitchSectionWrapper>
+        )}
+      </SwitchSectionWrapper>
+    </SaveableForm>
   );
 };
 

--- a/app/(dashboard)/mailboxes/[mailbox_slug]/settings/team/teamMemberRow.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/settings/team/teamMemberRow.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { toast } from "@/components/hooks/use-toast";
+import { useEffect } from "react";
+import { useManualSave } from "@/components/hooks/useManualSave";
+import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { TableCell, TableRow } from "@/components/ui/table";
-import { useDebouncedCallback } from "@/components/useDebouncedCallback";
 import { type UserRole } from "@/lib/data/user";
 import { api } from "@/trpc/react";
 
@@ -29,113 +29,102 @@ type TeamMemberRowProps = {
 };
 
 const TeamMemberRow = ({ member, mailboxSlug }: TeamMemberRowProps) => {
-  const [keywordsInput, setKeywordsInput] = useState(member.keywords.join(", "));
-  const [role, setRole] = useState<UserRole>(member.role);
-  const [localKeywords, setLocalKeywords] = useState<string[]>(member.keywords);
-  const [displayNameInput, setDisplayNameInput] = useState(member.displayName || "");
-
   const utils = api.useUtils();
+  const { mutate: updateTeamMember } = api.mailbox.members.update.useMutation();
+
+  const { currentData, isDirty, isLoading, updateData, handleSave, handleCancel, handleReset } = useManualSave(
+    {
+      keywordsInput: member.keywords.join(", "),
+      role: member.role,
+      localKeywords: member.keywords,
+      displayNameInput: member.displayName || "",
+    },
+    {
+      onSave: async (data) => {
+        await new Promise<void>((resolve, reject) => {
+          updateTeamMember(
+            {
+              mailboxSlug,
+              userId: member.id,
+              role: data.role,
+              keywords: data.localKeywords,
+              displayName: data.displayNameInput,
+            },
+            {
+              onSuccess: (updatedData) => {
+                utils.mailbox.members.list.setData({ mailboxSlug }, (oldData) => {
+                  if (!oldData) return oldData;
+                  return oldData.map((m) =>
+                    m.id === member.id
+                      ? {
+                          ...m,
+                          role: updatedData.role,
+                          keywords: updatedData.keywords,
+                          displayName: updatedData.displayName,
+                        }
+                      : m,
+                  );
+                });
+                resolve();
+              },
+              onError: reject,
+            },
+          );
+        });
+      },
+      successMessage: "Team member updated successfully",
+      errorMessage: "Failed to update team member",
+    },
+  );
 
   useEffect(() => {
-    setKeywordsInput(member.keywords.join(", "));
-    setRole(member.role);
-    setLocalKeywords(member.keywords);
-    setDisplayNameInput(member.displayName || "");
-  }, [member.keywords, member.role, member.displayName]);
-
-  const { mutate: updateTeamMember } = api.mailbox.members.update.useMutation({
-    onSuccess: (data) => {
-      utils.mailbox.members.list.setData({ mailboxSlug }, (oldData) => {
-        if (!oldData) return oldData;
-        return oldData.map((m) =>
-          m.id === member.id
-            ? {
-                ...m,
-                role: data.role,
-                keywords: data.keywords,
-                displayName: data.displayName,
-              }
-            : m,
-        );
-      });
-    },
-    onError: (error) => {
-      toast({
-        title: "Failed to update team member",
-        description: error.message,
-        variant: "destructive",
-      });
-
-      setKeywordsInput(member.keywords.join(", "));
-      setRole(member.role);
-      setDisplayNameInput(member.displayName || "");
-    },
-  });
-
-  // Debounced function for keyword updates
-  const debouncedUpdateKeywords = useDebouncedCallback((newKeywords: string[]) => {
-    updateTeamMember({
-      mailboxSlug,
-      userId: member.id,
-      role,
-      keywords: newKeywords,
+    handleReset({
+      keywordsInput: member.keywords.join(", "),
+      role: member.role,
+      localKeywords: member.keywords,
+      displayNameInput: member.displayName || "",
     });
-  }, 800);
-
-  const debouncedUpdateDisplayName = useDebouncedCallback((newDisplayName: string) => {
-    updateTeamMember({
-      mailboxSlug,
-      userId: member.id,
-      displayName: newDisplayName,
-    });
-  }, 800);
+  }, [member.keywords, member.role, member.displayName, handleReset]);
 
   const handleRoleChange = (newRole: UserRole) => {
-    setRole(newRole);
+    const newKeywords = newRole !== "nonCore" ? [] : currentData.localKeywords;
 
-    const newKeywords = newRole !== "nonCore" ? [] : localKeywords;
-
-    if (newRole !== "nonCore") {
-      setKeywordsInput("");
-      setLocalKeywords([]);
-    }
-
-    updateTeamMember({
-      mailboxSlug,
-      userId: member.id,
+    updateData({
       role: newRole,
-      keywords: newKeywords,
+      keywordsInput: newRole !== "nonCore" ? "" : currentData.keywordsInput,
+      localKeywords: newKeywords,
     });
   };
 
   const handleKeywordsChange = (value: string) => {
-    setKeywordsInput(value);
     const newKeywords = value
       .split(",")
       .map((k) => k.trim())
       .filter(Boolean);
-    setLocalKeywords(newKeywords);
-    debouncedUpdateKeywords(newKeywords);
+
+    updateData({
+      keywordsInput: value,
+      localKeywords: newKeywords,
+    });
   };
 
   const handleDisplayNameChange = (value: string) => {
-    setDisplayNameInput(value);
-    debouncedUpdateDisplayName(value);
+    updateData({ displayNameInput: value });
   };
 
   return (
-    <TableRow>
+    <TableRow className={isDirty ? "bg-orange-50 dark:bg-orange-950/20" : ""}>
       <TableCell>{member.email || ""}</TableCell>
       <TableCell>
         <Input
-          value={displayNameInput}
+          value={currentData.displayNameInput}
           onChange={(e) => handleDisplayNameChange(e.target.value)}
           placeholder="Enter display name"
           className="w-full max-w-sm"
         />
       </TableCell>
       <TableCell>
-        <Select value={role} onValueChange={(value: UserRole) => handleRoleChange(value)}>
+        <Select value={currentData.role} onValueChange={(value: UserRole) => handleRoleChange(value)}>
           <SelectTrigger className="w-[180px]">
             <SelectValue placeholder="Role" />
           </SelectTrigger>
@@ -148,11 +137,23 @@ const TeamMemberRow = ({ member, mailboxSlug }: TeamMemberRowProps) => {
       </TableCell>
       <TableCell>
         <Input
-          value={keywordsInput}
+          value={currentData.keywordsInput}
           onChange={(e) => handleKeywordsChange(e.target.value)}
           placeholder="Enter keywords separated by commas"
-          className={role === "nonCore" ? "" : "invisible"}
+          className={currentData.role === "nonCore" ? "" : "invisible"}
         />
+      </TableCell>
+      <TableCell>
+        {isDirty && (
+          <div className="flex items-center gap-2">
+            <Button variant="ghost" size="sm" onClick={handleCancel} disabled={isLoading}>
+              Cancel
+            </Button>
+            <Button size="sm" onClick={handleSave} disabled={isLoading}>
+              {isLoading ? "Saving..." : "Save"}
+            </Button>
+          </div>
+        )}
       </TableCell>
     </TableRow>
   );

--- a/app/(dashboard)/mailboxes/[mailbox_slug]/settings/team/teamSetting.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/settings/team/teamSetting.tsx
@@ -30,6 +30,7 @@ const TeamSetting = ({ mailboxSlug }: TeamSettingProps) => {
                 <TableHead>Name</TableHead>
                 <TableHead className="w-[180px]">Support role</TableHead>
                 <TableHead className="min-w-[200px]">Auto-assign keywords</TableHead>
+                <TableHead className="w-[150px]">Actions</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>

--- a/components/hooks/useManualSave.ts
+++ b/components/hooks/useManualSave.ts
@@ -1,0 +1,104 @@
+import { useCallback, useState } from "react";
+import { toast } from "./use-toast";
+
+export interface UseManualSaveOptions<T> {
+  onSave: (data: T) => Promise<void>;
+  onSuccess?: () => void;
+  onError?: (error: Error) => void;
+  successMessage?: string;
+  errorMessage?: string;
+}
+
+export interface UseManualSaveReturn<T> {
+  currentData: T;
+  originalData: T;
+  isDirty: boolean;
+  isLoading: boolean;
+  error: Error | null;
+  updateData: (updates: Partial<T>) => void;
+  setData: (data: T) => void;
+  handleSave: () => Promise<void>;
+  handleCancel: () => void;
+  handleReset: (newOriginalData: T) => void;
+}
+
+export function useManualSave<T extends Record<string, any>>(
+  initialData: T,
+  options: UseManualSaveOptions<T>,
+): UseManualSaveReturn<T> {
+  const [originalData, setOriginalData] = useState<T>(initialData);
+  const [currentData, setCurrentData] = useState<T>(initialData);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const isDirty = JSON.stringify(currentData) !== JSON.stringify(originalData);
+
+  const updateData = useCallback((updates: Partial<T>) => {
+    setCurrentData((prev) => ({ ...prev, ...updates }));
+    setError(null);
+  }, []);
+
+  const setData = useCallback((data: T) => {
+    setCurrentData(data);
+    setError(null);
+  }, []);
+
+  const handleSave = useCallback(async () => {
+    if (!isDirty) return;
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      await options.onSave(currentData);
+      setOriginalData(currentData);
+
+      if (options.successMessage) {
+        toast({
+          title: "Success",
+          description: options.successMessage,
+        });
+      }
+
+      options.onSuccess?.();
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error("An error occurred");
+      setError(error);
+
+      const errorMessage = options.errorMessage || error.message;
+      toast({
+        title: "Error",
+        description: errorMessage,
+        variant: "destructive",
+      });
+
+      options.onError?.(error);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [currentData, isDirty, options]);
+
+  const handleCancel = useCallback(() => {
+    setCurrentData(originalData);
+    setError(null);
+  }, [originalData]);
+
+  const handleReset = useCallback((newOriginalData: T) => {
+    setOriginalData(newOriginalData);
+    setCurrentData(newOriginalData);
+    setError(null);
+  }, []);
+
+  return {
+    currentData,
+    originalData,
+    isDirty,
+    isLoading,
+    error,
+    updateData,
+    setData,
+    handleSave,
+    handleCancel,
+    handleReset,
+  };
+}

--- a/components/ui/saveableForm.tsx
+++ b/components/ui/saveableForm.tsx
@@ -1,0 +1,53 @@
+import { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+import { Button } from "./button";
+
+export interface SaveableFormProps {
+  isDirty: boolean;
+  isLoading: boolean;
+  onSave: () => void;
+  onCancel: () => void;
+  children: ReactNode;
+  saveText?: string;
+  cancelText?: string;
+  showUnsavedIndicator?: boolean;
+  className?: string;
+  disabled?: boolean;
+}
+
+export function SaveableForm({
+  isDirty,
+  isLoading,
+  onSave,
+  onCancel,
+  children,
+  saveText = "Save Changes",
+  cancelText = "Cancel",
+  showUnsavedIndicator = true,
+  className,
+  disabled = false,
+}: SaveableFormProps) {
+  return (
+    <div className={cn("space-y-6", className)}>
+      <div className="relative">{children}</div>
+
+      {isDirty && (
+        <div className="flex items-center justify-between p-4 bg-orange-50 dark:bg-orange-950/20 border border-orange-200 dark:border-orange-800 rounded-lg">
+          <div className="flex items-center gap-2">
+            <div className="h-2 w-2 bg-orange-500 rounded-full" />
+            <span className="text-sm text-orange-700 dark:text-orange-300">You have unsaved changes</span>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <Button variant="ghost" size="sm" onClick={onCancel} disabled={isLoading || disabled}>
+              {cancelText}
+            </Button>
+            <Button size="sm" onClick={onSave} disabled={isLoading || disabled}>
+              {isLoading ? "Saving..." : saveText}
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Problem
Settings forms used auto-save with 2-second debounced callbacks, creating poor UX where:
- Users had no control / visibility over when changes were saved
- No visual feedback indicated save status  
- Users couldn't cancel changes before they were applied
- Confusing refresh-based updates with unclear timing

## Solution
Replaced auto-save pattern with manual save controls across all settings:
- Added explicit "Save Changes" and "Cancel" buttons
- Implemented visual indicators for unsaved changes (orange highlighting)
- Added loading states and success/error feedback
- Users now have full control over when changes are applied

## Affected Areas
- Mailbox name settings
- Customer VIP configuration  
- Auto-close settings
- Chat widget configuration
- Theme customization
- Team member management

## Result
Settings now provide a modern, user-friendly experience with clear save/cancel controls and immediate feedback.

### Screenshots

#### Before

https://github.com/user-attachments/assets/231089ef-627a-449e-9771-eed1b2c8a403

#### After

**Mailbox Name update page**

https://github.com/user-attachments/assets/6ccc1f23-ed0e-4856-a2d2-d82ad3fa146f

**VIP settings update page**

https://github.com/user-attachments/assets/7befa754-2b29-4049-97de-a57030691883

**Theme settings page**

https://github.com/user-attachments/assets/b0196007-57a0-4748-a1ac-706821a21b5c



