### PR TITLE
feat: support anonymous conversation messages retrieval

### DIFF
--- a/components/widget/Conversation.tsx
+++ b/components/widget/Conversation.tsx
@@ -168,7 +168,7 @@ export default function Conversation({
       }
       return null;
     },
-    enabled: !!conversationSlug && !!token && !isNewConversation && !isAnonymous,
+    enabled: !!conversationSlug && !!token && !isNewConversation,
   });
 
   const conversationMessages = conversation?.messages.filter((message) =>


### PR DESCRIPTION
### Overview
Builds on PR #393  to complete anonymous session functionality by enabling anonymous users to retrieve their conversation's messages history. Currently, when anonymous users click on a conversation, they're left with a blank conversation.

### What's New
Anonymous users can now access their saved conversation messages

### Changes
Frontend: Enable conversation fetching for anonymous users
Backend: Add support for anonymousSessionId-based conversation retrieval alongside existing email-based authentication

### Impact
Completes the anonymous session feature set introduced in PR #393, providing full conversation persistence and retrieval for anonymous users.

### Before

https://github.com/user-attachments/assets/8db7bfcb-9531-4910-8c1c-b99d5eb5ce2c

### After

https://github.com/user-attachments/assets/33cf033c-53ab-4f15-964c-6c4c71544268

