### PR TITLE
fix: add validation for cc/bcc email on the frontend and backend for conversation replies

### DIFF
--- a/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/conversation/messageActions.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/conversation/messageActions.tsx
@@ -16,6 +16,7 @@ import { ToastAction } from "@/components/ui/toast";
 import { useBreakpoint } from "@/components/useBreakpoint";
 import useKeyboardShortcut from "@/components/useKeyboardShortcut";
 import { useSession } from "@/components/useSession";
+import { isValidEmailAddress, parseEmailList } from "@/components/utils/email";
 import { getFirstName, hasDisplayName } from "@/lib/auth/authUtils";
 import { captureExceptionAndLog } from "@/lib/shared/sentry";
 import { cn } from "@/lib/utils";
@@ -180,8 +181,29 @@ export const MessageActions = () => {
     setSending(true);
 
     try {
-      const cc_emails = draftedEmail.cc.replace(/\s/g, "").split(",");
-      const bcc_emails = draftedEmail.bcc.replace(/\s/g, "").split(",");
+      const cc_emails = parseEmailList(draftedEmail.cc);
+      const bcc_emails = parseEmailList(draftedEmail.bcc);
+
+      for (const email of cc_emails) {
+        if (!isValidEmailAddress(email)) {
+          setSending(false);
+          return toast({
+            variant: "destructive",
+            title: `Invalid CC email address: ${email}`,
+          });
+        }
+      }
+
+      for (const email of bcc_emails) {
+        if (!isValidEmailAddress(email)) {
+          setSending(false);
+          return toast({
+            variant: "destructive",
+            title: `Invalid BCC email address: ${email}`,
+          });
+        }
+      }
+
       const conversationSlug = conversation.slug;
 
       const lastUserMessage = conversation.messages

--- a/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/list/newConversationModal.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/list/newConversationModal.tsx
@@ -14,7 +14,7 @@ import { Button } from "@/components/ui/button";
 import { DialogFooter } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { isValidEmailAddress } from "@/components/utils/email";
+import { isValidEmailAddress, parseEmailList } from "@/components/utils/email";
 import { captureExceptionAndLog } from "@/lib/shared/sentry";
 import { RouterInputs } from "@/trpc";
 import { api } from "@/trpc/react";
@@ -274,19 +274,6 @@ const CcAndBccInfo = ({
     </div>
   );
 };
-
-/**
- * @example
- * // "1@test.com, 2@test.com" -> ["1@test.com", "2@test.com"]
- * const emails = parseEmailList("1@test.com, 2@test.com");
- */
-const parseEmailList = (list: string) =>
-  list
-    .trim()
-    .replace(/\s/g, "")
-    .split(",")
-    .filter(Boolean)
-    .map((emailAdress) => emailAdress.trim());
 
 const Wrapper = ({ mailboxSlug, conversationSlug, onSubmit }: Props) => (
   <FileUploadProvider mailboxSlug={mailboxSlug} conversationSlug={conversationSlug}>

--- a/components/utils/email.ts
+++ b/components/utils/email.ts
@@ -1,1 +1,14 @@
 export const isValidEmailAddress = (email: string) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/u.test(email);
+
+/**
+ * @example
+ * // "1@test.com, 2@test.com" -> ["1@test.com", "2@test.com"]
+ * const emails = parseEmailList("1@test.com, 2@test.com");
+ */
+export const parseEmailList = (list: string) =>
+  list
+    .trim()
+    .replace(/\s/g, "")
+    .split(",")
+    .filter(Boolean)
+    .map((emailAdress) => emailAdress.trim());

--- a/trpc/router/mailbox/conversations/messages.ts
+++ b/trpc/router/mailbox/conversations/messages.ts
@@ -64,8 +64,8 @@ export const messagesRouter = {
       z.object({
         message: z.string(),
         fileSlugs: z.array(z.string()),
-        cc: z.array(z.string()),
-        bcc: z.array(z.string()),
+        cc: z.array(z.string().email().or(z.literal(""))).transform((arr) => arr.filter(Boolean)),
+        bcc: z.array(z.string().email().or(z.literal(""))).transform((arr) => arr.filter(Boolean)),
         shouldAutoAssign: z.boolean().optional().default(true),
         shouldClose: z.boolean().optional().default(true),
         responseToId: z.number().nullable(),
@@ -77,10 +77,8 @@ export const messagesRouter = {
         user: ctx.user,
         message,
         fileSlugs,
-        // TODO Add proper email validation on the frontend and backend using Zod,
-        // similar to how the new conversation modal does it.
-        cc: cc.filter(Boolean),
-        bcc: bcc.filter(Boolean),
+        cc,
+        bcc,
         shouldAutoAssign,
         close: shouldClose,
         responseToId,


### PR DESCRIPTION
Hello!

This patch addresses a leftover todo to add validation for cc/bcc email in the reply functionality.

Prev:
<img width="1512" alt="Screenshot 2025-06-22 at 6 08 24 PM" src="https://github.com/user-attachments/assets/ae15850c-875a-45e9-9e33-af956fbe5a58" />
<img width="1512" alt="Screenshot 2025-06-22 at 6 08 01 PM" src="https://github.com/user-attachments/assets/b0407eb9-dbb4-4ec0-8dcf-26392878c025" />

After:
<img width="1512" alt="Screenshot 2025-06-22 at 6 11 01 PM" src="https://github.com/user-attachments/assets/f5603f87-ab81-42d2-b083-0527e425df37" />
<img width="1512" alt="Screenshot 2025-06-22 at 6 11 09 PM" src="https://github.com/user-attachments/assets/e63b3f96-a73a-43b1-b009-37909b6ae817" />
