### PR TITLE
enhancement: move the toolbar for formatting such that it doesnt cover the cursor

### DIFF
--- a/components/tiptap/toolbar.tsx
+++ b/components/tiptap/toolbar.tsx
@@ -308,7 +308,7 @@ const Toolbar = ({
       <div
         className={cn(
           isAboveMd
-            ? "flex flex-wrap gap-1 absolute z-10 bottom-16 mb-2 right-3 rounded-t border rounded-sm bg-background p-1"
+            ? `flex flex-wrap gap-1 absolute z-10 ${open ? "bottom-11" : "bottom-16"} mb-2 right-3 rounded-t border rounded-sm bg-background p-1`
             : "flex flex-1 min-w-0 gap-1",
           open && isAboveMd && "left-3",
           !open && !isAboveMd && "hidden",


### PR DESCRIPTION
This is a small tweak to how the formatting toolbar appears when typing:

Before (it covers the cursor and the typed content):

https://github.com/user-attachments/assets/471f84cd-e20d-496d-a7ab-de75564a6eff

After (small amount of spacing added when toolbar is expanded):

https://github.com/user-attachments/assets/843ffe3f-98a1-4e12-8b86-5e3b361b1587

