### PR TITLE
Optimize HumanizedTime performance with single shared time hook

### DIFF
--- a/app/(dashboard)/mailboxes/[mailbox_slug]/settings/team/teamMemberRow.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/settings/team/teamMemberRow.tsx
@@ -128,12 +128,12 @@ const TeamMemberRow = ({ member, mailboxSlug }: TeamMemberRowProps) => {
     if (member.displayName?.trim()) {
       return member.displayName;
     }
-    
+
     if (member.email) {
-      const emailUsername = member.email.split('@')[0];
+      const emailUsername = member.email.split("@")[0];
       return emailUsername || member.email;
     }
-    
+
     return "?";
   };
 

--- a/components/hooks/use-now.ts
+++ b/components/hooks/use-now.ts
@@ -1,0 +1,42 @@
+import { useEffect, useState } from "react";
+
+let now = new Date();
+const listeners = new Set<(date: Date) => void>();
+let intervalId: NodeJS.Timeout | null = null;
+
+const startTimer = () => {
+  if (intervalId) return;
+  intervalId = setInterval(() => {
+    now = new Date();
+    for (const listener of listeners) {
+      listener(now);
+    }
+  }, 60000);
+};
+
+const stopTimer = () => {
+  if (intervalId) {
+    clearInterval(intervalId);
+    intervalId = null;
+  }
+};
+
+export function useNow() {
+  const [nowValue, setNowValue] = useState(now);
+
+  useEffect(() => {
+    const callback = (newNow: Date) => setNowValue(newNow);
+
+    listeners.add(callback);
+    startTimer();
+
+    return () => {
+      listeners.delete(callback);
+      if (listeners.size === 0) {
+        stopTimer();
+      }
+    };
+  }, []);
+
+  return nowValue;
+}


### PR DESCRIPTION
### The Problem
Our `HumanizedTime` components were being a bit... greedy. Each component was spinning up its own `setInterval` timer to update every minute. With 10+ components on some pages, we had 10+ timers running simultaneously. When you leave a certain page, these timers run for 60 seconds and may also lead to memory leaks.

### The Solution
Refactored to use a shared `useNow` hook that implements a classic **pub/sub pattern** (think town crier shouting the time to everyone instead of each person having their own clock).

**Key changes:**
- **New:** `components/hooks/use-now.ts` - Single shared timer with smart start/stop
- **Updated:** `components/humanizedTime.tsx` - Now uses the hook, much cleaner code
- **Performance:** N timers → 1 timer
- **Smart:** Timer only runs when components are actually mounted
- **Zero breaking changes:** Same API, same functionality

Instead of every component managing its own timer, we now have:
- One "publisher" (the shared timer) that updates the current time
- Multiple "subscribers" (the components) that get notified of updates
- Auto-cleanup: Timer stops when no one's listening

**Before:** 10 components = 10 timers 
**After:** 10 components = 1 timer

All existing usage stays exactly the same - the optimization is completely under the hood!