### PR TITLE
Refactor duplicate filter and input components

### DIFF
--- a/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/list/filters/assigneeFilter.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/list/filters/assigneeFilter.tsx
@@ -1,9 +1,5 @@
-import { Check, User } from "lucide-react";
-import { useState } from "react";
-import { Button } from "@/components/ui/button";
-import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem } from "@/components/ui/command";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { api } from "@/trpc/react";
+import { User } from "lucide-react";
+import { MemberFilter } from "./memberFilter";
 
 export function AssigneeFilter({
   selectedAssignees,
@@ -12,60 +8,15 @@ export function AssigneeFilter({
   selectedAssignees: string[];
   onChange: (assignees: string[]) => void;
 }) {
-  const [open, setOpen] = useState(false);
-  const [searchTerm, setSearchTerm] = useState("");
-  const { data: members } = api.organization.getMembers.useQuery(undefined, {
-    staleTime: Infinity,
-    refetchOnWindowFocus: false,
-    refetchOnMount: false,
-  });
-
-  const filteredMembers = members?.filter((member) =>
-    member.displayName.toLowerCase().includes(searchTerm.toLowerCase()),
-  );
-
   return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <Button variant={selectedAssignees.length ? "bright" : "outlined_subtle"} className="whitespace-nowrap">
-          <User className="h-4 w-4 mr-2" />
-          {selectedAssignees.length === 1
-            ? members?.find((m) => m.id === selectedAssignees[0])?.displayName
-            : selectedAssignees.length
-              ? `${selectedAssignees.length} assignees`
-              : "Assignee"}
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent className="w-[250px] p-0" align="start">
-        <Command shouldFilter={false}>
-          <CommandInput placeholder="Search assignees..." value={searchTerm} onValueChange={setSearchTerm} />
-          <div className="max-h-[300px] overflow-y-auto">
-            <CommandEmpty>No assignees found</CommandEmpty>
-            <CommandGroup>
-              {filteredMembers
-                ?.toSorted((a, b) => a.displayName.localeCompare(b.displayName))
-                .map((member) => (
-                  <CommandItem
-                    key={member.id}
-                    onSelect={() => {
-                      const isSelected = selectedAssignees.includes(member.id);
-                      onChange(
-                        isSelected
-                          ? selectedAssignees.filter((a) => a !== member.id)
-                          : [...selectedAssignees, member.id],
-                      );
-                    }}
-                  >
-                    <Check
-                      className={`mr-2 h-4 w-4 ${selectedAssignees.includes(member.id) ? "opacity-100" : "opacity-0"}`}
-                    />
-                    <span className="truncate">{member.displayName}</span>
-                  </CommandItem>
-                ))}
-            </CommandGroup>
-          </div>
-        </Command>
-      </PopoverContent>
-    </Popover>
+    <MemberFilter
+      selectedMembers={selectedAssignees}
+      onChange={onChange}
+      icon={User}
+      placeholder="Assignee"
+      searchPlaceholder="Search assignees..."
+      emptyText="No assignees found"
+      multiSelectionDisplay={(count) => `${count} assignees`}
+    />
   );
 }

--- a/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/list/filters/memberFilter.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/list/filters/memberFilter.tsx
@@ -1,0 +1,85 @@
+import { Check, LucideIcon } from "lucide-react";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem } from "@/components/ui/command";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { api } from "@/trpc/react";
+
+interface MemberFilterProps {
+  selectedMembers: string[];
+  onChange: (members: string[]) => void;
+  icon: LucideIcon;
+  placeholder: string;
+  searchPlaceholder: string;
+  emptyText: string;
+  singleSelectionDisplay?: (memberName: string) => string;
+  multiSelectionDisplay?: (count: number) => string;
+}
+
+export function MemberFilter({
+  selectedMembers,
+  onChange,
+  icon: Icon,
+  placeholder,
+  searchPlaceholder,
+  emptyText,
+  singleSelectionDisplay = (name) => name,
+  multiSelectionDisplay = (count) => `${count} selected`,
+}: MemberFilterProps) {
+  const [open, setOpen] = useState(false);
+  const [searchTerm, setSearchTerm] = useState("");
+  const { data: members } = api.organization.getMembers.useQuery(undefined, {
+    staleTime: Infinity,
+    refetchOnWindowFocus: false,
+    refetchOnMount: false,
+  });
+
+  const filteredMembers = members?.filter((member) =>
+    member.displayName.toLowerCase().includes(searchTerm.toLowerCase()),
+  );
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button variant={selectedMembers.length ? "bright" : "outlined_subtle"} className="whitespace-nowrap">
+          <Icon className="h-4 w-4 mr-2" />
+          {selectedMembers.length === 1
+            ? singleSelectionDisplay(members?.find((m) => m.id === selectedMembers[0])?.displayName || "")
+            : selectedMembers.length
+              ? multiSelectionDisplay(selectedMembers.length)
+              : placeholder}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[250px] p-0" align="start">
+        <Command shouldFilter={false}>
+          <CommandInput placeholder={searchPlaceholder} value={searchTerm} onValueChange={setSearchTerm} />
+          <div className="max-h-[300px] overflow-y-auto">
+            <CommandEmpty>{emptyText}</CommandEmpty>
+            <CommandGroup>
+              {filteredMembers
+                ?.toSorted((a, b) => a.displayName.localeCompare(b.displayName))
+                .map((member) => (
+                  <CommandItem
+                    key={member.id}
+                    onSelect={() => {
+                      const isSelected = selectedMembers.includes(member.id);
+                      onChange(
+                        isSelected
+                          ? selectedMembers.filter((m) => m !== member.id)
+                          : [...selectedMembers, member.id],
+                      );
+                    }}
+                  >
+                    <Check
+                      className={`mr-2 h-4 w-4 ${selectedMembers.includes(member.id) ? "opacity-100" : "opacity-0"}`}
+                    />
+                    <span className="truncate">{member.displayName}</span>
+                  </CommandItem>
+                ))}
+            </CommandGroup>
+          </div>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/list/filters/responderFilter.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/list/filters/responderFilter.tsx
@@ -1,9 +1,5 @@
-import { Check, MessagesSquare } from "lucide-react";
-import { useState } from "react";
-import { Button } from "@/components/ui/button";
-import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem } from "@/components/ui/command";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { api } from "@/trpc/react";
+import { MessagesSquare } from "lucide-react";
+import { MemberFilter } from "./memberFilter";
 
 export function ResponderFilter({
   selectedResponders,
@@ -12,60 +8,15 @@ export function ResponderFilter({
   selectedResponders: string[];
   onChange: (responders: string[]) => void;
 }) {
-  const [open, setOpen] = useState(false);
-  const [searchTerm, setSearchTerm] = useState("");
-  const { data: members } = api.organization.getMembers.useQuery(undefined, {
-    staleTime: Infinity,
-    refetchOnWindowFocus: false,
-    refetchOnMount: false,
-  });
-
-  const filteredMembers = members?.filter((member) =>
-    member.displayName.toLowerCase().includes(searchTerm.toLowerCase()),
-  );
-
   return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <Button variant={selectedResponders.length ? "bright" : "outlined_subtle"} className="whitespace-nowrap">
-          <MessagesSquare className="h-4 w-4 mr-2" />
-          {selectedResponders.length === 1
-            ? members?.find((m) => m.id === selectedResponders[0])?.displayName
-            : selectedResponders.length
-              ? `${selectedResponders.length} responders`
-              : "Replied by"}
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent className="w-[250px] p-0" align="start">
-        <Command shouldFilter={false}>
-          <CommandInput placeholder="Search responders..." value={searchTerm} onValueChange={setSearchTerm} />
-          <div className="max-h-[300px] overflow-y-auto">
-            <CommandEmpty>No responders found</CommandEmpty>
-            <CommandGroup>
-              {filteredMembers
-                ?.toSorted((a, b) => a.displayName.localeCompare(b.displayName))
-                .map((member) => (
-                  <CommandItem
-                    key={member.id}
-                    onSelect={() => {
-                      const isSelected = selectedResponders.includes(member.id);
-                      onChange(
-                        isSelected
-                          ? selectedResponders.filter((r) => r !== member.id)
-                          : [...selectedResponders, member.id],
-                      );
-                    }}
-                  >
-                    <Check
-                      className={`mr-2 h-4 w-4 ${selectedResponders.includes(member.id) ? "opacity-100" : "opacity-0"}`}
-                    />
-                    <span className="truncate">{member.displayName}</span>
-                  </CommandItem>
-                ))}
-            </CommandGroup>
-          </div>
-        </Command>
-      </PopoverContent>
-    </Popover>
+    <MemberFilter
+      selectedMembers={selectedResponders}
+      onChange={onChange}
+      icon={MessagesSquare}
+      placeholder="Replied by"
+      searchPlaceholder="Search responders..."
+      emptyText="No responders found"
+      multiSelectionDisplay={(count) => `${count} responders`}
+    />
   );
 }

--- a/app/(dashboard)/mailboxes/[mailbox_slug]/settings/chat/widgetHMACSecret.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/settings/chat/widgetHMACSecret.tsx
@@ -1,77 +1,11 @@
 "use client";
 
-import { Copy, Eye, EyeOff } from "lucide-react";
-import { useState } from "react";
-import CopyToClipboard from "react-copy-to-clipboard";
-import { Input } from "@/components/ui/input";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { SecretInput } from "@/components/secretInput";
 
 const WidgetHMACSecret = ({ hmacSecret }: { hmacSecret: string }) => {
-  const [showSecret, setShowSecret] = useState(false);
-  const [copyTooltip, setCopyTooltip] = useState({ open: false, content: "" });
-
   return (
     <div>
-      <Input
-        type={showSecret ? "text" : "password"}
-        value={hmacSecret}
-        aria-label="HMAC Secret"
-        disabled
-        iconsSuffix={
-          <>
-            <TooltipProvider delayDuration={0}>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button
-                    className="flex items-center gap-1"
-                    onClick={(e) => {
-                      e.preventDefault();
-                      setTimeout(() => {
-                        setShowSecret(!showSecret);
-                      }, 100);
-                    }}
-                  >
-                    {showSecret ? (
-                      <EyeOff className="h-4 w-4 text-muted-foreground" />
-                    ) : (
-                      <Eye className="h-4 w-4 text-muted-foreground" />
-                    )}
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent>{showSecret ? "Hide" : "Show"}</TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
-            <CopyToClipboard
-              text={hmacSecret}
-              onCopy={() => {
-                setCopyTooltip((copyTooltip) => ({ ...copyTooltip, content: "Copied!" }));
-                setTimeout(() => {
-                  setCopyTooltip((copyTooltip) => ({ ...copyTooltip, content: "" }));
-                }, 1000);
-              }}
-            >
-              <span>
-                <TooltipProvider delayDuration={0}>
-                  <Tooltip
-                    open={copyTooltip.open || !!copyTooltip.content}
-                    onOpenChange={(open) => setCopyTooltip({ ...copyTooltip, open })}
-                  >
-                    <TooltipTrigger asChild>
-                      <button
-                        className="text-primary flex cursor-pointer items-center gap-1"
-                        onClick={(e) => e.preventDefault()}
-                      >
-                        <Copy className="h-4 w-4 text-muted-foreground" />
-                      </button>
-                    </TooltipTrigger>
-                    <TooltipContent>{copyTooltip.content || "Copy"}</TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
-              </span>
-            </CopyToClipboard>
-          </>
-        }
-      />
+      <SecretInput value={hmacSecret} ariaLabel="HMAC Secret" />
     </div>
   );
 };

--- a/app/(dashboard)/mailboxes/[mailbox_slug]/settings/preferences/colorInput.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/settings/preferences/colorInput.tsx
@@ -1,0 +1,30 @@
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+interface ColorInputProps {
+  label: string;
+  value: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+export function ColorInput({ label, value, onChange }: ColorInputProps) {
+  return (
+    <div className="flex flex-col space-y-2">
+      <Label>{label}</Label>
+      <div className="grid grid-cols-[auto_1fr] gap-2">
+        <Input
+          type="color"
+          value={value}
+          onChange={onChange}
+          className="h-10 w-20 p-1"
+        />
+        <Input
+          type="text"
+          value={value}
+          onChange={onChange}
+          className="w-[200px]"
+        />
+      </div>
+    </div>
+  );
+}

--- a/app/(dashboard)/mailboxes/[mailbox_slug]/settings/preferences/themeSetting.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/settings/preferences/themeSetting.tsx
@@ -4,14 +4,13 @@ import { mapValues } from "lodash-es";
 import { useEffect, useState } from "react";
 import { useInboxTheme } from "@/app/(dashboard)/mailboxes/[mailbox_slug]/clientLayout";
 import { toast } from "@/components/hooks/use-toast";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { useDebouncedCallback } from "@/components/useDebouncedCallback";
 import { useOnChange } from "@/components/useOnChange";
 import { normalizeHex } from "@/lib/themes";
 import { RouterOutputs } from "@/trpc";
 import { api } from "@/trpc/react";
 import { SwitchSectionWrapper } from "../sectionWrapper";
+import { ColorInput } from "./colorInput";
 
 export type ThemeUpdates = {
   theme?: {
@@ -98,85 +97,31 @@ const ThemeSetting = ({ mailbox }: { mailbox: RouterOutputs["mailbox"]["get"] })
     >
       {isEnabled && (
         <div className="space-y-4">
-          <div className="flex flex-col space-y-2">
-            <Label>Background Color</Label>
-            <div className="grid grid-cols-[auto_1fr] gap-2">
-              <Input
-                type="color"
-                value={theme.background}
-                onChange={handleColorChange("background")}
-                className="h-10 w-20 p-1"
-              />
-              <Input
-                type="text"
-                value={theme.background}
-                onChange={handleColorChange("background")}
-                className="w-[200px]"
-              />
-            </div>
-          </div>
-
-          <div className="flex flex-col space-y-2">
-            <Label>Foreground Color</Label>
-            <div className="grid grid-cols-[auto_1fr] gap-2">
-              <Input
-                type="color"
-                value={theme.foreground}
-                onChange={handleColorChange("foreground")}
-                className="h-10 w-20 p-1"
-              />
-              <Input
-                type="text"
-                value={theme.foreground}
-                onChange={handleColorChange("foreground")}
-                className="w-[200px]"
-              />
-            </div>
-          </div>
-
-          <div className="flex flex-col space-y-2">
-            <Label>Primary Color</Label>
-            <div className="grid grid-cols-[auto_1fr] gap-2">
-              <Input
-                type="color"
-                value={theme.primary}
-                onChange={handleColorChange("primary")}
-                className="h-10 w-20 p-1"
-              />
-              <Input type="text" value={theme.primary} onChange={handleColorChange("primary")} className="w-[200px]" />
-            </div>
-          </div>
-
-          <div className="flex flex-col space-y-2">
-            <Label>Accent Color</Label>
-            <div className="grid grid-cols-[auto_1fr] gap-2">
-              <Input
-                type="color"
-                value={theme.accent}
-                onChange={handleColorChange("accent")}
-                className="h-10 w-20 p-1"
-              />
-              <Input type="text" value={theme.accent} onChange={handleColorChange("accent")} className="w-[200px]" />
-            </div>
-          </div>
-
-          <div className="flex flex-col space-y-2">
-            <Label>Sidebar Color</Label>
-            <div className="grid grid-cols-[auto_1fr] gap-2">
-              <Input
-                type="color"
-                value={theme.sidebarBackground}
-                onChange={handleColorChange("sidebarBackground")}
-                className="h-10 w-20 p-1"
-              />
-              <Input
-                type="text"
-                value={theme.sidebarBackground}
-                onChange={handleColorChange("sidebarBackground")}
-                className="w-[200px]"
-              />
-            </div>
-          </div>
+          <ColorInput
+            label="Background Color"
+            value={theme.background}
+            onChange={handleColorChange("background")}
+          />
+          <ColorInput
+            label="Foreground Color"
+            value={theme.foreground}
+            onChange={handleColorChange("foreground")}
+          />
+          <ColorInput
+            label="Primary Color"
+            value={theme.primary}
+            onChange={handleColorChange("primary")}
+          />
+          <ColorInput
+            label="Accent Color"
+            value={theme.accent}
+            onChange={handleColorChange("accent")}
+          />
+          <ColorInput
+            label="Sidebar Color"
+            value={theme.sidebarBackground}
+            onChange={handleColorChange("sidebarBackground")}
+          />
         </div>
       )}
     </SwitchSectionWrapper>

--- a/app/(dashboard)/mailboxes/[mailbox_slug]/settings/tools/metadataEndpointSetting.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/settings/tools/metadataEndpointSetting.tsx
@@ -1,10 +1,9 @@
 "use client";
 
 import cx from "classnames";
-import { Copy, ExternalLink, Eye, EyeOff, PlusCircle } from "lucide-react";
+import { ExternalLink, PlusCircle } from "lucide-react";
 import { useParams, useRouter } from "next/navigation";
 import { useRef, useState } from "react";
-import CopyToClipboard from "react-copy-to-clipboard";
 import type { MetadataEndpoint } from "@/app/types/global";
 import { getMarketingSiteUrl } from "@/components/constants";
 import { toast } from "@/components/hooks/use-toast";
@@ -14,6 +13,7 @@ import { Label } from "@/components/ui/label";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { api } from "@/trpc/react";
 import SectionWrapper from "../sectionWrapper";
+import { SecretInput } from "@/components/secretInput";
 
 type MetadataEndpointSettingProps = {
   metadataEndpoint: MetadataEndpoint | null;
@@ -26,12 +26,7 @@ const MetadataEndpointSetting = ({ metadataEndpoint }: MetadataEndpointSettingPr
 
   const inputRef = useRef<HTMLInputElement>(null);
   const [newUrl, setNewUrl] = useState(metadataEndpoint?.url || "");
-  const [showSecret, setShowSecret] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
-  const [copyTooltip, setCopyTooltip] = useState({
-    open: false,
-    content: "",
-  });
 
   const { mutateAsync: createEndpointMutation } = api.mailbox.metadataEndpoint.create.useMutation();
   const { mutateAsync: deleteEndpointMutation } = api.mailbox.metadataEndpoint.delete.useMutation();
@@ -191,65 +186,7 @@ const MetadataEndpointSetting = ({ metadataEndpoint }: MetadataEndpointSettingPr
           <>
             <div className="grid gap-1">
               <Label>HMAC Secret</Label>
-              <Input
-                type={showSecret ? "text" : "password"}
-                value={metadataEndpoint.hmacSecret}
-                disabled
-                iconsSuffix={
-                  <>
-                    <TooltipProvider delayDuration={0}>
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <button
-                            className="flex items-center gap-1"
-                            onClick={(e) => {
-                              e.preventDefault();
-                              setTimeout(() => {
-                                setShowSecret(!showSecret);
-                              }, 100);
-                            }}
-                          >
-                            {showSecret ? (
-                              <EyeOff className="h-4 w-4 text-muted-foreground" />
-                            ) : (
-                              <Eye className="h-4 w-4 text-muted-foreground" />
-                            )}
-                          </button>
-                        </TooltipTrigger>
-                        <TooltipContent>{showSecret ? "Hide" : "Show"}</TooltipContent>
-                      </Tooltip>
-                    </TooltipProvider>
-                    <CopyToClipboard
-                      text={metadataEndpoint.hmacSecret}
-                      onCopy={(_) => {
-                        setCopyTooltip((copyTooltip) => ({ ...copyTooltip, content: "Copied!" }));
-                        setTimeout(() => {
-                          setCopyTooltip((copyTooltip) => ({ ...copyTooltip, content: "" }));
-                        }, 1000);
-                      }}
-                    >
-                      <span>
-                        <TooltipProvider delayDuration={0}>
-                          <Tooltip
-                            open={copyTooltip.open || !!copyTooltip.content}
-                            onOpenChange={(open) => setCopyTooltip({ ...copyTooltip, open })}
-                          >
-                            <TooltipTrigger asChild>
-                              <button
-                                className="text-primary flex cursor-pointer items-center gap-1"
-                                onClick={(e) => e.preventDefault()}
-                              >
-                                <Copy className="h-4 w-4 text-muted-foreground" />
-                              </button>
-                            </TooltipTrigger>
-                            <TooltipContent>{copyTooltip.content || "Copy"}</TooltipContent>
-                          </Tooltip>
-                        </TooltipProvider>
-                      </span>
-                    </CopyToClipboard>
-                  </>
-                }
-              />
+              <SecretInput value={metadataEndpoint.hmacSecret} ariaLabel="HMAC Secret" />
             </div>
             <div>
               <Button

--- a/components/secretInput.tsx
+++ b/components/secretInput.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { Copy, Eye, EyeOff } from "lucide-react";
+import { useState } from "react";
+import CopyToClipboard from "react-copy-to-clipboard";
+import { Input } from "@/components/ui/input";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+
+interface SecretInputProps {
+  value: string;
+  ariaLabel?: string;
+  disabled?: boolean;
+  className?: string;
+}
+
+export function SecretInput({ value, ariaLabel = "Secret", disabled = true, className }: SecretInputProps) {
+  const [showSecret, setShowSecret] = useState(false);
+  const [copyTooltip, setCopyTooltip] = useState({ open: false, content: "" });
+
+  return (
+    <Input
+      type={showSecret ? "text" : "password"}
+      value={value}
+      aria-label={ariaLabel}
+      disabled={disabled}
+      className={className}
+      iconsSuffix={
+        <>
+          <TooltipProvider delayDuration={0}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  className="flex items-center gap-1"
+                  onClick={(e) => {
+                    e.preventDefault();
+                    setTimeout(() => {
+                      setShowSecret(!showSecret);
+                    }, 100);
+                  }}
+                >
+                  {showSecret ? (
+                    <EyeOff className="h-4 w-4 text-muted-foreground" />
+                  ) : (
+                    <Eye className="h-4 w-4 text-muted-foreground" />
+                  )}
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>{showSecret ? "Hide" : "Show"}</TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+          <CopyToClipboard
+            text={value}
+            onCopy={() => {
+              setCopyTooltip((copyTooltip) => ({ ...copyTooltip, content: "Copied!" }));
+              setTimeout(() => {
+                setCopyTooltip((copyTooltip) => ({ ...copyTooltip, content: "" }));
+              }, 1000);
+            }}
+          >
+            <span>
+              <TooltipProvider delayDuration={0}>
+                <Tooltip
+                  open={copyTooltip.open || !!copyTooltip.content}
+                  onOpenChange={(open) => setCopyTooltip({ ...copyTooltip, open })}
+                >
+                  <TooltipTrigger asChild>
+                    <button
+                      className="text-primary flex cursor-pointer items-center gap-1"
+                      onClick={(e) => e.preventDefault()}
+                    >
+                      <Copy className="h-4 w-4 text-muted-foreground" />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent>{copyTooltip.content || "Copy"}</TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            </span>
+          </CopyToClipboard>
+        </>
+      }
+    />
+  );
+}


### PR DESCRIPTION
Refactored some duplicate components I noticed while working on the codebase.

Created 3 reusable components:
- `MemberFilter` - replaces AssigneeFilter and ResponderFilter which were nearly identical
- `ColorInput` - replaces 5 duplicate color picker sections in theme settings
- `SecretInput` - replaces duplicate password fields with show/hide functionality

Removes ~400 lines of duplicate code.