### PR TITLE
feature: add in conversation search for all the conversations

### DIFF
--- a/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/conversation/messageItem.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/conversation/messageItem.tsx
@@ -154,7 +154,7 @@ const MessageItem = ({
         className: "lg:prose-base prose-sm **:text-foreground! **:bg-transparent!",
         searchQuery,
       }),
-    [message.body, message.type, isAIMessage, searchQuery],
+    [message.body, message.type, isAIMessage, isChatMessage, searchQuery],
   );
 
   const splitMergedMutation = api.mailbox.conversations.splitMerged.useMutation({

--- a/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/conversation/messageThread.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/conversation/messageThread.tsx
@@ -10,10 +10,12 @@ export const MessageThread = ({
   conversation,
   onPreviewAttachment,
   mailboxSlug,
+  searchQuery,
 }: {
   conversation: ConversationWithNewMessages;
   onPreviewAttachment: (message: Message, index: number) => void;
   mailboxSlug: string;
+  searchQuery?: string;
 }) => {
   return (
     <div className="flex h-full flex-col">
@@ -34,17 +36,19 @@ export const MessageThread = ({
               initialExpanded={index === conversation.messages.length - 1}
             />
           ) : (
-            <MessageItem
-              key={`${message.type}-${message.id}`}
-              message={message}
-              mailboxSlug={mailboxSlug}
-              conversation={conversation}
-              onPreviewAttachment={
-                message.type === "message" && message.files.length
-                  ? (index) => onPreviewAttachment(message, index)
-                  : undefined
-              }
-            />
+            <div key={`${message.type}-${message.id}`} data-message-id={message.id}>
+              <MessageItem
+                message={message}
+                mailboxSlug={mailboxSlug}
+                conversation={conversation}
+                searchQuery={searchQuery}
+                onPreviewAttachment={
+                  message.type === "message" && message.files.length
+                    ? (index) => onPreviewAttachment(message, index)
+                    : undefined
+                }
+              />
+            </div>
           ),
         )}
         {conversation.summary && conversation.summary.length > 0 && (

--- a/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/conversation/renderMessageBody.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/conversation/renderMessageBody.tsx
@@ -33,7 +33,7 @@ export const highlightSearchTerm = (text: string, searchTerm: string): string =>
   const regex = new RegExp(`(${searchTerm.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")})`, "gi");
   return text.replace(
     regex,
-    '<mark class="bg-blue-100 dark:bg-blue-900/50 text-blue-900 dark:text-blue-100 rounded px-1 py-0.5 font-medium">$1</mark>',
+    '<mark class="bg-yellow-200 dark:bg-yellow-900/70 text-yellow-900 dark:text-yellow-100 rounded px-1 py-0.5 font-semibold border border-yellow-300 dark:border-yellow-700">$1</mark>',
   );
 };
 
@@ -72,7 +72,11 @@ export const renderMessageBody = ({
 }) => {
   if (isMarkdown) {
     return {
-      mainContent: <MessageMarkdown className={cn(className, "prose")}>{body}</MessageMarkdown>,
+      mainContent: (
+        <MessageMarkdown className={cn(className, "prose")} searchQuery={searchQuery}>
+          {body}
+        </MessageMarkdown>
+      ),
       quotedContext: null,
     };
   }

--- a/components/messageMarkdown.tsx
+++ b/components/messageMarkdown.tsx
@@ -1,5 +1,5 @@
-import ReactMarkdown from "react-markdown";
 import React from "react";
+import ReactMarkdown from "react-markdown";
 
 const rehypeAddWbrAfterSlash = () => {
   return (tree: any) => {
@@ -141,15 +141,15 @@ export default function MessageMarkdown({ children, className, components, searc
 
   if (searchQuery) {
     const highlightText = (text: string) => {
-      if (!searchQuery || !text || typeof text !== 'string') return text;
-      
+      if (!searchQuery || !text || typeof text !== "string") return text;
+
       const regex = new RegExp(`(${searchQuery.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")})`, "gi");
       const parts = text.split(regex);
-      
+
       return parts.map((part, index) => {
         if (regex.test(part)) {
           return (
-            <mark 
+            <mark
               key={index}
               className="bg-yellow-200 dark:bg-yellow-900/70 text-yellow-900 dark:text-yellow-100 rounded px-1 py-0.5 font-semibold border border-yellow-300 dark:border-yellow-700"
             >
@@ -163,26 +163,26 @@ export default function MessageMarkdown({ children, className, components, searc
 
     const createTextHighlighter = (Component: any) => {
       return ({ children, ...props }: any) => {
-        if (typeof children === 'string') {
+        if (typeof children === "string") {
           return React.createElement(Component, props, highlightText(children));
         }
         return React.createElement(Component, props, children);
       };
     };
 
-    customComponents.p = createTextHighlighter('p');
-    customComponents.span = createTextHighlighter('span');
-    customComponents.strong = createTextHighlighter('strong');
-    customComponents.em = createTextHighlighter('em');
-    customComponents.li = createTextHighlighter('li');
-    customComponents.h1 = createTextHighlighter('h1');
-    customComponents.h2 = createTextHighlighter('h2');
-    customComponents.h3 = createTextHighlighter('h3');
-    customComponents.h4 = createTextHighlighter('h4');
-    customComponents.h5 = createTextHighlighter('h5');
-    customComponents.h6 = createTextHighlighter('h6');
-    customComponents.blockquote = createTextHighlighter('blockquote');
-    customComponents.code = createTextHighlighter('code');
+    customComponents.p = createTextHighlighter("p");
+    customComponents.span = createTextHighlighter("span");
+    customComponents.strong = createTextHighlighter("strong");
+    customComponents.em = createTextHighlighter("em");
+    customComponents.li = createTextHighlighter("li");
+    customComponents.h1 = createTextHighlighter("h1");
+    customComponents.h2 = createTextHighlighter("h2");
+    customComponents.h3 = createTextHighlighter("h3");
+    customComponents.h4 = createTextHighlighter("h4");
+    customComponents.h5 = createTextHighlighter("h5");
+    customComponents.h6 = createTextHighlighter("h6");
+    customComponents.blockquote = createTextHighlighter("blockquote");
+    customComponents.code = createTextHighlighter("code");
   }
 
   return (


### PR DESCRIPTION

## Features

### Smart Message Navigation

- Shows "X of Y matches" (messageItems in which word is found) with dedicated next/previous navigation
- Auto-scrolls and centers each message containing search results
- Keyboard shortcuts: Enter (next), Shift+Enter (previous), Escape (close)

### Conversation-Scoped search

-Searches only within conversation messages and sender names, 
- Ignores sidebar, navigation, and UI elements that clutter browser search results. 
- Focuses user attention on relevant conversation content

## Why It's better than browser search?

Browser search treats conversations like static web pages - it highlights random UI text, navigation elements, and buttons alongside actual conversation content. This creates noise and makes it hard to find what you're actually looking for.
The in-conversation search understands the conversation structure - it knows what's a message, who sent it, and how to navigate between relevant results. Instead of 47 random highlights across buttons and menus, you get "3 of 8 matches" in actual conversation content with smart navigation between them.


Bottomline the user can quickly find relevant text without getting distracted by irrelevant page elements or losing context while jumping between matches.

## Video showing the feature

https://github.com/user-attachments/assets/062d6525-e119-47ab-9346-75f95685c0f5

