### PR TITLE
perf: hoist members query to reduce unnecessary re-renders

### DIFF
--- a/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/conversation/assignPopoverButton.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/conversation/assignPopoverButton.tsx
@@ -2,6 +2,7 @@
 
 import { Bot, User } from "lucide-react";
 import { useEffect, useState } from "react";
+import { useOrganizationMembers } from "@/app/(dashboard)/mailboxes/[mailbox_slug]/organizationMembersContext";
 import { AssigneeOption, AssignSelect } from "@/components/assignSelect";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
@@ -11,7 +12,6 @@ import useKeyboardShortcut from "@/components/useKeyboardShortcut";
 import { useSession } from "@/components/useSession";
 import { getFullName } from "@/lib/auth/authUtils";
 import { cn } from "@/lib/utils";
-import { api } from "@/trpc/react";
 import { useAssignTicket } from "./useAssignTicket";
 
 export const AssignPopoverButton = ({
@@ -23,11 +23,7 @@ export const AssignPopoverButton = ({
 }) => {
   const { assignTicket } = useAssignTicket();
   const [showAssignModal, setShowAssignModal] = useState(false);
-  const { data: orgMembers = [] } = api.organization.getMembers.useQuery(undefined, {
-    staleTime: Infinity,
-    refetchOnWindowFocus: false,
-    refetchOnMount: false,
-  });
+  const { members: orgMembers = [] } = useOrganizationMembers();
   const { user: currentUser } = useSession() ?? {};
 
   const currentAssignee = orgMembers.find((m) => m.id === initialAssignedToId) ?? null;
@@ -103,6 +99,7 @@ export const AssignPopoverButton = ({
               onChange={handleAssignSelectChange}
               aiOption
               aiOptionSelected={!!(assignedTo && "ai" in assignedTo)}
+              members={orgMembers}
             />
 
             <div className="grid gap-1">

--- a/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/list/conversationList.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/list/conversationList.tsx
@@ -43,6 +43,12 @@ export const List = () => {
     },
   });
 
+  const { data: members } = api.organization.getMembers.useQuery(undefined, {
+    staleTime: Infinity,
+    refetchOnWindowFocus: false,
+    refetchOnMount: false,
+  });
+
   const conversations = conversationListData?.conversations ?? [];
   const defaultSort = conversationListData?.defaultSort;
 
@@ -243,6 +249,7 @@ export const List = () => {
               onSelectConversation={navigateToConversation}
               isSelected={allConversationsSelected || selectedConversations.includes(conversation.id)}
               onToggleSelect={() => toggleConversation(conversation.id)}
+              members={members}
             />
           ))}
           <div ref={loadMoreRef} />

--- a/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/list/conversationListItem.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/list/conversationListItem.tsx
@@ -9,7 +9,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { formatCurrency } from "@/components/utils/currency";
 import { cn } from "@/lib/utils";
-import { api } from "@/trpc/react";
+import { type RouterOutputs } from "@/trpc";
 import { useConversationsListInput } from "../shared/queries";
 import { useConversationListContext } from "./conversationListContext";
 import { highlightKeywords } from "./filters/highlightKeywords";
@@ -22,6 +22,7 @@ type ConversationListItemProps = {
   onSelectConversation: (slug: string) => void;
   isSelected: boolean;
   onToggleSelect: () => void;
+  members: RouterOutputs["organization"]["getMembers"] | undefined;
 };
 
 export const ConversationListItem = ({
@@ -30,6 +31,7 @@ export const ConversationListItem = ({
   onSelectConversation,
   isSelected,
   onToggleSelect,
+  members,
 }: ConversationListItemProps) => {
   const listItemRef = useRef<HTMLAnchorElement>(null);
   const { mailboxSlug } = useConversationListContext();
@@ -118,6 +120,7 @@ export const ConversationListItem = ({
                       className="flex items-center gap-1 text-muted-foreground text-[10px] md:text-xs"
                       assignedToId={conversation.assignedToId}
                       assignedToAI={conversation.assignedToAI}
+                      members={members}
                     />
                   )}
                   <div className="text-muted-foreground text-[10px] md:text-xs">
@@ -157,17 +160,13 @@ const AssignedToLabel = ({
   assignedToId,
   assignedToAI,
   className,
+  members,
 }: {
   assignedToId: string | null;
   assignedToAI?: boolean;
   className?: string;
+  members: RouterOutputs["organization"]["getMembers"] | undefined;
 }) => {
-  const { data: members } = api.organization.getMembers.useQuery(undefined, {
-    staleTime: Infinity,
-    refetchOnWindowFocus: false,
-    refetchOnMount: false,
-  });
-
   if (assignedToAI) {
     return (
       <div className={className} title="Assigned to Helper agent">

--- a/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/list/filters/assigneeFilter.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/list/filters/assigneeFilter.tsx
@@ -1,9 +1,9 @@
 import { Check, User } from "lucide-react";
 import { useState } from "react";
+import { useOrganizationMembers } from "@/app/(dashboard)/mailboxes/[mailbox_slug]/organizationMembersContext";
 import { Button } from "@/components/ui/button";
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem } from "@/components/ui/command";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { api } from "@/trpc/react";
 
 export function AssigneeFilter({
   selectedAssignees,
@@ -14,11 +14,7 @@ export function AssigneeFilter({
 }) {
   const [open, setOpen] = useState(false);
   const [searchTerm, setSearchTerm] = useState("");
-  const { data: members } = api.organization.getMembers.useQuery(undefined, {
-    staleTime: Infinity,
-    refetchOnWindowFocus: false,
-    refetchOnMount: false,
-  });
+  const { members } = useOrganizationMembers();
 
   const filteredMembers = members?.filter((member) =>
     member.displayName.toLowerCase().includes(searchTerm.toLowerCase()),

--- a/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/list/filters/responderFilter.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/list/filters/responderFilter.tsx
@@ -1,9 +1,9 @@
 import { Check, MessagesSquare } from "lucide-react";
 import { useState } from "react";
+import { useOrganizationMembers } from "@/app/(dashboard)/mailboxes/[mailbox_slug]/organizationMembersContext";
 import { Button } from "@/components/ui/button";
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem } from "@/components/ui/command";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { api } from "@/trpc/react";
 
 export function ResponderFilter({
   selectedResponders,
@@ -14,11 +14,7 @@ export function ResponderFilter({
 }) {
   const [open, setOpen] = useState(false);
   const [searchTerm, setSearchTerm] = useState("");
-  const { data: members } = api.organization.getMembers.useQuery(undefined, {
-    staleTime: Infinity,
-    refetchOnWindowFocus: false,
-    refetchOnMount: false,
-  });
+  const { members } = useOrganizationMembers();
 
   const filteredMembers = members?.filter((member) =>
     member.displayName.toLowerCase().includes(searchTerm.toLowerCase()),

--- a/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/ticketCommandBar/index.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/ticketCommandBar/index.tsx
@@ -2,6 +2,7 @@ import { X } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { useConversationContext } from "@/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/conversation/conversationContext";
 import { useAssignTicket } from "@/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/conversation/useAssignTicket";
+import { useOrganizationMembers } from "@/app/(dashboard)/mailboxes/[mailbox_slug]/organizationMembersContext";
 import { KeyboardShortcut } from "@/components/keyboardShortcut";
 import { Button } from "@/components/ui/button";
 import { Command } from "@/components/ui/command";
@@ -35,11 +36,7 @@ export function TicketCommandBar({ open, onOpenChange, onInsertReply, onToggleCc
   const [page, setPage] = useState<"main" | "previous-replies" | "assignees" | "notes" | "github-issue">("main");
   const pageRef = useRef<string>("main");
   const { user: currentUser } = useSession() ?? {};
-  const { data: orgMembers } = api.organization.getMembers.useQuery(undefined, {
-    staleTime: Infinity,
-    refetchOnWindowFocus: false,
-    refetchOnMount: false,
-  });
+  const { members: orgMembers } = useOrganizationMembers();
   const { data: tools } = api.mailbox.conversations.tools.list.useQuery(
     { mailboxSlug, conversationSlug },
     { staleTime: Infinity, refetchOnMount: false, refetchOnWindowFocus: false, enabled: !!conversationSlug },

--- a/app/(dashboard)/mailboxes/[mailbox_slug]/layout.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/layout.tsx
@@ -2,6 +2,7 @@ import { TRPCError } from "@trpc/server";
 import { redirect } from "next/navigation";
 import { AppSidebar } from "@/app/(dashboard)/mailboxes/[mailbox_slug]/appSidebar";
 import InboxClientLayout from "@/app/(dashboard)/mailboxes/[mailbox_slug]/clientLayout";
+import { OrganizationMembersProvider } from "@/app/(dashboard)/mailboxes/[mailbox_slug]/organizationMembersContext";
 import { SidebarProvider } from "@/components/ui/sidebar";
 import { env } from "@/lib/env";
 import { HelperProvider } from "@/packages/react/dist/cjs";
@@ -21,12 +22,14 @@ export default async function InboxLayout({
     return (
       <HelperProvider host={env.AUTH_URL} mailboxSlug={mailboxSlug} showToggleButton>
         <SidebarProvider>
-          <InboxClientLayout theme={preferences?.theme}>
-            <div className="flex h-svh w-full">
-              <AppSidebar mailboxSlug={mailboxSlug} />
-              <main className="flex-1 min-w-0">{children}</main>
-            </div>
-          </InboxClientLayout>
+          <OrganizationMembersProvider>
+            <InboxClientLayout theme={preferences?.theme}>
+              <div className="flex h-svh w-full">
+                <AppSidebar mailboxSlug={mailboxSlug} />
+                <main className="flex-1 min-w-0">{children}</main>
+              </div>
+            </InboxClientLayout>
+          </OrganizationMembersProvider>
         </SidebarProvider>
       </HelperProvider>
     );

--- a/app/(dashboard)/mailboxes/[mailbox_slug]/organizationMembersContext.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/organizationMembersContext.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createContext, useContext, type ReactNode } from "react";
+import { createContext, useContext, useMemo, type ReactNode } from "react";
 import { api } from "@/trpc/react";
 
 type OrganizationMember = {
@@ -11,14 +11,16 @@ type OrganizationMember = {
 
 type OrganizationMembersContextType = {
   members: OrganizationMember[] | undefined;
+  membersById: Map<string, OrganizationMember>;
   isLoading: boolean;
+  error: unknown;
 };
 
 const OrganizationMembersContext = createContext<OrganizationMembersContextType | null>(null);
 
 export function OrganizationMembersProvider({ children }: { children: ReactNode }) {
-  const { data: members, isLoading } = api.organization.getMembers.useQuery(undefined, {
-    staleTime: Infinity,
+  const { data: members, isLoading, error } = api.organization.getMembers.useQuery(undefined, {
+    staleTime: 5 * 60 * 1000, // 5 minutes instead of Infinity
     refetchOnWindowFocus: false,
     refetchOnMount: false,
   });

--- a/app/(dashboard)/mailboxes/[mailbox_slug]/organizationMembersContext.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/organizationMembersContext.tsx
@@ -19,14 +19,30 @@ type OrganizationMembersContextType = {
 const OrganizationMembersContext = createContext<OrganizationMembersContextType | null>(null);
 
 export function OrganizationMembersProvider({ children }: { children: ReactNode }) {
-  const { data: members, isLoading, error } = api.organization.getMembers.useQuery(undefined, {
-    staleTime: 5 * 60 * 1000, // 5 minutes instead of Infinity
+  const {
+    data: members,
+    isLoading,
+    error,
+  } = api.organization.getMembers.useQuery(undefined, {
+    staleTime: 5 * 60 * 1000,
     refetchOnWindowFocus: false,
     refetchOnMount: false,
   });
 
+  const membersById = useMemo(() => {
+    const map = new Map<string, OrganizationMember>();
+    if (members) {
+      members.forEach((member) => {
+        map.set(member.id, member);
+      });
+    }
+    return map;
+  }, [members]);
+
   return (
-    <OrganizationMembersContext.Provider value={{ members, isLoading }}>{children}</OrganizationMembersContext.Provider>
+    <OrganizationMembersContext.Provider value={{ members, membersById, isLoading, error }}>
+      {children}
+    </OrganizationMembersContext.Provider>
   );
 }
 

--- a/app/(dashboard)/mailboxes/[mailbox_slug]/organizationMembersContext.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/organizationMembersContext.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { createContext, useContext, type ReactNode } from "react";
+import { api } from "@/trpc/react";
+
+type OrganizationMember = {
+  id: string;
+  displayName: string;
+  email: string | null;
+};
+
+type OrganizationMembersContextType = {
+  members: OrganizationMember[] | undefined;
+  isLoading: boolean;
+};
+
+const OrganizationMembersContext = createContext<OrganizationMembersContextType | null>(null);
+
+export function OrganizationMembersProvider({ children }: { children: ReactNode }) {
+  const { data: members, isLoading } = api.organization.getMembers.useQuery(undefined, {
+    staleTime: Infinity,
+    refetchOnWindowFocus: false,
+    refetchOnMount: false,
+  });
+
+  return (
+    <OrganizationMembersContext.Provider value={{ members, isLoading }}>{children}</OrganizationMembersContext.Provider>
+  );
+}
+
+export function useOrganizationMembers() {
+  const context = useContext(OrganizationMembersContext);
+  if (!context) {
+    throw new Error("useOrganizationMembers must be used within an OrganizationMembersProvider");
+  }
+  return context;
+}

--- a/components/assignSelect.tsx
+++ b/components/assignSelect.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button";
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem } from "@/components/ui/command";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { useSession } from "@/components/useSession";
-import { api } from "@/trpc/react";
+import { type RouterOutputs } from "@/trpc";
 
 export type AssigneeOption =
   | {
@@ -18,21 +18,17 @@ interface AssignSelectProps {
   onChange: (assignee: AssigneeOption | null) => void;
   aiOption?: boolean;
   aiOptionSelected?: boolean;
+  members: RouterOutputs["organization"]["getMembers"] | undefined;
 }
 
-export const AssignSelect = ({ selectedUserId, onChange, aiOption, aiOptionSelected }: AssignSelectProps) => {
+export const AssignSelect = ({ selectedUserId, onChange, aiOption, aiOptionSelected, members }: AssignSelectProps) => {
   const { user } = useSession() ?? {};
   const [open, setOpen] = useState(false);
   const [searchTerm, setSearchTerm] = useState("");
   const [highlightedIndex, setHighlightedIndex] = useState(0);
-  const { data: orgMembers } = api.organization.getMembers.useQuery(undefined, {
-    staleTime: Infinity,
-    refetchOnWindowFocus: false,
-    refetchOnMount: false,
-  });
 
   const sortedMembers =
-    orgMembers?.sort((a, b) => {
+    members?.sort((a, b) => {
       if (a.id === user?.id) return -1;
       if (b.id === user?.id) return 1;
       return a.displayName.localeCompare(b.displayName);


### PR DESCRIPTION
- Move api.organization.getMembers query from AssignedToLabel to parent ConversationList component
- Pass members data down as props to ConversationListItem components
- Eliminates redundant useQuery hooks that caused unnecessary re-renders
- Each AssignedToLabel no longer manages its own query state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved performance and consistency by fetching organization member data once and sharing it across conversation list items.
  - Streamlined display of user assignment by passing member data directly to relevant components.
  - Introduced a context provider to supply organization member data throughout the mailbox layout for better state management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->