### PR TITLE
chore(Tech Debt): remove deprecated forwardRef

### DIFF
--- a/components/loadingSpinner.tsx
+++ b/components/loadingSpinner.tsx
@@ -17,24 +17,23 @@ const spinnerVariants = cva("relative", {
 
 interface LoadingSpinnerProps extends React.HTMLAttributes<HTMLDivElement>, VariantProps<typeof spinnerVariants> {
   spinnerClassName?: string;
+  ref?: React.Ref<HTMLDivElement>;
 }
 
-const LoadingSpinner = React.forwardRef<HTMLDivElement, LoadingSpinnerProps>(
-  ({ className, spinnerClassName, size, ...props }, ref) => {
-    return (
-      <div className={cn(spinnerVariants({ size }), className)} ref={ref} {...props}>
-        <div
-          className={cn(
-            spinnerVariants({ size }),
-            "border-primary absolute inset-0 animate-spin rounded-full border",
-            spinnerClassName,
-            "border-t-transparent",
-          )}
-        />
-      </div>
-    );
-  },
-);
+const LoadingSpinner = ({ className, spinnerClassName, size, ref, ...props }: LoadingSpinnerProps) => {
+  return (
+    <div className={cn(spinnerVariants({ size }), className)} ref={ref} {...props}>
+      <div
+        className={cn(
+          spinnerVariants({ size }),
+          "border-primary absolute inset-0 animate-spin rounded-full border",
+          spinnerClassName,
+          "border-t-transparent",
+        )}
+      />
+    </div>
+  );
+};
 
 LoadingSpinner.displayName = "LoadingSpinner";
 

--- a/components/tiptap/editor.tsx
+++ b/components/tiptap/editor.tsx
@@ -75,61 +75,7 @@ export type TipTapEditorRef = {
 
 type TipTapEditorPropsWithRef = TipTapEditorProps & { signature?: ReactNode; ref: React.Ref<TipTapEditorRef> };
 
-<<<<<<< chore/remove-element-ref
 const initialMentionState = { isOpen: false, position: null, range: null, selectedIndex: 0 };
-=======
-const TipTapEditor = React.forwardRef<TipTapEditorRef, TipTapEditorProps & { signature?: ReactNode }>(
-  (
-    {
-      defaultContent,
-      onUpdate,
-      onModEnter,
-      onOptionEnter,
-      onSlashKey,
-      autoFocus,
-      customToolbar,
-      enableImageUpload,
-      enableFileUpload,
-      placeholder,
-      signature,
-      editable,
-      ariaLabel,
-      className,
-      actionButtons,
-      isRecordingSupported,
-      isRecording,
-      startRecording,
-      stopRecording,
-    },
-    ref,
-  ) => {
-    const { mailboxSlug } = useConversationListContext();
-    const { data: helpArticles = [] } = api.mailbox.websites.pages.useQuery({ mailboxSlug });
-    const { isAboveMd } = useBreakpoint("md");
-    const [isMacOS, setIsMacOS] = React.useState(false);
-    const [toolbarOpen, setToolbarOpen] = React.useState(() => {
-      if (typeof window !== "undefined") {
-        return (localStorage.getItem("editorToolbarOpen") ?? "true") === "true";
-      }
-      return isAboveMd;
-    });
-    const [mentionState, setMentionState] = React.useState<{
-      isOpen: boolean;
-      position: { top: number; left: number } | null;
-      range: { from: number; to: number } | null;
-      selectedIndex: number;
-    }>(initialMentionState);
-    const mentionStateRef = useRefToLatest(mentionState);
-
-    useEffect(() => {
-      localStorage.setItem("editorToolbarOpen", String(toolbarOpen));
-    }, [toolbarOpen]);
-
-    const updateContent = useRefToLatest((editor: Editor) => {
-      const serializedContent = editor.getHTML();
-      onUpdate(serializedContent, editor.isEmpty && isEmptyContent(serializedContent));
-    });
->>>>>>> main
 
 const TipTapEditor = ({
   defaultContent,
@@ -151,7 +97,6 @@ const TipTapEditor = ({
   isRecording,
   startRecording,
   stopRecording,
-  hideDesktopToolbar,
   ref,
 }: TipTapEditorPropsWithRef) => {
   const { mailboxSlug } = useConversationListContext();
@@ -413,19 +358,6 @@ const TipTapEditor = ({
     const docText = editor.view.state.doc.textBetween(mentionState.range.from, mentionState.range.from + 1, "", "");
     if (docText !== "@") {
       setMentionState(initialMentionState);
-<<<<<<< chore/remove-element-ref
-=======
-    };
-
-    React.useEffect(() => {
-      setMentionState((state) => ({ ...state, selectedIndex: 0 }));
-    }, [mentionState.isOpen, getMentionQuery(), filteredArticles.map((a) => a.url).join(",")]);
-
-    const showActionButtons = !!actionButtons && (!toolbarOpen || isAboveMd);
-
-    if (!editor) {
-      return null;
->>>>>>> main
     }
   }, [editor, mentionState.isOpen, mentionState.range, editor?.view.state]);
 
@@ -453,6 +385,8 @@ const TipTapEditor = ({
   React.useEffect(() => {
     setMentionState((state) => ({ ...state, selectedIndex: 0 }));
   }, [mentionState.isOpen, getMentionQuery(), filteredArticles.map((a) => a.url).join(",")]);
+
+  const showActionButtons = !!actionButtons && (!toolbarOpen || isAboveMd);
 
   if (!editor) {
     return null;
@@ -506,7 +440,6 @@ const TipTapEditor = ({
             </div>
           ) : null}
         </div>
-<<<<<<< chore/remove-element-ref
 
         {editor && (
           <BubbleMenu
@@ -541,32 +474,9 @@ const TipTapEditor = ({
               isRecordingSupported,
               startRecording,
               stopRecording,
-              hideDesktopToolbar,
+              hasActionButtons: showActionButtons,
             }}
           />
-=======
-        <div className="flex w-full justify-between md:justify-start">
-          <div className="w-full md:w-auto">
-            <Toolbar
-              {...{
-                open: toolbarOpen,
-                setOpen: setToolbarOpen,
-                editor,
-                uploadFileAttachments,
-                uploadInlineImages,
-                customToolbar,
-                enableImageUpload,
-                enableFileUpload,
-                isRecording,
-                isRecordingSupported,
-                startRecording,
-                stopRecording,
-                hasActionButtons: showActionButtons,
-              }}
-            />
-          </div>
-          {showActionButtons ? <div className="flex-shrink-0 whitespace-nowrap">{actionButtons}</div> : null}
->>>>>>> main
         </div>
         {toolbarOpen && !isAboveMd ? null : <div className="flex-shrink-0 whitespace-nowrap">{actionButtons}</div>}
       </div>

--- a/components/tiptap/editor.tsx
+++ b/components/tiptap/editor.tsx
@@ -74,419 +74,415 @@ export type TipTapEditorRef = {
   editor: Editor | null;
 };
 
+type TipTapEditorPropsWithRef = TipTapEditorProps & { signature?: ReactNode; ref: React.Ref<TipTapEditorRef> };
+
 const initialMentionState = { isOpen: false, position: null, range: null, selectedIndex: 0 };
 
-const TipTapEditor = React.forwardRef<TipTapEditorRef, TipTapEditorProps & { signature?: ReactNode }>(
-  (
-    {
-      defaultContent,
-      onUpdate,
-      onModEnter,
-      onOptionEnter,
-      onSlashKey,
-      autoFocus,
-      customToolbar,
-      enableImageUpload,
-      enableFileUpload,
-      placeholder,
-      signature,
-      editable,
-      ariaLabel,
-      className,
-      actionButtons,
-      hideDesktopToolbar,
-      isRecordingSupported,
-      isRecording,
-      startRecording,
-      stopRecording,
-    },
-    ref,
-  ) => {
-    const { mailboxSlug } = useConversationListContext();
-    const { data: helpArticles = [] } = api.mailbox.websites.pages.useQuery({ mailboxSlug });
-    const { isAboveMd } = useBreakpoint("md");
-    const [isMacOS, setIsMacOS] = React.useState(false);
-    const [toolbarOpen, setToolbarOpen] = React.useState(() => {
-      if (typeof window !== "undefined") {
-        return (localStorage.getItem("editorToolbarOpen") ?? "true") === "true";
-      }
-      return isAboveMd;
-    });
-    const [mentionState, setMentionState] = React.useState<{
-      isOpen: boolean;
-      position: { top: number; left: number } | null;
-      range: { from: number; to: number } | null;
-      selectedIndex: number;
-    }>(initialMentionState);
-    const mentionStateRef = useRefToLatest(mentionState);
+const TipTapEditor = ({
+  defaultContent,
+  onUpdate,
+  onModEnter,
+  onOptionEnter,
+  onSlashKey,
+  autoFocus,
+  customToolbar,
+  enableImageUpload,
+  enableFileUpload,
+  placeholder,
+  signature,
+  editable,
+  ariaLabel,
+  className,
+  actionButtons,
+  isRecordingSupported,
+  isRecording,
+  startRecording,
+  stopRecording,
+  hideDesktopToolbar,
+  ref,
+}: TipTapEditorPropsWithRef) => {
+  const { mailboxSlug } = useConversationListContext();
+  const { data: helpArticles = [] } = api.mailbox.websites.pages.useQuery({ mailboxSlug });
+  const { isAboveMd } = useBreakpoint("md");
+  const [isMacOS, setIsMacOS] = React.useState(false);
+  const [toolbarOpen, setToolbarOpen] = React.useState(() => {
+    if (typeof window !== "undefined") {
+      return (localStorage.getItem("editorToolbarOpen") ?? "true") === "true";
+    }
+    return isAboveMd;
+  });
+  const [mentionState, setMentionState] = React.useState<{
+    isOpen: boolean;
+    position: { top: number; left: number } | null;
+    range: { from: number; to: number } | null;
+    selectedIndex: number;
+  }>(initialMentionState);
+  const mentionStateRef = useRefToLatest(mentionState);
 
-    useEffect(() => {
-      localStorage.setItem("editorToolbarOpen", String(toolbarOpen));
-    }, [toolbarOpen]);
+  useEffect(() => {
+    localStorage.setItem("editorToolbarOpen", String(toolbarOpen));
+  }, [toolbarOpen]);
 
-    const updateContent = useRefToLatest((editor: Editor) => {
-      const serializedContent = editor.getHTML();
-      onUpdate(serializedContent, editor.isEmpty && isEmptyContent(serializedContent));
-    });
+  const updateContent = useRefToLatest((editor: Editor) => {
+    const serializedContent = editor.getHTML();
+    onUpdate(serializedContent, editor.isEmpty && isEmptyContent(serializedContent));
+  });
 
-    const editor = useEditor({
-      immediatelyRender: false,
-      editable: editable !== undefined ? editable : true,
-      extensions: [
-        StarterKit.configure({ hardBreak: false }),
-        HardBreakIgnoreModEnter,
-        Underline,
-        NonInclusiveLink,
-        Image,
-        ...(placeholder ? [Placeholder.configure({ placeholder })] : []),
-      ],
-      editorProps: {
-        handleKeyDown: (view, event) => {
-          // Handle mention state keyboard navigation
-          if (mentionStateRef.current.isOpen) {
-            if (event.key === "Escape") {
-              setMentionState(initialMentionState);
-              return true;
-            }
-            if (event.key === "ArrowDown") {
-              event.preventDefault();
-              setMentionState((s) => ({ ...s, selectedIndex: Math.min(s.selectedIndex + 1, helpArticles.length - 1) }));
-              return true;
-            }
-            if (event.key === "ArrowUp") {
-              event.preventDefault();
-              setMentionState((s) => ({ ...s, selectedIndex: Math.max(s.selectedIndex - 1, 0) }));
-              return true;
-            }
-            if (event.key === "Enter") {
-              event.preventDefault();
-              const article = filteredArticles[mentionStateRef.current.selectedIndex];
-              if (article) handleSelectArticle(article);
-              return true;
-            }
-            if (event.key === "ArrowRight") {
-              setMentionState(initialMentionState);
-              return true;
-            }
-          }
-
-          // Handle Mod+Enter and Option+Enter
-          if (
-            (isMacOS && event.metaKey && event.key === "Enter") ||
-            (!isMacOS && event.ctrlKey && event.key === "Enter")
-          ) {
-            if (onModEnter) {
-              event.preventDefault();
-              onModEnter();
-              return true;
-            }
-          }
-
-          if (event.altKey && event.key === "Enter") {
-            if (onOptionEnter) {
-              event.preventDefault();
-              onOptionEnter();
-              return true;
-            }
-          }
-
-          // Handle slash key to focus command bar
-          if (event.key === "/") {
-            const { $from } = view.state.selection;
-            const isStartOfLine = $from.parentOffset === 0;
-            if (isStartOfLine) {
-              event.preventDefault();
-              onSlashKey?.();
-              return true;
-            }
-          }
-
-          return false;
-        },
-        handleTextInput(view, from, _to, text) {
-          if (text === "@") {
-            setTimeout(() => {
-              const pos = getCaretPosition(view, editorContentContainerRef);
-              setMentionState({
-                isOpen: true,
-                position: pos,
-                range: { from, to: from + 1 },
-                selectedIndex: 0,
-              });
-            }, 0);
-          }
-          return false;
-        },
-        handleDOMEvents: {
-          paste(view, event: Event) {
-            if (!(event instanceof ClipboardEvent)) return false;
-            const files = [...(event.clipboardData?.files ?? [])];
-            if (!files.length) {
-              setTimeout(() => {
-                // Unselect the text when pasting links into that text
-                const { from, to } = view.state.selection;
-                if (from !== to) {
-                  const node = view.state.doc.nodeAt(from);
-                  if (node?.marks.some((m) => m.type.name === "link")) {
-                    const transaction = view.state.tr.setSelection(TextSelection.create(view.state.doc, to));
-                    view.dispatch(transaction);
-                  }
-                }
-              }, 0);
-              return false;
-            }
-            uploadFiles.current(files);
-            event.preventDefault();
+  const editor = useEditor({
+    immediatelyRender: false,
+    editable: editable !== undefined ? editable : true,
+    extensions: [
+      StarterKit.configure({ hardBreak: false }),
+      HardBreakIgnoreModEnter,
+      Underline,
+      NonInclusiveLink,
+      Image,
+      ...(placeholder ? [Placeholder.configure({ placeholder })] : []),
+    ],
+    editorProps: {
+      handleKeyDown: (view, event) => {
+        // Handle mention state keyboard navigation
+        if (mentionStateRef.current.isOpen) {
+          if (event.key === "Escape") {
+            setMentionState(initialMentionState);
             return true;
-          },
+          }
+          if (event.key === "ArrowDown") {
+            event.preventDefault();
+            setMentionState((s) => ({ ...s, selectedIndex: Math.min(s.selectedIndex + 1, helpArticles.length - 1) }));
+            return true;
+          }
+          if (event.key === "ArrowUp") {
+            event.preventDefault();
+            setMentionState((s) => ({ ...s, selectedIndex: Math.max(s.selectedIndex - 1, 0) }));
+            return true;
+          }
+          if (event.key === "Enter") {
+            event.preventDefault();
+            const article = filteredArticles[mentionStateRef.current.selectedIndex];
+            if (article) handleSelectArticle(article);
+            return true;
+          }
+          if (event.key === "ArrowRight") {
+            setMentionState(initialMentionState);
+            return true;
+          }
+        }
+
+        // Handle Mod+Enter and Option+Enter
+        if (
+          (isMacOS && event.metaKey && event.key === "Enter") ||
+          (!isMacOS && event.ctrlKey && event.key === "Enter")
+        ) {
+          if (onModEnter) {
+            event.preventDefault();
+            onModEnter();
+            return true;
+          }
+        }
+
+        if (event.altKey && event.key === "Enter") {
+          if (onOptionEnter) {
+            event.preventDefault();
+            onOptionEnter();
+            return true;
+          }
+        }
+
+        // Handle slash key to focus command bar
+        if (event.key === "/") {
+          const { $from } = view.state.selection;
+          const isStartOfLine = $from.parentOffset === 0;
+          if (isStartOfLine) {
+            event.preventDefault();
+            onSlashKey?.();
+            return true;
+          }
+        }
+
+        return false;
+      },
+      handleTextInput(view, from, _to, text) {
+        if (text === "@") {
+          setTimeout(() => {
+            const pos = getCaretPosition(view, editorContentContainerRef);
+            setMentionState({
+              isOpen: true,
+              position: pos,
+              range: { from, to: from + 1 },
+              selectedIndex: 0,
+            });
+          }, 0);
+        }
+        return false;
+      },
+      handleDOMEvents: {
+        paste(view, event: Event) {
+          if (!(event instanceof ClipboardEvent)) return false;
+          const files = [...(event.clipboardData?.files ?? [])];
+          if (!files.length) {
+            setTimeout(() => {
+              // Unselect the text when pasting links into that text
+              const { from, to } = view.state.selection;
+              if (from !== to) {
+                const node = view.state.doc.nodeAt(from);
+                if (node?.marks.some((m) => m.type.name === "link")) {
+                  const transaction = view.state.tr.setSelection(TextSelection.create(view.state.doc, to));
+                  view.dispatch(transaction);
+                }
+              }
+            }, 0);
+            return false;
+          }
+          uploadFiles.current(files);
+          event.preventDefault();
+          return true;
         },
       },
-      content: defaultContent.content || "",
-      onUpdate: ({ editor }) => updateContent.current(editor),
-    });
+    },
+    content: defaultContent.content || "",
+    onUpdate: ({ editor }) => updateContent.current(editor),
+  });
 
-    const editorRef = useRef(editor);
-    useEffect(() => {
-      editorRef.current = editor;
-      return () => {
-        if (editor) {
-          editor.destroy();
-        }
-      };
-    }, [editor]);
-
-    const editorContentContainerRef = useRef<HTMLDivElement | null>(null);
-
-    useImperativeHandle(ref, () => ({
-      focus: () => editorRef.current?.commands.focus(),
-      scrollTo: (top: number) =>
-        editorContentContainerRef.current?.scrollTo({
-          top,
-          behavior: "smooth",
-        }),
-      editor: editorRef.current,
-    }));
-
-    const focusEditor = () => {
+  const editorRef = useRef(editor);
+  useEffect(() => {
+    editorRef.current = editor;
+    return () => {
       if (editor) {
-        editor.view.focus();
+        editor.destroy();
       }
     };
+  }, [editor]);
 
-    const { unsavedFiles, onUpload, onRetry } = useFileUpload();
-    const retryNonImageUpload = (file: File) =>
-      onRetry(file).upload.catch((message: string | null) =>
-        toast({
-          title: message ?? `Failed to upload ${file.name}`,
-          variant: "destructive",
-        }),
-      );
-    const insertFileAttachment = (file: File) =>
-      onUpload(file, { inline: false }).upload.catch((message: string | null) =>
-        toast({
-          title: message ?? `Failed to upload ${file.name}`,
-          variant: "destructive",
-        }),
-      );
-    const insertInlineImage = (file: File) => {
-      if (!editorRef.current) return;
-      const { upload, blobUrl } = onUpload(file, { inline: true });
-      editorRef.current.commands.setImage({
-        src: blobUrl,
-        upload,
-      });
-    };
-    const uploadInlineImages = (images: File[]) => {
-      for (const image of images) insertInlineImage(image);
-    };
-    const uploadFileAttachments = (nonImages: File[]) => {
-      for (const file of nonImages) insertFileAttachment(file);
-    };
-    const uploadFiles = useRefToLatest((files: File[]) => {
-      const [images, nonImages] = partition(files, (file) => imageFileTypes.includes(file.type));
-      if (enableImageUpload) uploadInlineImages(images);
-      if (enableFileUpload) uploadFileAttachments(nonImages);
+  const editorContentContainerRef = useRef<HTMLDivElement | null>(null);
+
+  useImperativeHandle(ref, () => ({
+    focus: () => editorRef.current?.commands.focus(),
+    scrollTo: (top: number) =>
+      editorContentContainerRef.current?.scrollTo({
+        top,
+        behavior: "smooth",
+      }),
+    editor: editorRef.current,
+  }));
+
+  const focusEditor = () => {
+    if (editor) {
+      editor.view.focus();
+    }
+  };
+
+  const { unsavedFiles, onUpload, onRetry } = useFileUpload();
+  const retryNonImageUpload = (file: File) =>
+    onRetry(file).upload.catch((message: string | null) =>
+      toast({
+        title: message ?? `Failed to upload ${file.name}`,
+        variant: "destructive",
+      }),
+    );
+  const insertFileAttachment = (file: File) =>
+    onUpload(file, { inline: false }).upload.catch((message: string | null) =>
+      toast({
+        title: message ?? `Failed to upload ${file.name}`,
+        variant: "destructive",
+      }),
+    );
+  const insertInlineImage = (file: File) => {
+    if (!editorRef.current) return;
+    const { upload, blobUrl } = onUpload(file, { inline: true });
+    editorRef.current.commands.setImage({
+      src: blobUrl,
+      upload,
     });
-    const attachments = unsavedFiles.filter((f) => !f.inline);
+  };
+  const uploadInlineImages = (images: File[]) => {
+    for (const image of images) insertInlineImage(image);
+  };
+  const uploadFileAttachments = (nonImages: File[]) => {
+    for (const file of nonImages) insertFileAttachment(file);
+  };
+  const uploadFiles = useRefToLatest((files: File[]) => {
+    const [images, nonImages] = partition(files, (file) => imageFileTypes.includes(file.type));
+    if (enableImageUpload) uploadInlineImages(images);
+    if (enableFileUpload) uploadFileAttachments(nonImages);
+  });
+  const attachments = unsavedFiles.filter((f) => !f.inline);
 
-    React.useEffect(() => {
-      setIsMacOS(new UAParser().getOS().name === "Mac OS");
-    }, []);
+  React.useEffect(() => {
+    setIsMacOS(new UAParser().getOS().name === "Mac OS");
+  }, []);
 
-    useEffect(() => {
-      if (editor && autoFocus) {
-        editor.commands.focus(autoFocus);
-      }
-    }, [editor, autoFocus]);
+  useEffect(() => {
+    if (editor && autoFocus) {
+      editor.commands.focus(autoFocus);
+    }
+  }, [editor, autoFocus]);
 
-    useEffect(() => {
-      if (editor && !editor.isEmpty) return;
-      if (editor) editor.commands.setContent(defaultContent.content || "");
-    }, [defaultContent, editor]);
+  useEffect(() => {
+    if (editor && !editor.isEmpty) return;
+    if (editor) editor.commands.setContent(defaultContent.content || "");
+  }, [defaultContent, editor]);
 
-    React.useEffect(() => {
-      if (!editor) return;
-      const plugin = {
-        props: {
-          handleKeyDown(view: any, event: KeyboardEvent) {
-            if (mentionState.isOpen && event.key === "Backspace") {
-              const state = view.state;
-              if (mentionState.range) {
-                const docText = state.doc.textBetween(mentionState.range.from, mentionState.range.from + 1, "", "");
-                const cursorPos = state.selection.from;
-                const query = state.doc.textBetween(mentionState.range.from + 1, cursorPos, "", "");
-                if (query === "") {
-                  setMentionState(initialMentionState);
-                  return false;
-                }
-                if (docText !== "@") {
-                  setMentionState(initialMentionState);
-                  return false;
-                }
+  React.useEffect(() => {
+    if (!editor) return;
+    const plugin = {
+      props: {
+        handleKeyDown(view: any, event: KeyboardEvent) {
+          if (mentionState.isOpen && event.key === "Backspace") {
+            const state = view.state;
+            if (mentionState.range) {
+              const docText = state.doc.textBetween(mentionState.range.from, mentionState.range.from + 1, "", "");
+              const cursorPos = state.selection.from;
+              const query = state.doc.textBetween(mentionState.range.from + 1, cursorPos, "", "");
+              if (query === "") {
+                setMentionState(initialMentionState);
                 return false;
               }
+              if (docText !== "@") {
+                setMentionState(initialMentionState);
+                return false;
+              }
+              return false;
             }
-            return false;
-          },
+          }
+          return false;
         },
-      } as const;
-      editor.view.setProps({ ...editor.view.props, ...plugin.props });
-      return () => {
-        // No-op cleanup for mock plugin
-      };
-    }, [editor, mentionState.isOpen, mentionState.range]);
-
-    React.useEffect(() => {
-      if (!editor || !mentionState.isOpen || !mentionState.range) return;
-      const docText = editor.view.state.doc.textBetween(mentionState.range.from, mentionState.range.from + 1, "", "");
-      if (docText !== "@") {
-        setMentionState(initialMentionState);
-      }
-    }, [editor, mentionState.isOpen, mentionState.range, editor?.view.state]);
-
-    const getMentionQuery = () => {
-      if (!editor || !mentionState.isOpen || !mentionState.range) return "";
-      const cursorPos = editor.view.state.selection.from;
-      if (cursorPos < mentionState.range.from + 1) return "";
-      return editor.view.state.doc.textBetween(mentionState.range.from + 1, cursorPos, "", "");
+      },
+    } as const;
+    editor.view.setProps({ ...editor.view.props, ...plugin.props });
+    return () => {
+      // No-op cleanup for mock plugin
     };
+  }, [editor, mentionState.isOpen, mentionState.range]);
 
-    const filteredArticles = helpArticles.filter((a) =>
-      a.title.toLowerCase().includes(getMentionQuery().toLowerCase()),
-    );
-
-    const handleSelectArticle = (article: { title: string; url: string }) => {
-      if (!editor || !mentionState.range) return;
-      const cursorPos = editor.view.state.selection.from;
-      editor
-        .chain()
-        .focus()
-        .deleteRange({ from: mentionState.range.from, to: cursorPos })
-        .insertContent(`<a href="${article.url}" target="_blank" rel="noopener noreferrer">${article.title}</a> `)
-        .run();
+  React.useEffect(() => {
+    if (!editor || !mentionState.isOpen || !mentionState.range) return;
+    const docText = editor.view.state.doc.textBetween(mentionState.range.from, mentionState.range.from + 1, "", "");
+    if (docText !== "@") {
       setMentionState(initialMentionState);
-    };
-
-    React.useEffect(() => {
-      setMentionState((state) => ({ ...state, selectedIndex: 0 }));
-    }, [mentionState.isOpen, getMentionQuery(), filteredArticles.map((a) => a.url).join(",")]);
-
-    if (!editor) {
-      return null;
     }
+  }, [editor, mentionState.isOpen, mentionState.range, editor?.view.state]);
 
-    return (
-      <div className={cn("relative flex flex-col gap-4", className)}>
+  const getMentionQuery = () => {
+    if (!editor || !mentionState.isOpen || !mentionState.range) return "";
+    const cursorPos = editor.view.state.selection.from;
+    if (cursorPos < mentionState.range.from + 1) return "";
+    return editor.view.state.doc.textBetween(mentionState.range.from + 1, cursorPos, "", "");
+  };
+
+  const filteredArticles = helpArticles.filter((a) => a.title.toLowerCase().includes(getMentionQuery().toLowerCase()));
+
+  const handleSelectArticle = (article: { title: string; url: string }) => {
+    if (!editor || !mentionState.range) return;
+    const cursorPos = editor.view.state.selection.from;
+    editor
+      .chain()
+      .focus()
+      .deleteRange({ from: mentionState.range.from, to: cursorPos })
+      .insertContent(`<a href="${article.url}" target="_blank" rel="noopener noreferrer">${article.title}</a> `)
+      .run();
+    setMentionState(initialMentionState);
+  };
+
+  React.useEffect(() => {
+    setMentionState((state) => ({ ...state, selectedIndex: 0 }));
+  }, [mentionState.isOpen, getMentionQuery(), filteredArticles.map((a) => a.url).join(",")]);
+
+  if (!editor) {
+    return null;
+  }
+
+  return (
+    <div className={cn("relative flex flex-col gap-4", className)}>
+      <div
+        className={cn(
+          "grow flex flex-col min-h-0 rounded border border-border bg-background",
+          toolbarOpen && isAboveMd && "pb-14",
+        )}
+        aria-label={ariaLabel}
+      >
         <div
-          className={cn(
-            "grow flex flex-col min-h-0 rounded border border-border bg-background",
-            toolbarOpen && isAboveMd && "pb-14",
-          )}
-          aria-label={ariaLabel}
+          className="flex-1 flex flex-col min-h-0 overflow-y-auto rounded-b p-3 text-sm text-foreground relative"
+          onClick={focusEditor}
+          onDragOver={(e) => e.preventDefault()}
+          onDrop={(event) => {
+            event.preventDefault();
+            const files = [...(event.dataTransfer.files ?? [])];
+            if (!files.length) return false;
+            uploadFiles.current(files);
+          }}
+          ref={editorContentContainerRef}
         >
-          <div
-            className="flex-1 flex flex-col min-h-0 overflow-y-auto rounded-b p-3 text-sm text-foreground relative"
-            onClick={focusEditor}
-            onDragOver={(e) => e.preventDefault()}
-            onDrop={(event) => {
-              event.preventDefault();
-              const files = [...(event.dataTransfer.files ?? [])];
-              if (!files.length) return false;
-              uploadFiles.current(files);
-            }}
-            ref={editorContentContainerRef}
-          >
-            <div className="grow">
-              <EditorContent editor={editor} />
+          <div className="grow">
+            <EditorContent editor={editor} />
+          </div>
+          <HelpArticlePopover
+            isOpen={mentionState.isOpen}
+            position={mentionState.position}
+            query={getMentionQuery()}
+            articles={filteredArticles}
+            selectedIndex={mentionState.selectedIndex}
+            setSelectedIndex={(index) =>
+              setMentionState((state) => ({
+                ...state,
+                selectedIndex: typeof index === "function" ? index(state.selectedIndex) : index,
+              }))
+            }
+            onSelect={handleSelectArticle}
+            onClose={() => setMentionState(initialMentionState)}
+          />
+          {signature}
+          {attachments.length > 0 ? (
+            <div className="flex w-full flex-wrap gap-2 pt-4">
+              {attachments.map((fileInfo, idx) => (
+                <FileAttachment key={idx} fileInfo={fileInfo} onRetry={retryNonImageUpload} />
+              ))}
             </div>
-            <HelpArticlePopover
-              isOpen={mentionState.isOpen}
-              position={mentionState.position}
-              query={getMentionQuery()}
-              articles={filteredArticles}
-              selectedIndex={mentionState.selectedIndex}
-              setSelectedIndex={(index) =>
-                setMentionState((state) => ({
-                  ...state,
-                  selectedIndex: typeof index === "function" ? index(state.selectedIndex) : index,
-                }))
-              }
-              onSelect={handleSelectArticle}
-              onClose={() => setMentionState(initialMentionState)}
-            />
-            {signature}
-            {attachments.length > 0 ? (
-              <div className="flex w-full flex-wrap gap-2 pt-4">
-                {attachments.map((fileInfo, idx) => (
-                  <FileAttachment key={idx} fileInfo={fileInfo} onRetry={retryNonImageUpload} />
-                ))}
-              </div>
-            ) : null}
-          </div>
+          ) : null}
+        </div>
 
-          {editor && (
-            <BubbleMenu
-              editor={editor}
-              tippyOptions={{
-                duration: 100,
-                placement: "bottom-start",
-                appendTo: editorContentContainerRef.current || "parent",
-              }}
-              shouldShow={({ editor }) =>
-                isAboveMd && editor.state.selection.content().size > 0 && !editor.isActive("image")
-              }
-              className="rounded border border-border bg-background p-2 text-xs text-muted-foreground"
-            >
-              Hint: Paste URL to create link
-            </BubbleMenu>
-          )}
-        </div>
-        <div className="flex w-full justify-between md:justify-start">
-          <div className="w-full md:w-auto">
-            <Toolbar
-              {...{
-                open: toolbarOpen,
-                setOpen: setToolbarOpen,
-                editor,
-                uploadFileAttachments,
-                uploadInlineImages,
-                customToolbar,
-                enableImageUpload,
-                enableFileUpload,
-                isRecording,
-                isRecordingSupported,
-                startRecording,
-                stopRecording,
-                hideDesktopToolbar,
-              }}
-            />
-          </div>
-          {toolbarOpen && !isAboveMd ? null : <div className="flex-shrink-0 whitespace-nowrap">{actionButtons}</div>}
-        </div>
+        {editor && (
+          <BubbleMenu
+            editor={editor}
+            tippyOptions={{
+              duration: 100,
+              placement: "bottom-start",
+              appendTo: editorContentContainerRef.current || "parent",
+            }}
+            shouldShow={({ editor }) =>
+              isAboveMd && editor.state.selection.content().size > 0 && !editor.isActive("image")
+            }
+            className="rounded border border-border bg-background p-2 text-xs text-muted-foreground"
+          >
+            Hint: Paste URL to create link
+          </BubbleMenu>
+        )}
       </div>
-    );
-  },
-);
+      <div className="flex w-full justify-between md:justify-start">
+        <div className="w-full md:w-auto">
+          <Toolbar
+            {...{
+              open: toolbarOpen,
+              setOpen: setToolbarOpen,
+              editor,
+              uploadFileAttachments,
+              uploadInlineImages,
+              customToolbar,
+              enableImageUpload,
+              enableFileUpload,
+              isRecording,
+              isRecordingSupported,
+              startRecording,
+              stopRecording,
+              hideDesktopToolbar,
+            }}
+          />
+        </div>
+        {toolbarOpen && !isAboveMd ? null : <div className="flex-shrink-0 whitespace-nowrap">{actionButtons}</div>}
+      </div>
+    </div>
+  );
+};
 
 TipTapEditor.displayName = "TipTapEditor";
 

--- a/components/tiptap/editor.tsx
+++ b/components/tiptap/editor.tsx
@@ -478,7 +478,7 @@ const TipTapEditor = ({
             }}
           />
         </div>
-        {toolbarOpen && !isAboveMd ? null : <div className="flex-shrink-0 whitespace-nowrap">{actionButtons}</div>}
+        {showActionButtons ? <div className="flex-shrink-0 whitespace-nowrap">{actionButtons}</div> : null}
       </div>
     </div>
   );

--- a/components/ui/accordion.tsx
+++ b/components/ui/accordion.tsx
@@ -7,46 +7,51 @@ import { cn } from "@/lib/utils";
 
 const Accordion = AccordionPrimitive.Root;
 
-const AccordionItem = React.forwardRef<
-  React.ComponentRef<typeof AccordionPrimitive.Item>,
-  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Item>
->(({ className, ...props }, ref) => (
-  <AccordionPrimitive.Item ref={ref} className={cn("border-b", className)} {...props} />
-));
+const AccordionItem = ({ className, ref, ...props }: React.ComponentPropsWithRef<typeof AccordionPrimitive.Item>) => {
+  return <AccordionPrimitive.Item ref={ref} className={cn("border-b", className)} {...props} />;
+};
 AccordionItem.displayName = "AccordionItem";
 
-const AccordionTrigger = React.forwardRef<
-  React.ComponentRef<typeof AccordionPrimitive.Trigger>,
-  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Trigger>
->(({ className, children, ...props }, ref) => (
-  <AccordionPrimitive.Header className="flex">
-    <AccordionPrimitive.Trigger
-      ref={ref}
-      className={cn(
-        "flex flex-1 items-center justify-between py-4 text-sm transition-all hover:underline [&[data-state=open]>svg]:rotate-180",
-        className,
-      )}
-      {...props}
-    >
-      {children}
-      <ChevronDown className="h-4 w-4 shrink-0 transition-transform duration-200" />
-    </AccordionPrimitive.Trigger>
-  </AccordionPrimitive.Header>
-));
+const AccordionTrigger = ({
+  className,
+  children,
+  ref,
+  ...props
+}: React.ComponentPropsWithRef<typeof AccordionPrimitive.Trigger>) => {
+  return (
+    <AccordionPrimitive.Header className="flex">
+      <AccordionPrimitive.Trigger
+        ref={ref}
+        className={cn(
+          "flex flex-1 items-center justify-between py-4 text-sm transition-all hover:underline [&[data-state=open]>svg]:rotate-180",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        <ChevronDown className="h-4 w-4 shrink-0 transition-transform duration-200" />
+      </AccordionPrimitive.Trigger>
+    </AccordionPrimitive.Header>
+  );
+};
 AccordionTrigger.displayName = AccordionPrimitive.Trigger.displayName;
 
-const AccordionContent = React.forwardRef<
-  React.ComponentRef<typeof AccordionPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Content>
->(({ className, children, ...props }, ref) => (
-  <AccordionPrimitive.Content
-    ref={ref}
-    className="overflow-hidden text-sm transition-all data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down"
-    {...props}
-  >
-    <div className={cn("pb-4 pt-0", className)}>{children}</div>
-  </AccordionPrimitive.Content>
-));
+const AccordionContent = ({
+  className,
+  children,
+  ref,
+  ...props
+}: React.ComponentPropsWithRef<typeof AccordionPrimitive.Content>) => {
+  return (
+    <AccordionPrimitive.Content
+      ref={ref}
+      className="overflow-hidden text-sm transition-all data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down"
+      {...props}
+    >
+      <div className={cn("pb-4 pt-0", className)}>{children}</div>
+    </AccordionPrimitive.Content>
+  );
+};
 
 AccordionContent.displayName = AccordionPrimitive.Content.displayName;
 

--- a/components/ui/accordion.tsx
+++ b/components/ui/accordion.tsx
@@ -8,7 +8,7 @@ import { cn } from "@/lib/utils";
 const Accordion = AccordionPrimitive.Root;
 
 const AccordionItem = React.forwardRef<
-  React.ElementRef<typeof AccordionPrimitive.Item>,
+  React.ComponentRef<typeof AccordionPrimitive.Item>,
   React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Item>
 >(({ className, ...props }, ref) => (
   <AccordionPrimitive.Item ref={ref} className={cn("border-b", className)} {...props} />
@@ -16,7 +16,7 @@ const AccordionItem = React.forwardRef<
 AccordionItem.displayName = "AccordionItem";
 
 const AccordionTrigger = React.forwardRef<
-  React.ElementRef<typeof AccordionPrimitive.Trigger>,
+  React.ComponentRef<typeof AccordionPrimitive.Trigger>,
   React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Trigger>
 >(({ className, children, ...props }, ref) => (
   <AccordionPrimitive.Header className="flex">
@@ -36,7 +36,7 @@ const AccordionTrigger = React.forwardRef<
 AccordionTrigger.displayName = AccordionPrimitive.Trigger.displayName;
 
 const AccordionContent = React.forwardRef<
-  React.ElementRef<typeof AccordionPrimitive.Content>,
+  React.ComponentRef<typeof AccordionPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Content>
 >(({ className, children, ...props }, ref) => (
   <AccordionPrimitive.Content

--- a/components/ui/alert.tsx
+++ b/components/ui/alert.tsx
@@ -18,26 +18,24 @@ const alertVariants = cva(
   },
 );
 
-const Alert = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof alertVariants>
->(({ className, variant, ...props }, ref) => (
-  <div ref={ref} role="alert" className={cn(alertVariants({ variant }), className)} {...props} />
-));
+const Alert = ({
+  className,
+  variant,
+  ref,
+  ...props
+}: React.ComponentPropsWithRef<"div"> & VariantProps<typeof alertVariants>) => {
+  return <div ref={ref} role="alert" className={cn(alertVariants({ variant }), className)} {...props} />;
+};
 Alert.displayName = "Alert";
 
-const AlertTitle = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLHeadingElement>>(
-  ({ className, ...props }, ref) => (
-    <h5 ref={ref} className={cn("mb-1 font-medium leading-none tracking-tight", className)} {...props} />
-  ),
-);
+const AlertTitle = ({ className, ref, ...props }: React.ComponentPropsWithRef<"h5">) => {
+  return <h5 ref={ref} className={cn("mb-1 font-medium leading-none tracking-tight", className)} {...props} />;
+};
 AlertTitle.displayName = "AlertTitle";
 
-const AlertDescription = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLParagraphElement>>(
-  ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn("text-sm [&_p]:leading-relaxed", className)} {...props} />
-  ),
-);
+const AlertDescription = ({ className, ref, ...props }: React.ComponentPropsWithRef<"div">) => {
+  return <div ref={ref} className={cn("text-sm [&_p]:leading-relaxed", className)} {...props} />;
+};
 AlertDescription.displayName = "AlertDescription";
 
 export { Alert, AlertTitle, AlertDescription };

--- a/components/ui/avatar.tsx
+++ b/components/ui/avatar.tsx
@@ -5,7 +5,7 @@ import * as React from "react";
 import { cn } from "@/lib/utils";
 
 const BaseAvatar = React.forwardRef<
-  React.ElementRef<typeof AvatarPrimitive.Root>,
+  React.ComponentRef<typeof AvatarPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Root>
 >(({ className, ...props }, ref) => (
   <AvatarPrimitive.Root
@@ -17,7 +17,7 @@ const BaseAvatar = React.forwardRef<
 BaseAvatar.displayName = AvatarPrimitive.Root.displayName;
 
 const AvatarImage = React.forwardRef<
-  React.ElementRef<typeof AvatarPrimitive.Image>,
+  React.ComponentRef<typeof AvatarPrimitive.Image>,
   React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Image>
 >(({ className, ...props }, ref) => (
   <AvatarPrimitive.Image ref={ref} className={cn("aspect-square h-full w-full", className)} {...props} />
@@ -25,7 +25,7 @@ const AvatarImage = React.forwardRef<
 AvatarImage.displayName = AvatarPrimitive.Image.displayName;
 
 const AvatarFallback = React.forwardRef<
-  React.ElementRef<typeof AvatarPrimitive.Fallback>,
+  React.ComponentRef<typeof AvatarPrimitive.Fallback>,
   React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Fallback>
 >(({ className, ...props }, ref) => (
   <AvatarPrimitive.Fallback

--- a/components/ui/avatar.tsx
+++ b/components/ui/avatar.tsx
@@ -4,36 +4,32 @@ import * as AvatarPrimitive from "@radix-ui/react-avatar";
 import * as React from "react";
 import { cn } from "@/lib/utils";
 
-const BaseAvatar = React.forwardRef<
-  React.ComponentRef<typeof AvatarPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Root>
->(({ className, ...props }, ref) => (
-  <AvatarPrimitive.Root
-    ref={ref}
-    className={cn("relative flex shrink-0 overflow-hidden rounded-full", className)}
-    {...props}
-  />
-));
+const BaseAvatar = ({ className, ref, ...props }: React.ComponentPropsWithRef<typeof AvatarPrimitive.Root>) => {
+  return (
+    <AvatarPrimitive.Root
+      ref={ref}
+      className={cn("relative flex shrink-0 overflow-hidden rounded-full", className)}
+      {...props}
+    />
+  );
+};
 BaseAvatar.displayName = AvatarPrimitive.Root.displayName;
 
-const AvatarImage = React.forwardRef<
-  React.ComponentRef<typeof AvatarPrimitive.Image>,
-  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Image>
->(({ className, ...props }, ref) => (
-  <AvatarPrimitive.Image ref={ref} className={cn("aspect-square h-full w-full", className)} {...props} />
-));
+const AvatarImage = ({ className, ref, ...props }: React.ComponentPropsWithRef<typeof AvatarPrimitive.Image>) => {
+  return <AvatarPrimitive.Image ref={ref} className={cn("aspect-square h-full w-full", className)} {...props} />;
+};
 AvatarImage.displayName = AvatarPrimitive.Image.displayName;
 
-const AvatarFallback = React.forwardRef<
-  React.ComponentRef<typeof AvatarPrimitive.Fallback>,
-  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Fallback>
->(({ className, ...props }, ref) => (
-  <AvatarPrimitive.Fallback
-    ref={ref}
-    className={cn("flex h-full w-full items-center justify-center rounded-full", className)}
-    {...props}
-  />
-));
+const AvatarFallback = ({ className, ref, ...props }: React.ComponentPropsWithRef<typeof AvatarPrimitive.Fallback>) => {
+  return (
+    <AvatarPrimitive.Fallback
+      ref={ref}
+      className={cn("flex h-full w-full items-center justify-center rounded-full", className)}
+      {...props}
+    />
+  );
+};
+
 AvatarFallback.displayName = AvatarPrimitive.Fallback.displayName;
 
 interface CustomAvatarProps {

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -67,20 +67,30 @@ export interface ButtonProps
     VariantProps<typeof buttonVariants> {
   asChild?: boolean;
   desktop?: boolean;
+  ref?: React.Ref<HTMLButtonElement>;
 }
 
-export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, iconOnly, asChild = false, desktop, tabIndex, ...props }, ref) => {
-    const Comp = asChild ? Slot : "button";
-    return (
-      <Comp
-        className={cn(buttonVariants({ variant, size, iconOnly, className }))}
-        ref={ref}
-        tabIndex={tabIndex}
-        data-desktop={desktop}
-        {...props}
-      />
-    );
-  },
-);
+export const Button = ({
+  className,
+  variant,
+  size,
+  iconOnly,
+  asChild = false,
+  desktop,
+  tabIndex,
+  ref,
+  ...props
+}: ButtonProps) => {
+  const Comp = asChild ? Slot : "button";
+  return (
+    <Comp
+      className={cn(buttonVariants({ variant, size, iconOnly, className }))}
+      ref={ref}
+      tabIndex={tabIndex}
+      data-desktop={desktop}
+      {...props}
+    />
+  );
+};
+
 Button.displayName = "Button";

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,42 +1,36 @@
 import * as React from "react";
 import { cn } from "@/lib/utils";
 
-const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn("rounded-lg border bg-card text-card-foreground shadow-xs", className)} {...props} />
-));
+const Card = ({ className, ref, ...props }: React.ComponentPropsWithRef<"div">) => {
+  return (
+    <div ref={ref} className={cn("rounded-lg border bg-card text-card-foreground shadow-xs", className)} {...props} />
+  );
+};
 Card.displayName = "Card";
 
-const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn("flex flex-col space-y-1.5 p-6", className)} {...props} />
-  ),
-);
+const CardHeader = ({ className, ref, ...props }: React.ComponentPropsWithRef<"div">) => {
+  return <div ref={ref} className={cn("flex flex-col space-y-1.5 p-6", className)} {...props} />;
+};
 CardHeader.displayName = "CardHeader";
 
-const CardTitle = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn("text-lg font-semibold leading-none tracking-tight", className)} {...props} />
-  ),
-);
+const CardTitle = ({ className, ref, ...props }: React.ComponentPropsWithRef<"div">) => {
+  return <div ref={ref} className={cn("text-lg font-semibold leading-none tracking-tight", className)} {...props} />;
+};
 CardTitle.displayName = "CardTitle";
 
-const CardDescription = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn("text-sm text-muted-foreground", className)} {...props} />
-  ),
-);
+const CardDescription = ({ className, ref, ...props }: React.ComponentPropsWithRef<"div">) => {
+  return <div ref={ref} className={cn("text-sm text-muted-foreground", className)} {...props} />;
+};
 CardDescription.displayName = "CardDescription";
 
-const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />,
-);
+const CardContent = ({ className, ref, ...props }: React.ComponentPropsWithRef<"div">) => {
+  return <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />;
+};
 CardContent.displayName = "CardContent";
 
-const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn("flex items-center p-6 pt-0", className)} {...props} />
-  ),
-);
+const CardFooter = ({ className, ref, ...props }: React.ComponentPropsWithRef<"div">) => {
+  return <div ref={ref} className={cn("flex items-center p-6 pt-0", className)} {...props} />;
+};
 CardFooter.displayName = "CardFooter";
 
 export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent };

--- a/components/ui/chart.tsx
+++ b/components/ui/chart.tsx
@@ -31,13 +31,17 @@ function useChart() {
   return context;
 }
 
-const ChartContainer = React.forwardRef<
-  HTMLDivElement,
-  React.ComponentProps<"div"> & {
-    config: ChartConfig;
-    children: React.ComponentProps<typeof RechartsPrimitive.ResponsiveContainer>["children"];
-  }
->(({ id, className, children, config, ...props }, ref) => {
+const ChartContainer = ({
+  id,
+  className,
+  children,
+  config,
+  ref,
+  ...props
+}: React.ComponentPropsWithRef<"div"> & {
+  config: ChartConfig;
+  children: React.ComponentProps<typeof RechartsPrimitive.ResponsiveContainer>["children"];
+}) => {
   const uniqueId = React.useId();
   const chartId = `chart-${id || uniqueId.replace(/:/g, "")}`;
 
@@ -57,7 +61,7 @@ const ChartContainer = React.forwardRef<
       </div>
     </ChartContext.Provider>
   );
-});
+};
 ChartContainer.displayName = "Chart";
 
 const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
@@ -91,152 +95,154 @@ ${colorConfig
 
 const ChartTooltip = RechartsPrimitive.Tooltip;
 
-const ChartTooltipContent = React.forwardRef<
-  HTMLDivElement,
-  React.ComponentProps<typeof RechartsPrimitive.Tooltip> &
-    React.ComponentProps<"div"> & {
-      hideLabel?: boolean;
-      hideIndicator?: boolean;
-      indicator?: "line" | "dot" | "dashed";
-      nameKey?: string;
-      labelKey?: string;
-      valueFormatter?: (value: number) => string;
+type ChartTooltipContentProps = React.ComponentProps<typeof RechartsPrimitive.Tooltip> &
+  React.ComponentPropsWithRef<"div"> & {
+    hideLabel?: boolean;
+    hideIndicator?: boolean;
+    indicator?: "line" | "dot" | "dashed";
+    nameKey?: string;
+    labelKey?: string;
+    valueFormatter?: (value: number) => string;
+  };
+
+const ChartTooltipContent = ({
+  active,
+  payload,
+  className,
+  indicator = "dot",
+  hideLabel = false,
+  hideIndicator = false,
+  label,
+  labelFormatter,
+  labelClassName,
+  formatter,
+  valueFormatter,
+  color,
+  nameKey,
+  labelKey,
+  ref,
+}: ChartTooltipContentProps) => {
+  const { config } = useChart();
+
+  const tooltipLabel = React.useMemo(() => {
+    if (hideLabel || !payload?.length) {
+      return null;
     }
->(
-  (
-    {
-      active,
-      payload,
-      className,
-      indicator = "dot",
-      hideLabel = false,
-      hideIndicator = false,
-      label,
-      labelFormatter,
-      labelClassName,
-      formatter,
-      valueFormatter,
-      color,
-      nameKey,
-      labelKey,
-    },
-    ref,
-  ) => {
-    const { config } = useChart();
+    const [item] = payload;
+    const key = `${labelKey || item?.dataKey || item?.name || "value"}`;
+    const itemConfig = item ? getPayloadConfigFromPayload(config, item, key) : undefined;
+    const value = !labelKey && typeof label === "string" ? config[label]?.label || label : itemConfig?.label;
 
-    const tooltipLabel = React.useMemo(() => {
-      if (hideLabel || !payload?.length) {
-        return null;
-      }
-      const [item] = payload;
-      const key = `${labelKey || item?.dataKey || item?.name || "value"}`;
-      const itemConfig = item ? getPayloadConfigFromPayload(config, item, key) : undefined;
-      const value = !labelKey && typeof label === "string" ? config[label]?.label || label : itemConfig?.label;
+    if (labelFormatter) {
+      return <div className={cn("font-medium", labelClassName)}>{labelFormatter(value, payload)}</div>;
+    }
 
-      if (labelFormatter) {
-        return <div className={cn("font-medium", labelClassName)}>{labelFormatter(value, payload)}</div>;
-      }
-
-      if (!value) {
-        return null;
-      }
-
-      return <div className={cn("font-medium", labelClassName)}>{value}</div>;
-    }, [label, labelFormatter, payload, hideLabel, labelClassName, config, labelKey]);
-
-    if (!active || !payload?.length) {
+    if (!value) {
       return null;
     }
 
-    const nestLabel = payload.length === 1 && indicator !== "dot";
+    return <div className={cn("font-medium", labelClassName)}>{value}</div>;
+  }, [label, labelFormatter, payload, hideLabel, labelClassName, config, labelKey]);
 
-    return (
-      <div
-        ref={ref}
-        className={cn(
-          "grid min-w-[8rem] items-start rounded-lg border border-border/50 bg-background px-2.5 py-1.5 text-xs shadow-xl",
-          className,
-        )}
-      >
-        {!nestLabel ? tooltipLabel : null}
-        <div className="grid gap-1.5">
-          {payload.map((item, index) => {
-            const key = `${nameKey || item.name || item.dataKey || "value"}`;
-            const itemConfig = getPayloadConfigFromPayload(config, item, key);
-            const indicatorColor = color || item.payload.fill || item.color;
+  if (!active || !payload?.length) {
+    return null;
+  }
 
-            return (
-              <div
-                key={item.dataKey}
-                className={cn(
-                  "flex w-full flex-wrap items-stretch gap-2 [&>svg]:h-2.5 [&>svg]:w-2.5 [&>svg]:text-muted-foreground",
-                  indicator === "dot" && "items-center",
-                )}
-              >
-                {formatter && item?.value !== undefined && item.name ? (
-                  formatter(item.value, item.name, item, index, item.payload)
-                ) : (
-                  <>
-                    {itemConfig?.icon ? (
-                      <itemConfig.icon />
-                    ) : (
-                      !hideIndicator && (
-                        <div
-                          className={cn("shrink-0 rounded-[2px] border-(--color-border) bg-(--color-bg)", {
-                            "h-2.5 w-2.5": indicator === "dot",
-                            "w-1": indicator === "line",
-                            "w-0 border-[1.5px] border-dashed bg-transparent": indicator === "dashed",
-                            "my-0.5": nestLabel && indicator === "dashed",
-                          })}
-                          style={
-                            {
-                              "--color-bg": indicatorColor,
-                              "--color-border": indicatorColor,
-                            } as React.CSSProperties
-                          }
-                        />
-                      )
+  const nestLabel = payload.length === 1 && indicator !== "dot";
+
+  return (
+    <div
+      ref={ref}
+      className={cn(
+        "grid min-w-[8rem] items-start rounded-lg border border-border/50 bg-background px-2.5 py-1.5 text-xs shadow-xl",
+        className,
+      )}
+    >
+      {!nestLabel ? tooltipLabel : null}
+      <div className="grid gap-1.5">
+        {payload.map((item, index) => {
+          const key = `${nameKey || item.name || item.dataKey || "value"}`;
+          const itemConfig = getPayloadConfigFromPayload(config, item, key);
+          const indicatorColor = color || item.payload.fill || item.color;
+
+          return (
+            <div
+              key={item.dataKey}
+              className={cn(
+                "flex w-full flex-wrap items-stretch gap-2 [&>svg]:h-2.5 [&>svg]:w-2.5 [&>svg]:text-muted-foreground",
+                indicator === "dot" && "items-center",
+              )}
+            >
+              {formatter && item?.value !== undefined && item.name ? (
+                formatter(item.value, item.name, item, index, item.payload)
+              ) : (
+                <>
+                  {itemConfig?.icon ? (
+                    <itemConfig.icon />
+                  ) : (
+                    !hideIndicator && (
+                      <div
+                        className={cn("shrink-0 rounded-[2px] border-(--color-border) bg-(--color-bg)", {
+                          "h-2.5 w-2.5": indicator === "dot",
+                          "w-1": indicator === "line",
+                          "w-0 border-[1.5px] border-dashed bg-transparent": indicator === "dashed",
+                          "my-0.5": nestLabel && indicator === "dashed",
+                        })}
+                        style={
+                          {
+                            "--color-bg": indicatorColor,
+                            "--color-border": indicatorColor,
+                          } as React.CSSProperties
+                        }
+                      />
+                    )
+                  )}
+                  <div
+                    className={cn(
+                      "flex flex-1 gap-2 justify-between leading-none",
+                      nestLabel ? "items-end" : "items-center",
                     )}
-                    <div
-                      className={cn(
-                        "flex flex-1 gap-2 justify-between leading-none",
-                        nestLabel ? "items-end" : "items-center",
-                      )}
-                    >
-                      <div className="grid gap-1.5">
-                        {nestLabel ? tooltipLabel : null}
-                        <span className="text-muted-foreground">{itemConfig?.label || item.name}</span>
-                      </div>
-                      {item.value && (
-                        <span className="font-mono font-medium tabular-nums text-foreground">
-                          {valueFormatter && typeof item.value === "number"
-                            ? valueFormatter(item.value)
-                            : item.value.toLocaleString()}
-                        </span>
-                      )}
+                  >
+                    <div className="grid gap-1.5">
+                      {nestLabel ? tooltipLabel : null}
+                      <span className="text-muted-foreground">{itemConfig?.label || item.name}</span>
                     </div>
-                  </>
-                )}
-              </div>
-            );
-          })}
-        </div>
+                    {item.value && (
+                      <span className="font-mono font-medium tabular-nums text-foreground">
+                        {valueFormatter && typeof item.value === "number"
+                          ? valueFormatter(item.value)
+                          : item.value.toLocaleString()}
+                      </span>
+                    )}
+                  </div>
+                </>
+              )}
+            </div>
+          );
+        })}
       </div>
-    );
-  },
-);
+    </div>
+  );
+};
+
 ChartTooltipContent.displayName = "ChartTooltip";
 
 const ChartLegend = RechartsPrimitive.Legend;
 
-const ChartLegendContent = React.forwardRef<
-  HTMLDivElement,
-  React.ComponentProps<"div"> &
-    Pick<RechartsPrimitive.LegendProps, "payload" | "verticalAlign"> & {
-      hideIcon?: boolean;
-      nameKey?: string;
-    }
->(({ className, hideIcon = false, payload, verticalAlign = "bottom", nameKey }, ref) => {
+type ChartLegendContentProps = React.ComponentPropsWithRef<"div"> &
+  Pick<RechartsPrimitive.LegendProps, "payload" | "verticalAlign"> & {
+    hideIcon?: boolean;
+    nameKey?: string;
+  };
+
+const ChartLegendContent = ({
+  className,
+  hideIcon = false,
+  payload,
+  verticalAlign = "bottom",
+  nameKey,
+  ref,
+}: ChartLegendContentProps) => {
   const { config } = useChart();
 
   if (!payload?.length) {
@@ -273,7 +279,7 @@ const ChartLegendContent = React.forwardRef<
       })}
     </div>
   );
-});
+};
 ChartLegendContent.displayName = "ChartLegend";
 
 // Helper to extract item config from a payload.

--- a/components/ui/checkbox.tsx
+++ b/components/ui/checkbox.tsx
@@ -6,7 +6,7 @@ import * as React from "react";
 import { cn } from "@/lib/utils";
 
 const Checkbox = React.forwardRef<
-  React.ElementRef<typeof CheckboxPrimitive.Root>,
+  React.ComponentRef<typeof CheckboxPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
 >(({ className, ...props }, ref) => (
   <CheckboxPrimitive.Root

--- a/components/ui/checkbox.tsx
+++ b/components/ui/checkbox.tsx
@@ -5,10 +5,7 @@ import { Check } from "lucide-react";
 import * as React from "react";
 import { cn } from "@/lib/utils";
 
-const Checkbox = React.forwardRef<
-  React.ComponentRef<typeof CheckboxPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
->(({ className, ...props }, ref) => (
+const Checkbox = ({ className, ref, ...props }: React.ComponentPropsWithRef<typeof CheckboxPrimitive.Root>) => (
   <CheckboxPrimitive.Root
     ref={ref}
     className={cn(
@@ -21,7 +18,7 @@ const Checkbox = React.forwardRef<
       <Check className="h-4 w-4" />
     </CheckboxPrimitive.Indicator>
   </CheckboxPrimitive.Root>
-));
+);
 Checkbox.displayName = CheckboxPrimitive.Root.displayName;
 
 export { Checkbox };

--- a/components/ui/command.tsx
+++ b/components/ui/command.tsx
@@ -8,7 +8,7 @@ import { Dialog, DialogContent } from "@/components/ui/dialog";
 import { cn } from "@/lib/utils";
 
 const Command = React.forwardRef<
-  React.ElementRef<typeof CommandPrimitive>,
+  React.ComponentRef<typeof CommandPrimitive>,
   React.ComponentPropsWithoutRef<typeof CommandPrimitive>
 >(({ className, ...props }, ref) => (
   <CommandPrimitive
@@ -35,7 +35,7 @@ const CommandDialog = ({ children, ...props }: DialogProps) => {
 };
 
 const CommandInput = React.forwardRef<
-  React.ElementRef<typeof CommandPrimitive.Input>,
+  React.ComponentRef<typeof CommandPrimitive.Input>,
   React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input>
 >(({ className, ...props }, ref) => (
   <div className="flex items-center border-b pl-3" cmdk-input-wrapper="">
@@ -54,7 +54,7 @@ const CommandInput = React.forwardRef<
 CommandInput.displayName = CommandPrimitive.Input.displayName;
 
 const CommandList = React.forwardRef<
-  React.ElementRef<typeof CommandPrimitive.List>,
+  React.ComponentRef<typeof CommandPrimitive.List>,
   React.ComponentPropsWithoutRef<typeof CommandPrimitive.List>
 >(({ className, ...props }, ref) => (
   <CommandPrimitive.List
@@ -67,14 +67,14 @@ const CommandList = React.forwardRef<
 CommandList.displayName = CommandPrimitive.List.displayName;
 
 const CommandEmpty = React.forwardRef<
-  React.ElementRef<typeof CommandPrimitive.Empty>,
+  React.ComponentRef<typeof CommandPrimitive.Empty>,
   React.ComponentPropsWithoutRef<typeof CommandPrimitive.Empty>
 >((props, ref) => <CommandPrimitive.Empty ref={ref} className="py-6 text-center text-sm" {...props} />);
 
 CommandEmpty.displayName = CommandPrimitive.Empty.displayName;
 
 const CommandGroup = React.forwardRef<
-  React.ElementRef<typeof CommandPrimitive.Group>,
+  React.ComponentRef<typeof CommandPrimitive.Group>,
   React.ComponentPropsWithoutRef<typeof CommandPrimitive.Group>
 >(({ className, ...props }, ref) => (
   <CommandPrimitive.Group
@@ -90,7 +90,7 @@ const CommandGroup = React.forwardRef<
 CommandGroup.displayName = CommandPrimitive.Group.displayName;
 
 const CommandSeparator = React.forwardRef<
-  React.ElementRef<typeof CommandPrimitive.Separator>,
+  React.ComponentRef<typeof CommandPrimitive.Separator>,
   React.ComponentPropsWithoutRef<typeof CommandPrimitive.Separator>
 >(({ className, ...props }, ref) => (
   <CommandPrimitive.Separator ref={ref} className={cn("-mx-1 h-px bg-border", className)} {...props} />
@@ -98,7 +98,7 @@ const CommandSeparator = React.forwardRef<
 CommandSeparator.displayName = CommandPrimitive.Separator.displayName;
 
 const CommandItem = React.forwardRef<
-  React.ElementRef<typeof CommandPrimitive.Item>,
+  React.ComponentRef<typeof CommandPrimitive.Item>,
   React.ComponentPropsWithoutRef<typeof CommandPrimitive.Item>
 >(({ className, ...props }, ref) => (
   <CommandPrimitive.Item

--- a/components/ui/command.tsx
+++ b/components/ui/command.tsx
@@ -7,10 +7,7 @@ import * as React from "react";
 import { Dialog, DialogContent } from "@/components/ui/dialog";
 import { cn } from "@/lib/utils";
 
-const Command = React.forwardRef<
-  React.ComponentRef<typeof CommandPrimitive>,
-  React.ComponentPropsWithoutRef<typeof CommandPrimitive>
->(({ className, ...props }, ref) => (
+const Command = ({ className, ref, ...props }: React.ComponentPropsWithRef<typeof CommandPrimitive>) => (
   <CommandPrimitive
     ref={ref}
     className={cn(
@@ -19,7 +16,7 @@ const Command = React.forwardRef<
     )}
     {...props}
   />
-));
+);
 Command.displayName = CommandPrimitive.displayName;
 
 const CommandDialog = ({ children, ...props }: DialogProps) => {
@@ -34,10 +31,7 @@ const CommandDialog = ({ children, ...props }: DialogProps) => {
   );
 };
 
-const CommandInput = React.forwardRef<
-  React.ComponentRef<typeof CommandPrimitive.Input>,
-  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input>
->(({ className, ...props }, ref) => (
+const CommandInput = ({ className, ref, ...props }: React.ComponentPropsWithRef<typeof CommandPrimitive.Input>) => (
   <div className="flex items-center border-b pl-3" cmdk-input-wrapper="">
     <Search className="h-4 w-4 shrink-0 opacity-50" />
     <CommandPrimitive.Input
@@ -49,34 +43,27 @@ const CommandInput = React.forwardRef<
       {...props}
     />
   </div>
-));
+);
 
 CommandInput.displayName = CommandPrimitive.Input.displayName;
 
-const CommandList = React.forwardRef<
-  React.ComponentRef<typeof CommandPrimitive.List>,
-  React.ComponentPropsWithoutRef<typeof CommandPrimitive.List>
->(({ className, ...props }, ref) => (
+const CommandList = ({ className, ref, ...props }: React.ComponentPropsWithRef<typeof CommandPrimitive.List>) => (
   <CommandPrimitive.List
     ref={ref}
     className={cn("max-h-[300px] overflow-y-auto overflow-x-hidden", className)}
     {...props}
   />
-));
+);
 
 CommandList.displayName = CommandPrimitive.List.displayName;
 
-const CommandEmpty = React.forwardRef<
-  React.ComponentRef<typeof CommandPrimitive.Empty>,
-  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Empty>
->((props, ref) => <CommandPrimitive.Empty ref={ref} className="py-6 text-center text-sm" {...props} />);
+const CommandEmpty = ({ className, ref, ...props }: React.ComponentPropsWithRef<typeof CommandPrimitive.Empty>) => (
+  <CommandPrimitive.Empty ref={ref} className="py-6 text-center text-sm" {...props} />
+);
 
 CommandEmpty.displayName = CommandPrimitive.Empty.displayName;
 
-const CommandGroup = React.forwardRef<
-  React.ComponentRef<typeof CommandPrimitive.Group>,
-  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Group>
->(({ className, ...props }, ref) => (
+const CommandGroup = ({ className, ref, ...props }: React.ComponentPropsWithRef<typeof CommandPrimitive.Group>) => (
   <CommandPrimitive.Group
     ref={ref}
     className={cn(
@@ -85,22 +72,20 @@ const CommandGroup = React.forwardRef<
     )}
     {...props}
   />
-));
+);
 
 CommandGroup.displayName = CommandPrimitive.Group.displayName;
 
-const CommandSeparator = React.forwardRef<
-  React.ComponentRef<typeof CommandPrimitive.Separator>,
-  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Separator>
->(({ className, ...props }, ref) => (
+const CommandSeparator = ({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithRef<typeof CommandPrimitive.Separator>) => (
   <CommandPrimitive.Separator ref={ref} className={cn("-mx-1 h-px bg-border", className)} {...props} />
-));
+);
 CommandSeparator.displayName = CommandPrimitive.Separator.displayName;
 
-const CommandItem = React.forwardRef<
-  React.ComponentRef<typeof CommandPrimitive.Item>,
-  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Item>
->(({ className, ...props }, ref) => (
+const CommandItem = ({ className, ref, ...props }: React.ComponentPropsWithRef<typeof CommandPrimitive.Item>) => (
   <CommandPrimitive.Item
     ref={ref}
     className={cn(
@@ -109,7 +94,7 @@ const CommandItem = React.forwardRef<
     )}
     {...props}
   />
-));
+);
 
 CommandItem.displayName = CommandPrimitive.Item.displayName;
 

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -14,7 +14,7 @@ const DialogPortal = DialogPrimitive.Portal;
 const DialogClose = DialogPrimitive.Close;
 
 const DialogOverlay = React.forwardRef<
-  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentRef<typeof DialogPrimitive.Overlay>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Overlay
@@ -29,7 +29,7 @@ const DialogOverlay = React.forwardRef<
 DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
 const DialogContent = React.forwardRef<
-  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentRef<typeof DialogPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
 >(({ className, children, ...props }, ref) => (
   <DialogPortal>
@@ -63,7 +63,7 @@ const DialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivEleme
 DialogFooter.displayName = "DialogFooter";
 
 const DialogTitle = React.forwardRef<
-  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentRef<typeof DialogPrimitive.Title>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Title ref={ref} className={cn("text-lg leading-none tracking-tight", className)} {...props} />
@@ -71,7 +71,7 @@ const DialogTitle = React.forwardRef<
 DialogTitle.displayName = DialogPrimitive.Title.displayName;
 
 const DialogDescription = React.forwardRef<
-  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentRef<typeof DialogPrimitive.Description>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Description ref={ref} className={cn("text-sm text-muted-foreground", className)} {...props} />

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -13,10 +13,7 @@ const DialogPortal = DialogPrimitive.Portal;
 
 const DialogClose = DialogPrimitive.Close;
 
-const DialogOverlay = React.forwardRef<
-  React.ComponentRef<typeof DialogPrimitive.Overlay>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
->(({ className, ...props }, ref) => (
+const DialogOverlay = ({ className, ref, ...props }: React.ComponentPropsWithRef<typeof DialogPrimitive.Overlay>) => (
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
@@ -25,13 +22,15 @@ const DialogOverlay = React.forwardRef<
     )}
     {...props}
   />
-));
+);
 DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
-const DialogContent = React.forwardRef<
-  React.ComponentRef<typeof DialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => (
+const DialogContent = ({
+  className,
+  children,
+  ref,
+  ...props
+}: React.ComponentPropsWithRef<typeof DialogPrimitive.Content>) => (
   <DialogPortal>
     <DialogOverlay />
     <DialogPrimitive.Content
@@ -49,7 +48,7 @@ const DialogContent = React.forwardRef<
       </DialogPrimitive.Close>
     </DialogPrimitive.Content>
   </DialogPortal>
-));
+);
 DialogContent.displayName = DialogPrimitive.Content.displayName;
 
 const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
@@ -62,20 +61,18 @@ const DialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivEleme
 );
 DialogFooter.displayName = "DialogFooter";
 
-const DialogTitle = React.forwardRef<
-  React.ComponentRef<typeof DialogPrimitive.Title>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
->(({ className, ...props }, ref) => (
+const DialogTitle = ({ className, ref, ...props }: React.ComponentPropsWithRef<typeof DialogPrimitive.Title>) => (
   <DialogPrimitive.Title ref={ref} className={cn("text-lg leading-none tracking-tight", className)} {...props} />
-));
+);
 DialogTitle.displayName = DialogPrimitive.Title.displayName;
 
-const DialogDescription = React.forwardRef<
-  React.ComponentRef<typeof DialogPrimitive.Description>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
->(({ className, ...props }, ref) => (
+const DialogDescription = ({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithRef<typeof DialogPrimitive.Description>) => (
   <DialogPrimitive.Description ref={ref} className={cn("text-sm text-muted-foreground", className)} {...props} />
-));
+);
 DialogDescription.displayName = DialogPrimitive.Description.displayName;
 
 export {

--- a/components/ui/dropdown-menu.tsx
+++ b/components/ui/dropdown-menu.tsx
@@ -13,7 +13,7 @@ const DropdownMenuSub = DropdownMenuPrimitive.Sub;
 const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup;
 
 const DropdownMenuSubTrigger = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.SubTrigger>,
+  React.ComponentRef<typeof DropdownMenuPrimitive.SubTrigger>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger> & {
     inset?: boolean;
   }
@@ -34,7 +34,7 @@ const DropdownMenuSubTrigger = React.forwardRef<
 DropdownMenuSubTrigger.displayName = DropdownMenuPrimitive.SubTrigger.displayName;
 
 const DropdownMenuSubContent = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
+  React.ComponentRef<typeof DropdownMenuPrimitive.SubContent>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
 >(({ className, ...props }, ref) => (
   <DropdownMenuPrimitive.SubContent
@@ -49,7 +49,7 @@ const DropdownMenuSubContent = React.forwardRef<
 DropdownMenuSubContent.displayName = DropdownMenuPrimitive.SubContent.displayName;
 
 const DropdownMenuContent = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.Content>,
+  React.ComponentRef<typeof DropdownMenuPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
 >(({ className, sideOffset = 4, ...props }, ref) => (
   <DropdownMenuPrimitive.Portal>
@@ -67,7 +67,7 @@ const DropdownMenuContent = React.forwardRef<
 DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;
 
 const DropdownMenuItem = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.Item>,
+  React.ComponentRef<typeof DropdownMenuPrimitive.Item>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
     inset?: boolean;
   }
@@ -85,7 +85,7 @@ const DropdownMenuItem = React.forwardRef<
 DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName;
 
 const DropdownMenuCheckboxItem = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.CheckboxItem>,
+  React.ComponentRef<typeof DropdownMenuPrimitive.CheckboxItem>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem>
 >(({ className, children, checked, ...props }, ref) => (
   <DropdownMenuPrimitive.CheckboxItem
@@ -108,7 +108,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
 DropdownMenuCheckboxItem.displayName = DropdownMenuPrimitive.CheckboxItem.displayName;
 
 const DropdownMenuRadioItem = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.RadioItem>,
+  React.ComponentRef<typeof DropdownMenuPrimitive.RadioItem>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.RadioItem>
 >(({ className, children, ...props }, ref) => (
   <DropdownMenuPrimitive.RadioItem
@@ -130,7 +130,7 @@ const DropdownMenuRadioItem = React.forwardRef<
 DropdownMenuRadioItem.displayName = DropdownMenuPrimitive.RadioItem.displayName;
 
 const DropdownMenuLabel = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.Label>,
+  React.ComponentRef<typeof DropdownMenuPrimitive.Label>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label> & {
     inset?: boolean;
   }
@@ -144,7 +144,7 @@ const DropdownMenuLabel = React.forwardRef<
 DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName;
 
 const DropdownMenuSeparator = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.Separator>,
+  React.ComponentRef<typeof DropdownMenuPrimitive.Separator>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
 >(({ className, ...props }, ref) => (
   <DropdownMenuPrimitive.Separator ref={ref} className={cn("-mx-1 my-1 h-px bg-muted", className)} {...props} />

--- a/components/ui/dropdown-menu.tsx
+++ b/components/ui/dropdown-menu.tsx
@@ -12,144 +12,166 @@ const DropdownMenuPortal = DropdownMenuPrimitive.Portal;
 const DropdownMenuSub = DropdownMenuPrimitive.Sub;
 const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup;
 
-const DropdownMenuSubTrigger = React.forwardRef<
-  React.ComponentRef<typeof DropdownMenuPrimitive.SubTrigger>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger> & {
-    inset?: boolean;
-  }
->(({ className, inset, children, ...props }, ref) => (
-  <DropdownMenuPrimitive.SubTrigger
-    ref={ref}
-    className={cn(
-      "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-hidden focus:bg-accent data-[state=open]:bg-accent",
-      inset && "pl-8",
-      className,
-    )}
-    {...props}
-  >
-    {children}
-    <ChevronRight className="ml-auto h-4 w-4" />
-  </DropdownMenuPrimitive.SubTrigger>
-));
-DropdownMenuSubTrigger.displayName = DropdownMenuPrimitive.SubTrigger.displayName;
-
-const DropdownMenuSubContent = React.forwardRef<
-  React.ComponentRef<typeof DropdownMenuPrimitive.SubContent>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
->(({ className, ...props }, ref) => (
-  <DropdownMenuPrimitive.SubContent
-    ref={ref}
-    className={cn(
-      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-      className,
-    )}
-    {...props}
-  />
-));
-DropdownMenuSubContent.displayName = DropdownMenuPrimitive.SubContent.displayName;
-
-const DropdownMenuContent = React.forwardRef<
-  React.ComponentRef<typeof DropdownMenuPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
->(({ className, sideOffset = 4, ...props }, ref) => (
-  <DropdownMenuPrimitive.Portal>
-    <DropdownMenuPrimitive.Content
+function DropdownMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ref,
+  ...props
+}: React.ComponentPropsWithRef<typeof DropdownMenuPrimitive.SubTrigger> & {
+  inset?: boolean;
+}) {
+  return (
+    <DropdownMenuPrimitive.SubTrigger
       ref={ref}
-      sideOffset={sideOffset}
       className={cn(
-        "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent",
+        inset && "pl-8",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRight className="ml-auto h-4 w-4" />
+    </DropdownMenuPrimitive.SubTrigger>
+  );
+}
+
+function DropdownMenuSubContent({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithRef<typeof DropdownMenuPrimitive.SubContent>) {
+  return (
+    <DropdownMenuPrimitive.SubContent
+      ref={ref}
+      className={cn(
+        "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className,
       )}
       {...props}
     />
-  </DropdownMenuPrimitive.Portal>
-));
-DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;
+  );
+}
 
-const DropdownMenuItem = React.forwardRef<
-  React.ComponentRef<typeof DropdownMenuPrimitive.Item>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
-    inset?: boolean;
-  }
->(({ className, inset, ...props }, ref) => (
-  <DropdownMenuPrimitive.Item
-    ref={ref}
-    className={cn(
-      "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden transition-colors focus:bg-accent focus:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
-      inset && "pl-8",
-      className,
-    )}
-    {...props}
-  />
-));
-DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName;
+function DropdownMenuContent({
+  className,
+  sideOffset = 4,
+  ref,
+  ...props
+}: React.ComponentPropsWithRef<typeof DropdownMenuPrimitive.Content>) {
+  return (
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.Content
+        ref={ref}
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+          className,
+        )}
+        {...props}
+      />
+    </DropdownMenuPrimitive.Portal>
+  );
+}
 
-const DropdownMenuCheckboxItem = React.forwardRef<
-  React.ComponentRef<typeof DropdownMenuPrimitive.CheckboxItem>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem>
->(({ className, children, checked, ...props }, ref) => (
-  <DropdownMenuPrimitive.CheckboxItem
-    ref={ref}
-    className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-hidden transition-colors focus:bg-accent focus:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50",
-      className,
-    )}
-    checked={checked}
-    {...props}
-  >
-    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
-      <DropdownMenuPrimitive.ItemIndicator>
-        <Check className="h-4 w-4" />
-      </DropdownMenuPrimitive.ItemIndicator>
-    </span>
-    {children}
-  </DropdownMenuPrimitive.CheckboxItem>
-));
-DropdownMenuCheckboxItem.displayName = DropdownMenuPrimitive.CheckboxItem.displayName;
+function DropdownMenuItem({
+  className,
+  inset,
+  ref,
+  ...props
+}: React.ComponentPropsWithRef<typeof DropdownMenuPrimitive.Item> & {
+  inset?: boolean;
+}) {
+  return (
+    <DropdownMenuPrimitive.Item
+      ref={ref}
+      className={cn(
+        "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+        inset && "pl-8",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
 
-const DropdownMenuRadioItem = React.forwardRef<
-  React.ComponentRef<typeof DropdownMenuPrimitive.RadioItem>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.RadioItem>
->(({ className, children, ...props }, ref) => (
-  <DropdownMenuPrimitive.RadioItem
-    ref={ref}
-    className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-hidden transition-colors focus:bg-accent focus:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50",
-      className,
-    )}
-    {...props}
-  >
-    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
-      <DropdownMenuPrimitive.ItemIndicator>
-        <Circle className="h-2 w-2 fill-current" />
-      </DropdownMenuPrimitive.ItemIndicator>
-    </span>
-    {children}
-  </DropdownMenuPrimitive.RadioItem>
-));
-DropdownMenuRadioItem.displayName = DropdownMenuPrimitive.RadioItem.displayName;
+function DropdownMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  ref,
+  ...props
+}: React.ComponentPropsWithRef<typeof DropdownMenuPrimitive.CheckboxItem>) {
+  return (
+    <DropdownMenuPrimitive.CheckboxItem
+      ref={ref}
+      className={cn(
+        "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+        className,
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <Check className="h-4 w-4" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.CheckboxItem>
+  );
+}
 
-const DropdownMenuLabel = React.forwardRef<
-  React.ComponentRef<typeof DropdownMenuPrimitive.Label>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label> & {
-    inset?: boolean;
-  }
->(({ className, inset, ...props }, ref) => (
-  <DropdownMenuPrimitive.Label
-    ref={ref}
-    className={cn("px-2 py-1.5 text-sm font-semibold", inset && "pl-8", className)}
-    {...props}
-  />
-));
-DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName;
+function DropdownMenuRadioItem({
+  className,
+  children,
+  ref,
+  ...props
+}: React.ComponentPropsWithRef<typeof DropdownMenuPrimitive.RadioItem>) {
+  return (
+    <DropdownMenuPrimitive.RadioItem
+      ref={ref}
+      className={cn(
+        "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+        className,
+      )}
+      {...props}
+    >
+      <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <Circle className="h-2 w-2 fill-current" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.RadioItem>
+  );
+}
 
-const DropdownMenuSeparator = React.forwardRef<
-  React.ComponentRef<typeof DropdownMenuPrimitive.Separator>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
->(({ className, ...props }, ref) => (
-  <DropdownMenuPrimitive.Separator ref={ref} className={cn("-mx-1 my-1 h-px bg-muted", className)} {...props} />
-));
-DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName;
+function DropdownMenuLabel({
+  className,
+  inset,
+  ref,
+  ...props
+}: React.ComponentPropsWithRef<typeof DropdownMenuPrimitive.Label> & {
+  inset?: boolean;
+}) {
+  return (
+    <DropdownMenuPrimitive.Label
+      ref={ref}
+      className={cn("px-2 py-1.5 text-sm font-semibold", inset && "pl-8", className)}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuSeparator({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithRef<typeof DropdownMenuPrimitive.Separator>) {
+  return <DropdownMenuPrimitive.Separator ref={ref} className={cn("-mx-1 my-1 h-px bg-muted", className)} {...props} />;
+}
 
 const DropdownMenuShortcut = ({ className, ...props }: React.HTMLAttributes<HTMLSpanElement>) => {
   return <span className={cn("ml-auto text-xs tracking-widest opacity-60", className)} {...props} />;

--- a/components/ui/dropdown-menu.tsx
+++ b/components/ui/dropdown-menu.tsx
@@ -12,7 +12,7 @@ const DropdownMenuPortal = DropdownMenuPrimitive.Portal;
 const DropdownMenuSub = DropdownMenuPrimitive.Sub;
 const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup;
 
-function DropdownMenuSubTrigger({
+const DropdownMenuSubTrigger = ({
   className,
   inset,
   children,
@@ -20,162 +20,160 @@ function DropdownMenuSubTrigger({
   ...props
 }: React.ComponentPropsWithRef<typeof DropdownMenuPrimitive.SubTrigger> & {
   inset?: boolean;
-}) {
-  return (
-    <DropdownMenuPrimitive.SubTrigger
-      ref={ref}
-      className={cn(
-        "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent",
-        inset && "pl-8",
-        className,
-      )}
-      {...props}
-    >
-      {children}
-      <ChevronRight className="ml-auto h-4 w-4" />
-    </DropdownMenuPrimitive.SubTrigger>
-  );
-}
+}) => (
+  <DropdownMenuPrimitive.SubTrigger
+    ref={ref}
+    className={cn(
+      "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-hidden focus:bg-accent data-[state=open]:bg-accent",
+      inset && "pl-8",
+      className,
+    )}
+    {...props}
+  >
+    {children}
+    <ChevronRight className="ml-auto h-4 w-4" />
+  </DropdownMenuPrimitive.SubTrigger>
+);
 
-function DropdownMenuSubContent({
+DropdownMenuSubTrigger.displayName = DropdownMenuPrimitive.SubTrigger.displayName;
+
+const DropdownMenuSubContent = ({
   className,
   ref,
   ...props
-}: React.ComponentPropsWithRef<typeof DropdownMenuPrimitive.SubContent>) {
-  return (
-    <DropdownMenuPrimitive.SubContent
-      ref={ref}
-      className={cn(
-        "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-        className,
-      )}
-      {...props}
-    />
-  );
-}
+}: React.ComponentPropsWithRef<typeof DropdownMenuPrimitive.SubContent>) => (
+  <DropdownMenuPrimitive.SubContent
+    ref={ref}
+    className={cn(
+      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      className,
+    )}
+    {...props}
+  />
+);
+DropdownMenuSubContent.displayName = DropdownMenuPrimitive.SubContent.displayName;
 
-function DropdownMenuContent({
+const DropdownMenuContent = ({
   className,
   sideOffset = 4,
   ref,
   ...props
-}: React.ComponentPropsWithRef<typeof DropdownMenuPrimitive.Content>) {
-  return (
-    <DropdownMenuPrimitive.Portal>
-      <DropdownMenuPrimitive.Content
-        ref={ref}
-        sideOffset={sideOffset}
-        className={cn(
-          "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-          className,
-        )}
-        {...props}
-      />
-    </DropdownMenuPrimitive.Portal>
-  );
-}
+}: React.ComponentPropsWithRef<typeof DropdownMenuPrimitive.Content>) => (
+  <DropdownMenuPrimitive.Portal>
+    <DropdownMenuPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className,
+      )}
+      {...props}
+    />
+  </DropdownMenuPrimitive.Portal>
+);
+DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;
 
-function DropdownMenuItem({
+const DropdownMenuItem = ({
   className,
   inset,
   ref,
   ...props
 }: React.ComponentPropsWithRef<typeof DropdownMenuPrimitive.Item> & {
   inset?: boolean;
-}) {
-  return (
-    <DropdownMenuPrimitive.Item
-      ref={ref}
-      className={cn(
-        "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
-        inset && "pl-8",
-        className,
-      )}
-      {...props}
-    />
-  );
-}
+}) => (
+  <DropdownMenuPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      inset && "pl-8",
+      className,
+    )}
+    {...props}
+  />
+);
+DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName;
 
-function DropdownMenuCheckboxItem({
+const DropdownMenuCheckboxItem = ({
   className,
   children,
   checked,
   ref,
   ...props
-}: React.ComponentPropsWithRef<typeof DropdownMenuPrimitive.CheckboxItem>) {
-  return (
-    <DropdownMenuPrimitive.CheckboxItem
-      ref={ref}
-      className={cn(
-        "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
-        className,
-      )}
-      checked={checked}
-      {...props}
-    >
-      <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
-        <DropdownMenuPrimitive.ItemIndicator>
-          <Check className="h-4 w-4" />
-        </DropdownMenuPrimitive.ItemIndicator>
-      </span>
-      {children}
-    </DropdownMenuPrimitive.CheckboxItem>
-  );
-}
+}: React.ComponentPropsWithRef<typeof DropdownMenuPrimitive.CheckboxItem>) => (
+  <DropdownMenuPrimitive.CheckboxItem
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-hidden transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className,
+    )}
+    checked={checked}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <DropdownMenuPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" />
+      </DropdownMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </DropdownMenuPrimitive.CheckboxItem>
+);
 
-function DropdownMenuRadioItem({
+DropdownMenuCheckboxItem.displayName = DropdownMenuPrimitive.CheckboxItem.displayName;
+
+const DropdownMenuRadioItem = ({
   className,
   children,
   ref,
   ...props
-}: React.ComponentPropsWithRef<typeof DropdownMenuPrimitive.RadioItem>) {
-  return (
-    <DropdownMenuPrimitive.RadioItem
-      ref={ref}
-      className={cn(
-        "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
-        className,
-      )}
-      {...props}
-    >
-      <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
-        <DropdownMenuPrimitive.ItemIndicator>
-          <Circle className="h-2 w-2 fill-current" />
-        </DropdownMenuPrimitive.ItemIndicator>
-      </span>
-      {children}
-    </DropdownMenuPrimitive.RadioItem>
-  );
-}
+}: React.ComponentPropsWithRef<typeof DropdownMenuPrimitive.RadioItem>) => (
+  <DropdownMenuPrimitive.RadioItem
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-hidden transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className,
+    )}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <DropdownMenuPrimitive.ItemIndicator>
+        <Circle className="h-2 w-2 fill-current" />
+      </DropdownMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </DropdownMenuPrimitive.RadioItem>
+);
 
-function DropdownMenuLabel({
+DropdownMenuRadioItem.displayName = DropdownMenuPrimitive.RadioItem.displayName;
+
+const DropdownMenuLabel = ({
   className,
   inset,
   ref,
   ...props
 }: React.ComponentPropsWithRef<typeof DropdownMenuPrimitive.Label> & {
   inset?: boolean;
-}) {
-  return (
-    <DropdownMenuPrimitive.Label
-      ref={ref}
-      className={cn("px-2 py-1.5 text-sm font-semibold", inset && "pl-8", className)}
-      {...props}
-    />
-  );
-}
+}) => (
+  <DropdownMenuPrimitive.Label
+    ref={ref}
+    className={cn("px-2 py-1.5 text-sm font-semibold", inset && "pl-8", className)}
+    {...props}
+  />
+);
 
-function DropdownMenuSeparator({
+DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName;
+
+const DropdownMenuSeparator = ({
   className,
   ref,
   ...props
-}: React.ComponentPropsWithRef<typeof DropdownMenuPrimitive.Separator>) {
-  return <DropdownMenuPrimitive.Separator ref={ref} className={cn("-mx-1 my-1 h-px bg-muted", className)} {...props} />;
-}
+}: React.ComponentPropsWithRef<typeof DropdownMenuPrimitive.Separator>) => (
+  <DropdownMenuPrimitive.Separator ref={ref} className={cn("-mx-1 my-1 h-px bg-muted", className)} {...props} />
+);
+DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName;
 
-const DropdownMenuShortcut = ({ className, ...props }: React.HTMLAttributes<HTMLSpanElement>) => {
-  return <span className={cn("ml-auto text-xs tracking-widest opacity-60", className)} {...props} />;
-};
+const DropdownMenuShortcut = ({ className, ...props }: React.HTMLAttributes<HTMLSpanElement>) => (
+  <span className={cn("ml-auto text-xs tracking-widest opacity-60", className)} {...props} />
+);
 DropdownMenuShortcut.displayName = "DropdownMenuShortcut";
 
 export {

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -7,35 +7,33 @@ export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> 
   hint?: React.ReactNode;
   iconsSuffix?: React.ReactNode;
   iconsPrefix?: React.ReactNode;
+  ref?: React.Ref<HTMLInputElement>;
 }
 
-const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  ({ className, type, onModEnter, iconsSuffix, iconsPrefix, hint, ...props }, ref) => {
-    return (
-      <>
-        <div className="relative grow">
-          {iconsPrefix && <div className="absolute inset-y-0 left-0 flex items-center gap-2 pl-3">{iconsPrefix}</div>}
-          <input
-            type={type}
-            className={cn(
-              "w-full rounded-lg bg-background border border-border text-sm focus:border-transparent focus:outline-hidden focus:ring-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
-              "placeholder:text-muted-foreground",
-              "text-base",
-              iconsPrefix && "pl-10",
-              className,
-            )}
-            ref={ref}
-            onKeyDown={props.onKeyDown || (onModEnter ? onModEnterKeyboardEvent(onModEnter) : undefined)}
-            {...props}
-          />
-          {iconsSuffix && <div className="absolute inset-y-0 right-0 flex items-center gap-2 pr-3">{iconsSuffix}</div>}
-        </div>
-        {hint && <div className="mt-2 text-sm text-muted-foreground">{hint}</div>}
-      </>
-    );
-  },
-);
-
+const Input = ({ className, type, onModEnter, iconsSuffix, iconsPrefix, hint, ref, ...props }: InputProps) => {
+  return (
+    <>
+      <div className="relative grow">
+        {iconsPrefix && <div className="absolute inset-y-0 left-0 flex items-center gap-2 pl-3">{iconsPrefix}</div>}
+        <input
+          type={type}
+          className={cn(
+            "w-full rounded-lg bg-background border border-border text-sm focus:border-transparent focus:outline-hidden focus:ring-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
+            "placeholder:text-muted-foreground",
+            "text-base",
+            iconsPrefix && "pl-10",
+            className,
+          )}
+          ref={ref}
+          onKeyDown={props.onKeyDown || (onModEnter ? onModEnterKeyboardEvent(onModEnter) : undefined)}
+          {...props}
+        />
+        {iconsSuffix && <div className="absolute inset-y-0 right-0 flex items-center gap-2 pr-3">{iconsSuffix}</div>}
+      </div>
+      {hint && <div className="mt-2 text-sm text-muted-foreground">{hint}</div>}
+    </>
+  );
+};
 Input.displayName = "Input";
 
 export { Input };

--- a/components/ui/label.tsx
+++ b/components/ui/label.tsx
@@ -10,7 +10,7 @@ const labelVariants = cva(
 );
 
 const Label = React.forwardRef<
-  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentRef<typeof LabelPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> & VariantProps<typeof labelVariants>
 >(({ className, ...props }, ref) => (
   <LabelPrimitive.Root ref={ref} className={cn(labelVariants(), className)} {...props} />

--- a/components/ui/label.tsx
+++ b/components/ui/label.tsx
@@ -9,12 +9,13 @@ const labelVariants = cva(
   "mb-1 block text-sm border-border focus:border-transparent focus:outline-hidden focus:ring-muted-foreground peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
 );
 
-const Label = React.forwardRef<
-  React.ComponentRef<typeof LabelPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> & VariantProps<typeof labelVariants>
->(({ className, ...props }, ref) => (
+const Label = ({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithRef<typeof LabelPrimitive.Root> & VariantProps<typeof labelVariants>) => (
   <LabelPrimitive.Root ref={ref} className={cn(labelVariants(), className)} {...props} />
-));
+);
 Label.displayName = LabelPrimitive.Root.displayName;
 
 export { Label };

--- a/components/ui/popover.tsx
+++ b/components/ui/popover.tsx
@@ -9,7 +9,7 @@ const Popover = PopoverPrimitive.Root;
 const PopoverTrigger = PopoverPrimitive.Trigger;
 
 const PopoverContent = React.forwardRef<
-  React.ElementRef<typeof PopoverPrimitive.Content>,
+  React.ComponentRef<typeof PopoverPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
 >(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
   <PopoverPrimitive.Portal>

--- a/components/ui/popover.tsx
+++ b/components/ui/popover.tsx
@@ -8,10 +8,13 @@ const Popover = PopoverPrimitive.Root;
 
 const PopoverTrigger = PopoverPrimitive.Trigger;
 
-const PopoverContent = React.forwardRef<
-  React.ComponentRef<typeof PopoverPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
->(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
+const PopoverContent = ({
+  className,
+  align = "center",
+  sideOffset = 4,
+  ref,
+  ...props
+}: React.ComponentPropsWithRef<typeof PopoverPrimitive.Content>) => (
   <PopoverPrimitive.Portal>
     <PopoverPrimitive.Content
       ref={ref}
@@ -24,7 +27,7 @@ const PopoverContent = React.forwardRef<
       {...props}
     />
   </PopoverPrimitive.Portal>
-));
+);
 PopoverContent.displayName = PopoverPrimitive.Content.displayName;
 
 export { Popover, PopoverTrigger, PopoverContent };

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -26,11 +26,15 @@ const selectTriggerVariants = cva(
   },
 );
 
-const SelectTrigger = React.forwardRef<
-  React.ComponentRef<typeof SelectPrimitive.Trigger>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger> &
-    VariantProps<typeof selectTriggerVariants> & { hideArrow?: true | "mobileOnly" }
->(({ className, children, variant, hideArrow, ...props }, ref) => (
+const SelectTrigger = ({
+  className,
+  children,
+  variant,
+  hideArrow,
+  ref,
+  ...props
+}: React.ComponentPropsWithRef<typeof SelectPrimitive.Trigger> &
+  VariantProps<typeof selectTriggerVariants> & { hideArrow?: true | "mobileOnly" }) => (
   <SelectPrimitive.Trigger ref={ref} className={cn(selectTriggerVariants({ variant, className }))} {...props}>
     {children}
     {hideArrow !== true && (
@@ -39,13 +43,14 @@ const SelectTrigger = React.forwardRef<
       </SelectPrimitive.Icon>
     )}
   </SelectPrimitive.Trigger>
-));
+);
 SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;
 
-const SelectScrollUpButton = React.forwardRef<
-  React.ComponentRef<typeof SelectPrimitive.ScrollUpButton>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpButton>
->(({ className, ...props }, ref) => (
+const SelectScrollUpButton = ({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithRef<typeof SelectPrimitive.ScrollUpButton>) => (
   <SelectPrimitive.ScrollUpButton
     ref={ref}
     className={cn("flex cursor-default items-center justify-center py-1", className)}
@@ -53,13 +58,14 @@ const SelectScrollUpButton = React.forwardRef<
   >
     <ChevronUp className="h-4 w-4 text-foreground" />
   </SelectPrimitive.ScrollUpButton>
-));
+);
 SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName;
 
-const SelectScrollDownButton = React.forwardRef<
-  React.ComponentRef<typeof SelectPrimitive.ScrollDownButton>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollDownButton>
->(({ className, ...props }, ref) => (
+const SelectScrollDownButton = ({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithRef<typeof SelectPrimitive.ScrollDownButton>) => (
   <SelectPrimitive.ScrollDownButton
     ref={ref}
     className={cn("flex cursor-default items-center justify-center py-1", className)}
@@ -67,13 +73,16 @@ const SelectScrollDownButton = React.forwardRef<
   >
     <ChevronDown className="h-4 w-4 text-foreground" />
   </SelectPrimitive.ScrollDownButton>
-));
+);
 SelectScrollDownButton.displayName = SelectPrimitive.ScrollDownButton.displayName;
 
-const SelectContent = React.forwardRef<
-  React.ComponentRef<typeof SelectPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
->(({ className, children, position = "popper", ...props }, ref) => (
+const SelectContent = ({
+  className,
+  children,
+  position = "popper",
+  ref,
+  ...props
+}: React.ComponentPropsWithRef<typeof SelectPrimitive.Content>) => (
   <SelectPrimitive.Portal>
     <SelectPrimitive.Content
       ref={ref}
@@ -99,21 +108,20 @@ const SelectContent = React.forwardRef<
       <SelectScrollDownButton />
     </SelectPrimitive.Content>
   </SelectPrimitive.Portal>
-));
+);
 SelectContent.displayName = SelectPrimitive.Content.displayName;
 
-const SelectLabel = React.forwardRef<
-  React.ComponentRef<typeof SelectPrimitive.Label>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
->(({ className, ...props }, ref) => (
+const SelectLabel = ({ className, ref, ...props }: React.ComponentPropsWithRef<typeof SelectPrimitive.Label>) => (
   <SelectPrimitive.Label ref={ref} className={cn("py-1.5 pl-8 pr-2 text-sm font-semibold", className)} {...props} />
-));
+);
 SelectLabel.displayName = SelectPrimitive.Label.displayName;
 
-const SelectItem = React.forwardRef<
-  React.ComponentRef<typeof SelectPrimitive.Item>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
->(({ className, children, ...props }, ref) => (
+const SelectItem = ({
+  className,
+  children,
+  ref,
+  ...props
+}: React.ComponentPropsWithRef<typeof SelectPrimitive.Item>) => (
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
@@ -130,15 +138,16 @@ const SelectItem = React.forwardRef<
 
     <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
   </SelectPrimitive.Item>
-));
+);
 SelectItem.displayName = SelectPrimitive.Item.displayName;
 
-const SelectSeparator = React.forwardRef<
-  React.ComponentRef<typeof SelectPrimitive.Separator>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>
->(({ className, ...props }, ref) => (
+const SelectSeparator = ({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithRef<typeof SelectPrimitive.Separator>) => (
   <SelectPrimitive.Separator ref={ref} className={cn("-mx-1 my-1 h-px bg-border", className)} {...props} />
-));
+);
 SelectSeparator.displayName = SelectPrimitive.Separator.displayName;
 
 export {

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -27,7 +27,7 @@ const selectTriggerVariants = cva(
 );
 
 const SelectTrigger = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitive.Trigger>,
+  React.ComponentRef<typeof SelectPrimitive.Trigger>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger> &
     VariantProps<typeof selectTriggerVariants> & { hideArrow?: true | "mobileOnly" }
 >(({ className, children, variant, hideArrow, ...props }, ref) => (
@@ -43,7 +43,7 @@ const SelectTrigger = React.forwardRef<
 SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;
 
 const SelectScrollUpButton = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitive.ScrollUpButton>,
+  React.ComponentRef<typeof SelectPrimitive.ScrollUpButton>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpButton>
 >(({ className, ...props }, ref) => (
   <SelectPrimitive.ScrollUpButton
@@ -57,7 +57,7 @@ const SelectScrollUpButton = React.forwardRef<
 SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName;
 
 const SelectScrollDownButton = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitive.ScrollDownButton>,
+  React.ComponentRef<typeof SelectPrimitive.ScrollDownButton>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollDownButton>
 >(({ className, ...props }, ref) => (
   <SelectPrimitive.ScrollDownButton
@@ -71,7 +71,7 @@ const SelectScrollDownButton = React.forwardRef<
 SelectScrollDownButton.displayName = SelectPrimitive.ScrollDownButton.displayName;
 
 const SelectContent = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitive.Content>,
+  React.ComponentRef<typeof SelectPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
 >(({ className, children, position = "popper", ...props }, ref) => (
   <SelectPrimitive.Portal>
@@ -103,7 +103,7 @@ const SelectContent = React.forwardRef<
 SelectContent.displayName = SelectPrimitive.Content.displayName;
 
 const SelectLabel = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitive.Label>,
+  React.ComponentRef<typeof SelectPrimitive.Label>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
 >(({ className, ...props }, ref) => (
   <SelectPrimitive.Label ref={ref} className={cn("py-1.5 pl-8 pr-2 text-sm font-semibold", className)} {...props} />
@@ -111,7 +111,7 @@ const SelectLabel = React.forwardRef<
 SelectLabel.displayName = SelectPrimitive.Label.displayName;
 
 const SelectItem = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitive.Item>,
+  React.ComponentRef<typeof SelectPrimitive.Item>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
 >(({ className, children, ...props }, ref) => (
   <SelectPrimitive.Item
@@ -134,7 +134,7 @@ const SelectItem = React.forwardRef<
 SelectItem.displayName = SelectPrimitive.Item.displayName;
 
 const SelectSeparator = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitive.Separator>,
+  React.ComponentRef<typeof SelectPrimitive.Separator>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>
 >(({ className, ...props }, ref) => (
   <SelectPrimitive.Separator ref={ref} className={cn("-mx-1 my-1 h-px bg-border", className)} {...props} />

--- a/components/ui/separator.tsx
+++ b/components/ui/separator.tsx
@@ -5,7 +5,7 @@ import * as React from "react";
 import { cn } from "@/lib/utils";
 
 const Separator = React.forwardRef<
-  React.ElementRef<typeof SeparatorPrimitive.Root>,
+  React.ComponentRef<typeof SeparatorPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root>
 >(({ className, orientation = "horizontal", decorative = true, ...props }, ref) => (
   <SeparatorPrimitive.Root

--- a/components/ui/separator.tsx
+++ b/components/ui/separator.tsx
@@ -4,10 +4,13 @@ import * as SeparatorPrimitive from "@radix-ui/react-separator";
 import * as React from "react";
 import { cn } from "@/lib/utils";
 
-const Separator = React.forwardRef<
-  React.ComponentRef<typeof SeparatorPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root>
->(({ className, orientation = "horizontal", decorative = true, ...props }, ref) => (
+const Separator = ({
+  className,
+  orientation = "horizontal",
+  decorative = true,
+  ref,
+  ...props
+}: React.ComponentPropsWithRef<typeof SeparatorPrimitive.Root>) => (
   <SeparatorPrimitive.Root
     ref={ref}
     decorative={decorative}
@@ -15,7 +18,7 @@ const Separator = React.forwardRef<
     className={cn("shrink-0 bg-border", orientation === "horizontal" ? "h-[1px] w-full" : "h-full w-[1px]", className)}
     {...props}
   />
-));
+);
 Separator.displayName = SeparatorPrimitive.Root.displayName;
 
 export { Separator };

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -12,7 +12,7 @@ const SheetClose = SheetPrimitive.Close;
 const SheetPortal = SheetPrimitive.Portal;
 
 const SheetOverlay = React.forwardRef<
-  React.ElementRef<typeof SheetPrimitive.Overlay>,
+  React.ComponentRef<typeof SheetPrimitive.Overlay>,
   React.ComponentPropsWithoutRef<typeof SheetPrimitive.Overlay>
 >(({ className, ...props }, ref) => (
   <SheetPrimitive.Overlay
@@ -49,7 +49,7 @@ interface SheetContentProps
   extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
     VariantProps<typeof sheetVariants> {}
 
-const SheetContent = React.forwardRef<React.ElementRef<typeof SheetPrimitive.Content>, SheetContentProps>(
+const SheetContent = React.forwardRef<React.ComponentRef<typeof SheetPrimitive.Content>, SheetContentProps>(
   ({ side = "right", className, children, ...props }, ref) => (
     <SheetPortal>
       <SheetOverlay />
@@ -76,7 +76,7 @@ const SheetFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElemen
 SheetFooter.displayName = "SheetFooter";
 
 const SheetTitle = React.forwardRef<
-  React.ElementRef<typeof SheetPrimitive.Title>,
+  React.ComponentRef<typeof SheetPrimitive.Title>,
   React.ComponentPropsWithoutRef<typeof SheetPrimitive.Title>
 >(({ className, ...props }, ref) => (
   <SheetPrimitive.Title ref={ref} className={cn("text-lg font-semibold text-foreground", className)} {...props} />
@@ -84,7 +84,7 @@ const SheetTitle = React.forwardRef<
 SheetTitle.displayName = SheetPrimitive.Title.displayName;
 
 const SheetDescription = React.forwardRef<
-  React.ElementRef<typeof SheetPrimitive.Description>,
+  React.ComponentRef<typeof SheetPrimitive.Description>,
   React.ComponentPropsWithoutRef<typeof SheetPrimitive.Description>
 >(({ className, ...props }, ref) => (
   <SheetPrimitive.Description ref={ref} className={cn("text-sm text-muted-foreground", className)} {...props} />

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -11,10 +11,7 @@ const SheetTrigger = SheetPrimitive.Trigger;
 const SheetClose = SheetPrimitive.Close;
 const SheetPortal = SheetPrimitive.Portal;
 
-const SheetOverlay = React.forwardRef<
-  React.ComponentRef<typeof SheetPrimitive.Overlay>,
-  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Overlay>
->(({ className, ...props }, ref) => (
+const SheetOverlay = ({ className, ref, ...props }: React.ComponentPropsWithRef<typeof SheetPrimitive.Overlay>) => (
   <SheetPrimitive.Overlay
     className={cn(
       "fixed inset-0 z-50 bg-foreground/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
@@ -23,7 +20,7 @@ const SheetOverlay = React.forwardRef<
     {...props}
     ref={ref}
   />
-));
+);
 SheetOverlay.displayName = SheetPrimitive.Overlay.displayName;
 
 const sheetVariants = cva(
@@ -46,23 +43,22 @@ const sheetVariants = cva(
 );
 
 interface SheetContentProps
-  extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
+  extends React.ComponentPropsWithRef<typeof SheetPrimitive.Content>,
     VariantProps<typeof sheetVariants> {}
 
-const SheetContent = React.forwardRef<React.ComponentRef<typeof SheetPrimitive.Content>, SheetContentProps>(
-  ({ side = "right", className, children, ...props }, ref) => (
-    <SheetPortal>
-      <SheetOverlay />
-      <SheetPrimitive.Content ref={ref} className={cn(sheetVariants({ side }), className)} {...props}>
-        {children}
-        <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
-          <X className="h-4 w-4" />
-          <span className="sr-only">Close</span>
-        </SheetPrimitive.Close>
-      </SheetPrimitive.Content>
-    </SheetPortal>
-  ),
+const SheetContent = ({ side = "right", className, children, ref, ...props }: SheetContentProps) => (
+  <SheetPortal>
+    <SheetOverlay />
+    <SheetPrimitive.Content ref={ref} className={cn(sheetVariants({ side }), className)} {...props}>
+      {children}
+      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </SheetPrimitive.Close>
+    </SheetPrimitive.Content>
+  </SheetPortal>
 );
+
 SheetContent.displayName = SheetPrimitive.Content.displayName;
 
 const SheetHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
@@ -75,20 +71,18 @@ const SheetFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElemen
 );
 SheetFooter.displayName = "SheetFooter";
 
-const SheetTitle = React.forwardRef<
-  React.ComponentRef<typeof SheetPrimitive.Title>,
-  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Title>
->(({ className, ...props }, ref) => (
+const SheetTitle = ({ className, ref, ...props }: React.ComponentPropsWithRef<typeof SheetPrimitive.Title>) => (
   <SheetPrimitive.Title ref={ref} className={cn("text-lg font-semibold text-foreground", className)} {...props} />
-));
+);
 SheetTitle.displayName = SheetPrimitive.Title.displayName;
 
-const SheetDescription = React.forwardRef<
-  React.ComponentRef<typeof SheetPrimitive.Description>,
-  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Description>
->(({ className, ...props }, ref) => (
+const SheetDescription = ({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithRef<typeof SheetPrimitive.Description>) => (
   <SheetPrimitive.Description ref={ref} className={cn("text-sm text-muted-foreground", className)} {...props} />
-));
+);
 SheetDescription.displayName = SheetPrimitive.Description.displayName;
 
 export {

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -32,87 +32,92 @@ function useSidebar() {
   return context;
 }
 
-const SidebarProvider = React.forwardRef<HTMLDivElement, React.ComponentProps<"div">>(
-  ({ className, style, children, ...props }, ref) => {
-    const isMobile = useIsMobile();
-    const [openMobile, setOpenMobile] = React.useState(false);
-    const [open, setOpen] = React.useState(true);
+const SidebarProvider = ({ className, style, children, ref, ...props }: React.ComponentPropsWithRef<"div">) => {
+  const isMobile = useIsMobile();
+  const [openMobile, setOpenMobile] = React.useState(false);
+  const [open, setOpen] = React.useState(true);
 
-    const toggleSidebar = React.useCallback(() => {
-      if (isMobile) {
-        setOpenMobile((open) => !open);
-      } else {
-        setOpen((open) => !open);
-      }
-    }, [isMobile]);
+  const toggleSidebar = React.useCallback(() => {
+    if (isMobile) {
+      setOpenMobile((open) => !open);
+    } else {
+      setOpen((open) => !open);
+    }
+  }, [isMobile]);
 
-    const contextValue = React.useMemo<SidebarContext>(
-      () => ({
-        isMobile,
-        openMobile,
-        setOpenMobile,
-        open,
-        setOpen,
-        toggleSidebar,
-      }),
-      [isMobile, openMobile, setOpenMobile, open, setOpen, toggleSidebar],
-    );
+  const contextValue = React.useMemo<SidebarContext>(
+    () => ({
+      isMobile,
+      openMobile,
+      setOpenMobile,
+      open,
+      setOpen,
+      toggleSidebar,
+    }),
+    [isMobile, openMobile, setOpenMobile, open, setOpen, toggleSidebar],
+  );
 
-    return (
-      <SidebarContext.Provider value={contextValue}>
-        <TooltipProvider delayDuration={0}>
-          <div
-            className={cn("group/sidebar-wrapper flex h-svh w-full has-data-[variant=inset]:bg-sidebar", className)}
-            ref={ref}
-            style={style}
-            {...props}
-          >
-            {children}
-          </div>
-        </TooltipProvider>
-      </SidebarContext.Provider>
-    );
-  },
-);
+  return (
+    <SidebarContext.Provider value={contextValue}>
+      <TooltipProvider delayDuration={0}>
+        <div
+          className={cn("group/sidebar-wrapper flex h-svh w-full has-data-[variant=inset]:bg-sidebar", className)}
+          ref={ref}
+          style={style}
+          {...props}
+        >
+          {children}
+        </div>
+      </TooltipProvider>
+    </SidebarContext.Provider>
+  );
+};
+
 SidebarProvider.displayName = "SidebarProvider";
 
-const SidebarRail = React.forwardRef<HTMLButtonElement, React.ComponentProps<"button">>(
-  ({ className, ...props }, ref) => {
-    const { toggleSidebar } = useSidebar();
+const SidebarRail = ({ className, ref, ...props }: React.ComponentPropsWithRef<"button">) => {
+  const { toggleSidebar } = useSidebar();
 
-    return (
-      <button
-        ref={ref}
-        data-sidebar="rail"
-        aria-label="Toggle Sidebar"
-        tabIndex={-1}
-        onClick={toggleSidebar}
-        title="Toggle Sidebar"
-        className={cn(
-          "group relative flex items-center justify-center bg-sidebar",
-          "absolute inset-y-0 z-50 w-1 transition-all ease-linear",
-          "group-data-[side=left]:right-0 group-data-[side=right]:left-0",
-          "group-data-[side=left]:cursor-w-resize group-data-[side=right]:cursor-e-resize",
-          "group-data-[state=collapsed]:group-data-[side=left]:cursor-e-resize group-data-[state=collapsed]:group-data-[side=right]:cursor-w-resize",
-          "border-r border-r-sidebar-border/50",
-          "hover:w-2 hover:border-r-4 hover:border-r-sidebar-border",
-          className,
-        )}
-        {...props}
-      />
-    );
-  },
-);
+  return (
+    <button
+      ref={ref}
+      data-sidebar="rail"
+      aria-label="Toggle Sidebar"
+      tabIndex={-1}
+      onClick={toggleSidebar}
+      title="Toggle Sidebar"
+      className={cn(
+        "group relative flex items-center justify-center bg-sidebar",
+        "absolute inset-y-0 z-50 w-1 transition-all ease-linear",
+        "group-data-[side=left]:right-0 group-data-[side=right]:left-0",
+        "group-data-[side=left]:cursor-w-resize group-data-[side=right]:cursor-e-resize",
+        "group-data-[state=collapsed]:group-data-[side=left]:cursor-e-resize group-data-[state=collapsed]:group-data-[side=right]:cursor-w-resize",
+        "border-r border-r-sidebar-border/50",
+        "hover:w-2 hover:border-r-4 hover:border-r-sidebar-border",
+        className,
+      )}
+      {...props}
+    />
+  );
+};
+
 SidebarRail.displayName = "SidebarRail";
 
-const Sidebar = React.forwardRef<
-  HTMLDivElement,
-  React.ComponentProps<"div"> & {
-    side?: "left" | "right";
-    variant?: "sidebar" | "floating" | "inset";
-    collapsible?: "offcanvas" | "icon" | "none";
-  }
->(({ side = "left", variant = "sidebar", collapsible = "offcanvas", className, children, ...props }, ref) => {
+type SidebarProps = React.ComponentPropsWithRef<"div"> & {
+  side?: "left" | "right";
+  variant?: "sidebar" | "floating" | "inset";
+  collapsible?: "offcanvas" | "icon" | "none";
+};
+
+const Sidebar = ({
+  side = "left",
+  variant = "sidebar",
+  collapsible = "offcanvas",
+  className,
+  children,
+  ref,
+  ...props
+}: SidebarProps) => {
   const { isMobile, open, openMobile, setOpenMobile } = useSidebar();
 
   if (collapsible === "none") {
@@ -183,27 +188,26 @@ const Sidebar = React.forwardRef<
       <SidebarRail />
     </div>
   );
-});
+};
 Sidebar.displayName = "Sidebar";
 
-const SidebarInput = React.forwardRef<React.ComponentRef<typeof Input>, React.ComponentProps<typeof Input>>(
-  ({ className, ...props }, ref) => {
-    return (
-      <Input
-        ref={ref}
-        data-sidebar="input"
-        className={cn(
-          "h-8 w-full bg-background shadow-none focus-visible:ring-2 focus-visible:ring-sidebar-ring",
-          className,
-        )}
-        {...props}
-      />
-    );
-  },
-);
+const SidebarInput = ({ className, ref, ...props }: React.ComponentPropsWithRef<typeof Input>) => {
+  return (
+    <Input
+      ref={ref}
+      data-sidebar="input"
+      className={cn(
+        "h-8 w-full bg-background shadow-none focus-visible:ring-2 focus-visible:ring-sidebar-ring",
+        className,
+      )}
+      {...props}
+    />
+  );
+};
+
 SidebarInput.displayName = "SidebarInput";
 
-const SidebarHeader = React.forwardRef<HTMLDivElement, React.ComponentProps<"div">>(({ className, ...props }, ref) => {
+const SidebarHeader = ({ className, ref, ...props }: React.ComponentPropsWithRef<"div">) => {
   return (
     <div
       ref={ref}
@@ -212,10 +216,11 @@ const SidebarHeader = React.forwardRef<HTMLDivElement, React.ComponentProps<"div
       {...props}
     />
   );
-});
+};
+
 SidebarHeader.displayName = "SidebarHeader";
 
-const SidebarFooter = React.forwardRef<HTMLDivElement, React.ComponentProps<"div">>(({ className, ...props }, ref) => {
+const SidebarFooter = ({ className, ref, ...props }: React.ComponentPropsWithRef<"div">) => {
   return (
     <div
       ref={ref}
@@ -224,24 +229,23 @@ const SidebarFooter = React.forwardRef<HTMLDivElement, React.ComponentProps<"div
       {...props}
     />
   );
-});
+};
 SidebarFooter.displayName = "SidebarFooter";
 
-const SidebarSeparator = React.forwardRef<React.ComponentRef<typeof Separator>, React.ComponentProps<typeof Separator>>(
-  ({ className, ...props }, ref) => {
-    return (
-      <Separator
-        ref={ref}
-        data-sidebar="separator"
-        className={cn("mx-2 w-auto bg-sidebar-border", className)}
-        {...props}
-      />
-    );
-  },
-);
+const SidebarSeparator = ({ className, ref, ...props }: React.ComponentPropsWithRef<typeof Separator>) => {
+  return (
+    <Separator
+      ref={ref}
+      data-sidebar="separator"
+      className={cn("mx-2 w-auto bg-sidebar-border", className)}
+      {...props}
+    />
+  );
+};
+
 SidebarSeparator.displayName = "SidebarSeparator";
 
-const SidebarContent = React.forwardRef<HTMLDivElement, React.ComponentProps<"div">>(({ className, ...props }, ref) => {
+const SidebarContent = ({ className, ref, ...props }: React.ComponentPropsWithRef<"div">) => {
   return (
     <div
       ref={ref}
@@ -253,10 +257,10 @@ const SidebarContent = React.forwardRef<HTMLDivElement, React.ComponentProps<"di
       {...props}
     />
   );
-});
+};
 SidebarContent.displayName = "SidebarContent";
 
-const SidebarGroup = React.forwardRef<HTMLDivElement, React.ComponentProps<"div">>(({ className, ...props }, ref) => {
+const SidebarGroup = ({ className, ref, ...props }: React.ComponentPropsWithRef<"div">) => {
   return (
     <div
       ref={ref}
@@ -265,66 +269,70 @@ const SidebarGroup = React.forwardRef<HTMLDivElement, React.ComponentProps<"div"
       {...props}
     />
   );
-});
+};
 SidebarGroup.displayName = "SidebarGroup";
 
-const SidebarGroupLabel = React.forwardRef<HTMLDivElement, React.ComponentProps<"div"> & { asChild?: boolean }>(
-  ({ className, asChild = false, ...props }, ref) => {
-    const Comp = asChild ? Slot : "div";
+const SidebarGroupLabel = ({
+  className,
+  asChild = false,
+  ref,
+  ...props
+}: React.ComponentPropsWithRef<"div"> & { asChild?: boolean }) => {
+  const Comp = asChild ? Slot : "div";
 
-    return (
-      <Comp
-        ref={ref}
-        data-sidebar="group-label"
-        className={cn(
-          "duration-200 flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium text-sidebar-foreground/70 outline-hidden ring-sidebar-ring transition-[margin,opa] ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
-          "group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0",
-          className,
-        )}
-        {...props}
-      />
-    );
-  },
-);
+  return (
+    <Comp
+      ref={ref}
+      data-sidebar="group-label"
+      className={cn(
+        "duration-200 flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium text-sidebar-foreground/70 outline-hidden ring-sidebar-ring transition-[margin,opa] ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+        "group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0",
+        className,
+      )}
+      {...props}
+    />
+  );
+};
 SidebarGroupLabel.displayName = "SidebarGroupLabel";
 
-const SidebarGroupAction = React.forwardRef<HTMLButtonElement, React.ComponentProps<"button"> & { asChild?: boolean }>(
-  ({ className, asChild = false, ...props }, ref) => {
-    const Comp = asChild ? Slot : "button";
+const SidebarGroupAction = ({
+  className,
+  asChild = false,
+  ref,
+  ...props
+}: React.ComponentPropsWithRef<"button"> & { asChild?: boolean }) => {
+  const Comp = asChild ? Slot : "button";
 
-    return (
-      <Comp
-        ref={ref}
-        data-sidebar="group-action"
-        className={cn(
-          "absolute right-3 top-3.5 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground outline-hidden ring-sidebar-ring transition-transform hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
-          // Increases the hit area of the button on mobile.
-          "after:absolute after:-inset-2 md:after:hidden",
-          "group-data-[collapsible=icon]:hidden",
-          className,
-        )}
-        {...props}
-      />
-    );
-  },
-);
+  return (
+    <Comp
+      ref={ref}
+      data-sidebar="group-action"
+      className={cn(
+        "absolute right-3 top-3.5 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground outline-hidden ring-sidebar-ring transition-transform hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+        // Increases the hit area of the button on mobile.
+        "after:absolute after:-inset-2 md:after:hidden",
+        "group-data-[collapsible=icon]:hidden",
+        className,
+      )}
+      {...props}
+    />
+  );
+};
 SidebarGroupAction.displayName = "SidebarGroupAction";
 
-const SidebarGroupContent = React.forwardRef<HTMLDivElement, React.ComponentProps<"div">>(
-  ({ className, ...props }, ref) => (
-    <div ref={ref} data-sidebar="group-content" className={cn("w-full text-sm", className)} {...props} />
-  ),
-);
+const SidebarGroupContent = ({ className, ref, ...props }: React.ComponentPropsWithRef<"div">) => {
+  return <div ref={ref} data-sidebar="group-content" className={cn("w-full text-sm", className)} {...props} />;
+};
 SidebarGroupContent.displayName = "SidebarGroupContent";
 
-const SidebarMenu = React.forwardRef<HTMLUListElement, React.ComponentProps<"ul">>(({ className, ...props }, ref) => (
+const SidebarMenu = ({ className, ref, ...props }: React.ComponentPropsWithRef<"ul">) => (
   <ul ref={ref} data-sidebar="menu" className={cn("flex w-full min-w-0 flex-col gap-1", className)} {...props} />
-));
+);
 SidebarMenu.displayName = "SidebarMenu";
 
-const SidebarMenuItem = React.forwardRef<HTMLLIElement, React.ComponentProps<"li">>(({ className, ...props }, ref) => (
+const SidebarMenuItem = ({ className, ref, ...props }: React.ComponentPropsWithRef<"li">) => (
   <li ref={ref} data-sidebar="menu-item" className={cn("group/menu-item relative", className)} {...props} />
-));
+);
 SidebarMenuItem.displayName = "SidebarMenuItem";
 
 const sidebarMenuButtonVariants = cva(
@@ -349,14 +357,22 @@ const sidebarMenuButtonVariants = cva(
   },
 );
 
-const SidebarMenuButton = React.forwardRef<
-  HTMLButtonElement,
-  React.ComponentProps<"button"> & {
-    asChild?: boolean;
-    isActive?: boolean;
-    tooltip?: string | React.ComponentProps<typeof TooltipContent>;
-  } & VariantProps<typeof sidebarMenuButtonVariants>
->(({ asChild = false, isActive = false, variant = "default", size = "default", tooltip, className, ...props }, ref) => {
+type SidebarMenuButtonProps = React.ComponentPropsWithRef<"button"> & {
+  asChild?: boolean;
+  isActive?: boolean;
+  tooltip?: string | React.ComponentProps<typeof TooltipContent>;
+} & VariantProps<typeof sidebarMenuButtonVariants>;
+
+const SidebarMenuButton = ({
+  asChild = false,
+  isActive = false,
+  variant = "default",
+  size = "default",
+  tooltip,
+  className,
+  ref,
+  ...props
+}: SidebarMenuButtonProps) => {
   const Comp = asChild ? Slot : "button";
   const { isMobile, open } = useSidebar();
 
@@ -383,16 +399,21 @@ const SidebarMenuButton = React.forwardRef<
       <TooltipContent side="right" align="center" hidden={isMobile || open} {...tooltipProps} />
     </Tooltip>
   );
-});
+};
 SidebarMenuButton.displayName = "SidebarMenuButton";
 
-const SidebarMenuAction = React.forwardRef<
-  HTMLButtonElement,
-  React.ComponentProps<"button"> & {
-    asChild?: boolean;
-    showOnHover?: boolean;
-  }
->(({ className, asChild = false, showOnHover = false, ...props }, ref) => {
+type SidebarMenuActionProps = React.ComponentPropsWithRef<"button"> & {
+  asChild?: boolean;
+  showOnHover?: boolean;
+};
+
+const SidebarMenuAction = ({
+  className,
+  asChild = false,
+  showOnHover = false,
+  ref,
+  ...props
+}: SidebarMenuActionProps) => {
   const Comp = asChild ? Slot : "button";
 
   return (
@@ -414,35 +435,32 @@ const SidebarMenuAction = React.forwardRef<
       {...props}
     />
   );
-});
+};
 SidebarMenuAction.displayName = "SidebarMenuAction";
 
-const SidebarMenuBadge = React.forwardRef<HTMLDivElement, React.ComponentProps<"div">>(
-  ({ className, ...props }, ref) => (
-    <div
-      ref={ref}
-      data-sidebar="menu-badge"
-      className={cn(
-        "absolute right-1 flex h-5 min-w-5 items-center justify-center rounded-md px-1 text-xs font-medium tabular-nums text-sidebar-foreground select-none pointer-events-none",
-        "peer-hover/menu-button:text-sidebar-accent-foreground peer-data-[active=true]/menu-button:text-sidebar-accent-foreground",
-        "peer-data-[size=sm]/menu-button:top-1",
-        "peer-data-[size=default]/menu-button:top-1.5",
-        "peer-data-[size=lg]/menu-button:top-2.5",
-        "group-data-[collapsible=icon]:hidden",
-        className,
-      )}
-      {...props}
-    />
-  ),
+const SidebarMenuBadge = ({ className, ref, ...props }: React.ComponentPropsWithRef<"div">) => (
+  <div
+    ref={ref}
+    data-sidebar="menu-badge"
+    className={cn(
+      "absolute right-1 flex h-5 min-w-5 items-center justify-center rounded-md px-1 text-xs font-medium tabular-nums text-sidebar-foreground select-none pointer-events-none",
+      "peer-hover/menu-button:text-sidebar-accent-foreground peer-data-[active=true]/menu-button:text-sidebar-accent-foreground",
+      "peer-data-[size=sm]/menu-button:top-1",
+      "peer-data-[size=default]/menu-button:top-1.5",
+      "peer-data-[size=lg]/menu-button:top-2.5",
+      "group-data-[collapsible=icon]:hidden",
+      className,
+    )}
+    {...props}
+  />
 );
 SidebarMenuBadge.displayName = "SidebarMenuBadge";
 
-const SidebarMenuSkeleton = React.forwardRef<
-  HTMLDivElement,
-  React.ComponentProps<"div"> & {
-    showIcon?: boolean;
-  }
->(({ className, showIcon = false, ...props }, ref) => {
+type SidebarMenuSkeletonProps = React.ComponentPropsWithRef<"div"> & {
+  showIcon?: boolean;
+};
+
+const SidebarMenuSkeleton = ({ className, showIcon = false, ref, ...props }: SidebarMenuSkeletonProps) => {
   // Random width between 50 to 90%.
   const width = React.useMemo(() => {
     return `${Math.floor(Math.random() * 40) + 50}%`;
@@ -467,38 +485,40 @@ const SidebarMenuSkeleton = React.forwardRef<
       />
     </div>
   );
-});
+};
 SidebarMenuSkeleton.displayName = "SidebarMenuSkeleton";
 
-const SidebarMenuSub = React.forwardRef<HTMLUListElement, React.ComponentProps<"ul">>(
-  ({ className, ...props }, ref) => (
-    <ul
-      ref={ref}
-      data-sidebar="menu-sub"
-      className={cn(
-        "mx-3.5 flex min-w-0 translate-x-px flex-col gap-1 border-l border-sidebar-border px-2.5 py-0.5",
-        "group-data-[collapsible=icon]:hidden",
-        className,
-      )}
-      {...props}
-    />
-  ),
+const SidebarMenuSub = ({ className, ref, ...props }: React.ComponentPropsWithRef<"ul">) => (
+  <ul
+    ref={ref}
+    data-sidebar="menu-sub"
+    className={cn(
+      "mx-3.5 flex min-w-0 translate-x-px flex-col gap-1 border-l border-sidebar-border px-2.5 py-0.5",
+      "group-data-[collapsible=icon]:hidden",
+      className,
+    )}
+    {...props}
+  />
 );
 SidebarMenuSub.displayName = "SidebarMenuSub";
 
-const SidebarMenuSubItem = React.forwardRef<HTMLLIElement, React.ComponentProps<"li">>(({ ...props }, ref) => (
-  <li ref={ref} {...props} />
-));
+const SidebarMenuSubItem = ({ ref, ...props }: React.ComponentPropsWithRef<"li">) => <li ref={ref} {...props} />;
 SidebarMenuSubItem.displayName = "SidebarMenuSubItem";
 
-const SidebarMenuSubButton = React.forwardRef<
-  HTMLAnchorElement,
-  React.ComponentProps<"a"> & {
-    asChild?: boolean;
-    size?: "sm" | "md";
-    isActive?: boolean;
-  }
->(({ asChild = false, size = "md", isActive, className, ...props }, ref) => {
+type SidebarMenuSubButtonProps = React.ComponentPropsWithRef<"a"> & {
+  asChild?: boolean;
+  size?: "sm" | "md";
+  isActive?: boolean;
+};
+
+const SidebarMenuSubButton = ({
+  asChild = false,
+  size = "md",
+  isActive,
+  className,
+  ref,
+  ...props
+}: SidebarMenuSubButtonProps) => {
   const Comp = asChild ? Slot : "a";
 
   return (
@@ -518,32 +538,30 @@ const SidebarMenuSubButton = React.forwardRef<
       {...props}
     />
   );
-});
+};
 SidebarMenuSubButton.displayName = "SidebarMenuSubButton";
 
-const SidebarTrigger = React.forwardRef<React.ComponentRef<typeof Button>, React.ComponentProps<typeof Button>>(
-  ({ className, onClick, ...props }, ref) => {
-    const { toggleSidebar, open } = useSidebar();
+const SidebarTrigger = ({ className, onClick, ref, ...props }: React.ComponentPropsWithRef<typeof Button>) => {
+  const { toggleSidebar, open } = useSidebar();
 
-    return (
-      <Button
-        ref={ref}
-        data-sidebar="trigger"
-        variant="ghost"
-        size="sm"
-        className={cn("h-7 w-7", className)}
-        onClick={(event) => {
-          onClick?.(event);
-          toggleSidebar();
-        }}
-        {...props}
-      >
-        <PanelLeft className={cn("h-4 w-4 transition-transform duration-200", !open && "rotate-180")} />
-        <span className="sr-only">Toggle Sidebar</span>
-      </Button>
-    );
-  },
-);
+  return (
+    <Button
+      ref={ref}
+      data-sidebar="trigger"
+      variant="ghost"
+      size="sm"
+      className={cn("h-7 w-7", className)}
+      onClick={(event) => {
+        onClick?.(event);
+        toggleSidebar();
+      }}
+      {...props}
+    >
+      <PanelLeft className={cn("h-4 w-4 transition-transform duration-200", !open && "rotate-180")} />
+      <span className="sr-only">Toggle Sidebar</span>
+    </Button>
+  );
+};
 SidebarTrigger.displayName = "SidebarTrigger";
 
 export {

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -186,7 +186,7 @@ const Sidebar = React.forwardRef<
 });
 Sidebar.displayName = "Sidebar";
 
-const SidebarInput = React.forwardRef<React.ElementRef<typeof Input>, React.ComponentProps<typeof Input>>(
+const SidebarInput = React.forwardRef<React.ComponentRef<typeof Input>, React.ComponentProps<typeof Input>>(
   ({ className, ...props }, ref) => {
     return (
       <Input
@@ -227,7 +227,7 @@ const SidebarFooter = React.forwardRef<HTMLDivElement, React.ComponentProps<"div
 });
 SidebarFooter.displayName = "SidebarFooter";
 
-const SidebarSeparator = React.forwardRef<React.ElementRef<typeof Separator>, React.ComponentProps<typeof Separator>>(
+const SidebarSeparator = React.forwardRef<React.ComponentRef<typeof Separator>, React.ComponentProps<typeof Separator>>(
   ({ className, ...props }, ref) => {
     return (
       <Separator
@@ -521,7 +521,7 @@ const SidebarMenuSubButton = React.forwardRef<
 });
 SidebarMenuSubButton.displayName = "SidebarMenuSubButton";
 
-const SidebarTrigger = React.forwardRef<React.ElementRef<typeof Button>, React.ComponentProps<typeof Button>>(
+const SidebarTrigger = React.forwardRef<React.ComponentRef<typeof Button>, React.ComponentProps<typeof Button>>(
   ({ className, onClick, ...props }, ref) => {
     const { toggleSidebar, open } = useSidebar();
 

--- a/components/ui/switch.tsx
+++ b/components/ui/switch.tsx
@@ -4,10 +4,7 @@ import * as SwitchPrimitives from "@radix-ui/react-switch";
 import * as React from "react";
 import { cn } from "@/lib/utils";
 
-const Switch = React.forwardRef<
-  React.ComponentRef<typeof SwitchPrimitives.Root>,
-  React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>
->(({ className, ...props }, ref) => (
+const Switch = ({ className, ref, ...props }: React.ComponentPropsWithRef<typeof SwitchPrimitives.Root>) => (
   <SwitchPrimitives.Root
     className={cn(
       "peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-bright data-[state=unchecked]:bg-border",
@@ -22,7 +19,7 @@ const Switch = React.forwardRef<
       )}
     />
   </SwitchPrimitives.Root>
-));
+);
 Switch.displayName = SwitchPrimitives.Root.displayName;
 
 export { Switch };

--- a/components/ui/switch.tsx
+++ b/components/ui/switch.tsx
@@ -5,7 +5,7 @@ import * as React from "react";
 import { cn } from "@/lib/utils";
 
 const Switch = React.forwardRef<
-  React.ElementRef<typeof SwitchPrimitives.Root>,
+  React.ComponentRef<typeof SwitchPrimitives.Root>,
   React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>
 >(({ className, ...props }, ref) => (
   <SwitchPrimitives.Root

--- a/components/ui/table.tsx
+++ b/components/ui/table.tsx
@@ -1,70 +1,56 @@
 import * as React from "react";
 import { cn } from "@/lib/utils";
 
-const Table = React.forwardRef<HTMLTableElement, React.HTMLAttributes<HTMLTableElement>>(
-  ({ className, ...props }, ref) => (
-    <div className="relative w-full overflow-auto">
-      <table ref={ref} className={cn("w-full caption-bottom text-sm", className)} {...props} />
-    </div>
-  ),
+const Table = ({ className, ref, ...props }: React.ComponentPropsWithRef<"table">) => (
+  <div className="relative w-full overflow-auto">
+    <table ref={ref} className={cn("w-full caption-bottom text-sm", className)} {...props} />
+  </div>
 );
 Table.displayName = "Table";
 
-const TableHeader = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(
-  ({ className, ...props }, ref) => <thead ref={ref} className={cn("[&_tr]:border-b", className)} {...props} />,
+const TableHeader = ({ className, ref, ...props }: React.ComponentPropsWithRef<"thead">) => (
+  <thead ref={ref} className={cn("[&_tr]:border-b", className)} {...props} />
 );
 TableHeader.displayName = "TableHeader";
 
-const TableBody = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(
-  ({ className, ...props }, ref) => (
-    <tbody ref={ref} className={cn("[&_tr:last-child]:border-0", className)} {...props} />
-  ),
+const TableBody = ({ className, ref, ...props }: React.ComponentPropsWithRef<"tbody">) => (
+  <tbody ref={ref} className={cn("[&_tr:last-child]:border-0", className)} {...props} />
 );
 TableBody.displayName = "TableBody";
 
-const TableFooter = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(
-  ({ className, ...props }, ref) => (
-    <tfoot ref={ref} className={cn("border-t bg-muted/50 font-medium last:[&>tr]:border-b-0", className)} {...props} />
-  ),
+const TableFooter = ({ className, ref, ...props }: React.ComponentPropsWithRef<"tfoot">) => (
+  <tfoot ref={ref} className={cn("border-t bg-muted/50 font-medium last:[&>tr]:border-b-0", className)} {...props} />
 );
 TableFooter.displayName = "TableFooter";
 
-const TableRow = React.forwardRef<HTMLTableRowElement, React.HTMLAttributes<HTMLTableRowElement>>(
-  ({ className, ...props }, ref) => (
-    <tr
-      ref={ref}
-      className={cn("border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted", className)}
-      {...props}
-    />
-  ),
+const TableRow = ({ className, ref, ...props }: React.ComponentPropsWithRef<"tr">) => (
+  <tr
+    ref={ref}
+    className={cn("border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted", className)}
+    {...props}
+  />
 );
 TableRow.displayName = "TableRow";
 
-const TableHead = React.forwardRef<HTMLTableCellElement, React.ThHTMLAttributes<HTMLTableCellElement>>(
-  ({ className, ...props }, ref) => (
-    <th
-      ref={ref}
-      className={cn(
-        "h-12 px-4 text-left align-middle text-xs font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0",
-        className,
-      )}
-      {...props}
-    />
-  ),
+const TableHead = ({ className, ref, ...props }: React.ComponentPropsWithRef<"th">) => (
+  <th
+    ref={ref}
+    className={cn(
+      "h-12 px-4 text-left align-middle text-xs font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0",
+      className,
+    )}
+    {...props}
+  />
 );
 TableHead.displayName = "TableHead";
 
-const TableCell = React.forwardRef<HTMLTableCellElement, React.TdHTMLAttributes<HTMLTableCellElement>>(
-  ({ className, ...props }, ref) => (
-    <td ref={ref} className={cn("p-4 align-middle [&:has([role=checkbox])]:pr-0", className)} {...props} />
-  ),
+const TableCell = ({ className, ref, ...props }: React.ComponentPropsWithRef<"td">) => (
+  <td ref={ref} className={cn("p-4 align-middle [&:has([role=checkbox])]:pr-0", className)} {...props} />
 );
 TableCell.displayName = "TableCell";
 
-const TableCaption = React.forwardRef<HTMLTableCaptionElement, React.HTMLAttributes<HTMLTableCaptionElement>>(
-  ({ className, ...props }, ref) => (
-    <caption ref={ref} className={cn("mt-4 text-sm text-muted-foreground", className)} {...props} />
-  ),
+const TableCaption = ({ className, ref, ...props }: React.ComponentPropsWithRef<"caption">) => (
+  <caption ref={ref} className={cn("mt-4 text-sm text-muted-foreground", className)} {...props} />
 );
 TableCaption.displayName = "TableCaption";
 

--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -7,7 +7,7 @@ import { cn } from "@/lib/utils";
 const Tabs = TabsPrimitive.Root;
 
 const TabsList = React.forwardRef<
-  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentRef<typeof TabsPrimitive.List>,
   React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
 >(({ className, ...props }, ref) => (
   <TabsPrimitive.List
@@ -22,7 +22,7 @@ const TabsList = React.forwardRef<
 TabsList.displayName = TabsPrimitive.List.displayName;
 
 const TabsTrigger = React.forwardRef<
-  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentRef<typeof TabsPrimitive.Trigger>,
   React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
 >(({ className, ...props }, ref) => (
   <TabsPrimitive.Trigger
@@ -37,7 +37,7 @@ const TabsTrigger = React.forwardRef<
 TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
 
 const TabsContent = React.forwardRef<
-  React.ElementRef<typeof TabsPrimitive.Content>,
+  React.ComponentRef<typeof TabsPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
 >(({ className, ...props }, ref) => (
   <TabsPrimitive.Content

--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -6,10 +6,7 @@ import { cn } from "@/lib/utils";
 
 const Tabs = TabsPrimitive.Root;
 
-const TabsList = React.forwardRef<
-  React.ComponentRef<typeof TabsPrimitive.List>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
->(({ className, ...props }, ref) => (
+const TabsList = ({ className, ref, ...props }: React.ComponentPropsWithRef<typeof TabsPrimitive.List>) => (
   <TabsPrimitive.List
     ref={ref}
     className={cn(
@@ -18,13 +15,10 @@ const TabsList = React.forwardRef<
     )}
     {...props}
   />
-));
+);
 TabsList.displayName = TabsPrimitive.List.displayName;
 
-const TabsTrigger = React.forwardRef<
-  React.ComponentRef<typeof TabsPrimitive.Trigger>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
->(({ className, ...props }, ref) => (
+const TabsTrigger = ({ className, ref, ...props }: React.ComponentPropsWithRef<typeof TabsPrimitive.Trigger>) => (
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
@@ -33,13 +27,10 @@ const TabsTrigger = React.forwardRef<
     )}
     {...props}
   />
-));
+);
 TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
 
-const TabsContent = React.forwardRef<
-  React.ComponentRef<typeof TabsPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
->(({ className, ...props }, ref) => (
+const TabsContent = ({ className, ref, ...props }: React.ComponentPropsWithRef<typeof TabsPrimitive.Content>) => (
   <TabsPrimitive.Content
     ref={ref}
     className={cn(
@@ -48,7 +39,7 @@ const TabsContent = React.forwardRef<
     )}
     {...props}
   />
-));
+);
 TabsContent.displayName = TabsPrimitive.Content.displayName;
 
 export { Tabs, TabsList, TabsTrigger, TabsContent };

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -4,7 +4,7 @@ import { cn } from "@/lib/utils";
 
 export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
   onModEnter?: () => void;
-  ref?: React.RefObject<HTMLTextAreaElement>;
+  ref?: React.Ref<HTMLTextAreaElement>;
 }
 
 const Textarea = ({ className, onModEnter, ref, ...props }: TextareaProps) => {

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -4,9 +4,10 @@ import { cn } from "@/lib/utils";
 
 export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
   onModEnter?: () => void;
+  ref?: React.RefObject<HTMLTextAreaElement>;
 }
 
-const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(({ className, onModEnter, ...props }, ref) => {
+const Textarea = ({ className, onModEnter, ref, ...props }: TextareaProps) => {
   return (
     <textarea
       className={cn(
@@ -19,7 +20,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(({ classNa
       {...props}
     />
   );
-});
+};
 Textarea.displayName = "Textarea";
 
 export { Textarea };

--- a/components/ui/toast.tsx
+++ b/components/ui/toast.tsx
@@ -9,7 +9,7 @@ import { cn } from "@/lib/utils";
 const ToastProvider = ToastPrimitives.Provider;
 
 const ToastViewport = React.forwardRef<
-  React.ElementRef<typeof ToastPrimitives.Viewport>,
+  React.ComponentRef<typeof ToastPrimitives.Viewport>,
   React.ComponentPropsWithoutRef<typeof ToastPrimitives.Viewport>
 >(({ className, ...props }, ref) => (
   <ToastPrimitives.Viewport
@@ -39,7 +39,7 @@ const toastVariants = cva(
 );
 
 const Toast = React.forwardRef<
-  React.ElementRef<typeof ToastPrimitives.Root>,
+  React.ComponentRef<typeof ToastPrimitives.Root>,
   React.ComponentPropsWithoutRef<typeof ToastPrimitives.Root> & VariantProps<typeof toastVariants>
 >(({ className, variant, ...props }, ref) => {
   const variantIconMap: Record<string, React.ElementType> = {
@@ -62,7 +62,7 @@ const Toast = React.forwardRef<
 Toast.displayName = ToastPrimitives.Root.displayName;
 
 const ToastAction = React.forwardRef<
-  React.ElementRef<typeof ToastPrimitives.Action>,
+  React.ComponentRef<typeof ToastPrimitives.Action>,
   React.ComponentPropsWithoutRef<typeof ToastPrimitives.Action>
 >(({ className, ...props }, ref) => (
   <ToastPrimitives.Action
@@ -74,7 +74,7 @@ const ToastAction = React.forwardRef<
 ToastAction.displayName = ToastPrimitives.Action.displayName;
 
 const ToastClose = React.forwardRef<
-  React.ElementRef<typeof ToastPrimitives.Close>,
+  React.ComponentRef<typeof ToastPrimitives.Close>,
   React.ComponentPropsWithoutRef<typeof ToastPrimitives.Close>
 >(({ className, ...props }, ref) => (
   <ToastPrimitives.Close ref={ref} className={cn("text-success-foreground", className)} toast-close="" {...props}>
@@ -84,7 +84,7 @@ const ToastClose = React.forwardRef<
 ToastClose.displayName = ToastPrimitives.Close.displayName;
 
 const ToastTitle = React.forwardRef<
-  React.ElementRef<typeof ToastPrimitives.Title>,
+  React.ComponentRef<typeof ToastPrimitives.Title>,
   React.ComponentPropsWithoutRef<typeof ToastPrimitives.Title>
 >(({ className, ...props }, ref) => (
   <ToastPrimitives.Title ref={ref} className={cn("text-sm font-semibold", className)} {...props} />
@@ -92,7 +92,7 @@ const ToastTitle = React.forwardRef<
 ToastTitle.displayName = ToastPrimitives.Title.displayName;
 
 const ToastDescription = React.forwardRef<
-  React.ElementRef<typeof ToastPrimitives.Description>,
+  React.ComponentRef<typeof ToastPrimitives.Description>,
   React.ComponentPropsWithoutRef<typeof ToastPrimitives.Description>
 >(({ className, ...props }, ref) => (
   <ToastPrimitives.Description ref={ref} className={cn("text-sm", className)} {...props} />

--- a/components/ui/toast.tsx
+++ b/components/ui/toast.tsx
@@ -8,10 +8,7 @@ import { cn } from "@/lib/utils";
 
 const ToastProvider = ToastPrimitives.Provider;
 
-const ToastViewport = React.forwardRef<
-  React.ComponentRef<typeof ToastPrimitives.Viewport>,
-  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Viewport>
->(({ className, ...props }, ref) => (
+const ToastViewport = ({ className, ref, ...props }: React.ComponentPropsWithRef<typeof ToastPrimitives.Viewport>) => (
   <ToastPrimitives.Viewport
     ref={ref}
     className={cn(
@@ -20,7 +17,7 @@ const ToastViewport = React.forwardRef<
     )}
     {...props}
   />
-));
+);
 ToastViewport.displayName = ToastPrimitives.Viewport.displayName;
 
 const toastVariants = cva(
@@ -38,10 +35,12 @@ const toastVariants = cva(
   },
 );
 
-const Toast = React.forwardRef<
-  React.ComponentRef<typeof ToastPrimitives.Root>,
-  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Root> & VariantProps<typeof toastVariants>
->(({ className, variant, ...props }, ref) => {
+const Toast = ({
+  className,
+  variant,
+  ref,
+  ...props
+}: React.ComponentPropsWithRef<typeof ToastPrimitives.Root> & VariantProps<typeof toastVariants>) => {
   const variantIconMap: Record<string, React.ElementType> = {
     success: CircleCheck,
     destructive: CircleAlert,
@@ -58,45 +57,37 @@ const Toast = React.forwardRef<
       {props.children}
     </ToastPrimitives.Root>
   );
-});
+};
 Toast.displayName = ToastPrimitives.Root.displayName;
 
-const ToastAction = React.forwardRef<
-  React.ComponentRef<typeof ToastPrimitives.Action>,
-  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Action>
->(({ className, ...props }, ref) => (
+const ToastAction = ({ className, ref, ...props }: React.ComponentPropsWithRef<typeof ToastPrimitives.Action>) => (
   <ToastPrimitives.Action
     ref={ref}
     className={cn("text-sm leading-none text-success-foreground underline", className)}
     {...props}
   />
-));
+);
 ToastAction.displayName = ToastPrimitives.Action.displayName;
 
-const ToastClose = React.forwardRef<
-  React.ComponentRef<typeof ToastPrimitives.Close>,
-  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Close>
->(({ className, ...props }, ref) => (
+const ToastClose = ({ className, ref, ...props }: React.ComponentPropsWithRef<typeof ToastPrimitives.Close>) => (
   <ToastPrimitives.Close ref={ref} className={cn("text-success-foreground", className)} toast-close="" {...props}>
     <X className="h-4 w-4 shrink-0" />
   </ToastPrimitives.Close>
-));
+);
 ToastClose.displayName = ToastPrimitives.Close.displayName;
 
-const ToastTitle = React.forwardRef<
-  React.ComponentRef<typeof ToastPrimitives.Title>,
-  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Title>
->(({ className, ...props }, ref) => (
+const ToastTitle = ({ className, ref, ...props }: React.ComponentPropsWithRef<typeof ToastPrimitives.Title>) => (
   <ToastPrimitives.Title ref={ref} className={cn("text-sm font-semibold", className)} {...props} />
-));
+);
 ToastTitle.displayName = ToastPrimitives.Title.displayName;
 
-const ToastDescription = React.forwardRef<
-  React.ComponentRef<typeof ToastPrimitives.Description>,
-  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Description>
->(({ className, ...props }, ref) => (
+const ToastDescription = ({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithRef<typeof ToastPrimitives.Description>) => (
   <ToastPrimitives.Description ref={ref} className={cn("text-sm", className)} {...props} />
-));
+);
 ToastDescription.displayName = ToastPrimitives.Description.displayName;
 
 type ToastProps = React.ComponentPropsWithoutRef<typeof Toast>;

--- a/components/ui/toggle.tsx
+++ b/components/ui/toggle.tsx
@@ -26,12 +26,15 @@ const toggleVariants = cva(
   },
 );
 
-const Toggle = React.forwardRef<
-  React.ComponentRef<typeof TogglePrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof TogglePrimitive.Root> & VariantProps<typeof toggleVariants>
->(({ className, variant, size, ...props }, ref) => (
+const Toggle = ({
+  className,
+  variant,
+  size,
+  ref,
+  ...props
+}: React.ComponentPropsWithRef<typeof TogglePrimitive.Root> & VariantProps<typeof toggleVariants>) => (
   <TogglePrimitive.Root ref={ref} className={cn(toggleVariants({ variant, size, className }))} {...props} />
-));
+);
 
 Toggle.displayName = TogglePrimitive.Root.displayName;
 

--- a/components/ui/toggle.tsx
+++ b/components/ui/toggle.tsx
@@ -27,7 +27,7 @@ const toggleVariants = cva(
 );
 
 const Toggle = React.forwardRef<
-  React.ElementRef<typeof TogglePrimitive.Root>,
+  React.ComponentRef<typeof TogglePrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof TogglePrimitive.Root> & VariantProps<typeof toggleVariants>
 >(({ className, variant, size, ...props }, ref) => (
   <TogglePrimitive.Root ref={ref} className={cn(toggleVariants({ variant, size, className }))} {...props} />

--- a/components/ui/tooltip.tsx
+++ b/components/ui/tooltip.tsx
@@ -30,18 +30,16 @@ const tooltipContentVariants = cva(
 );
 
 interface TooltipContentProps
-  extends React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>,
+  extends React.ComponentPropsWithRef<typeof TooltipPrimitive.Content>,
     VariantProps<typeof tooltipContentVariants> {}
 
-const TooltipContent = React.forwardRef<React.ComponentRef<typeof TooltipPrimitive.Content>, TooltipContentProps>(
-  ({ className, sideOffset = 4, size, variant, ...props }, ref) => (
-    <TooltipPrimitive.Content
-      ref={ref}
-      sideOffset={sideOffset}
-      className={cn(tooltipContentVariants({ size, variant }), className)}
-      {...props}
-    />
-  ),
+const TooltipContent = ({ className, sideOffset = 4, size, variant, ref, ...props }: TooltipContentProps) => (
+  <TooltipPrimitive.Content
+    ref={ref}
+    sideOffset={sideOffset}
+    className={cn(tooltipContentVariants({ size, variant }), className)}
+    {...props}
+  />
 );
 TooltipContent.displayName = TooltipPrimitive.Content.displayName;
 

--- a/components/ui/tooltip.tsx
+++ b/components/ui/tooltip.tsx
@@ -33,7 +33,7 @@ interface TooltipContentProps
   extends React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>,
     VariantProps<typeof tooltipContentVariants> {}
 
-const TooltipContent = React.forwardRef<React.ElementRef<typeof TooltipPrimitive.Content>, TooltipContentProps>(
+const TooltipContent = React.forwardRef<React.ComponentRef<typeof TooltipPrimitive.Content>, TooltipContentProps>(
   ({ className, sideOffset = 4, size, variant, ...props }, ref) => (
     <TooltipPrimitive.Content
       ref={ref}

--- a/packages/marketing/components/ui/button.tsx
+++ b/packages/marketing/components/ui/button.tsx
@@ -65,20 +65,29 @@ const buttonVariants = cva(
 interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement>, VariantProps<typeof buttonVariants> {
   asChild?: boolean;
   desktop?: boolean;
+  ref?: React.RefObject<HTMLButtonElement>;
 }
 
-export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, iconOnly, asChild = false, desktop, tabIndex, ...props }, ref) => {
-    const Comp = asChild ? Slot : "button";
-    return (
-      <Comp
-        className={cn(buttonVariants({ variant, size, iconOnly, className }))}
-        ref={ref}
-        tabIndex={tabIndex}
-        data-desktop={desktop}
-        {...props}
-      />
-    );
-  },
-);
+export const Button = ({
+  className,
+  variant,
+  size,
+  iconOnly,
+  asChild = false,
+  desktop,
+  tabIndex,
+  ref,
+  ...props
+}: ButtonProps) => {
+  const Comp = asChild ? Slot : "button";
+  return (
+    <Comp
+      className={cn(buttonVariants({ variant, size, iconOnly, className }))}
+      ref={ref}
+      tabIndex={tabIndex}
+      data-desktop={desktop}
+      {...props}
+    />
+  );
+};
 Button.displayName = "Button";

--- a/packages/marketing/components/ui/button.tsx
+++ b/packages/marketing/components/ui/button.tsx
@@ -65,7 +65,7 @@ const buttonVariants = cva(
 interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement>, VariantProps<typeof buttonVariants> {
   asChild?: boolean;
   desktop?: boolean;
-  ref?: React.RefObject<HTMLButtonElement>;
+  ref?: React.Ref<HTMLButtonElement>;
 }
 
 export const Button = ({

--- a/packages/marketing/components/ui/tooltip.tsx
+++ b/packages/marketing/components/ui/tooltip.tsx
@@ -30,18 +30,16 @@ const tooltipContentVariants = cva(
 );
 
 interface TooltipContentProps
-  extends React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>,
+  extends React.ComponentPropsWithRef<typeof TooltipPrimitive.Content>,
     VariantProps<typeof tooltipContentVariants> {}
 
-const TooltipContent = React.forwardRef<React.ComponentRef<typeof TooltipPrimitive.Content>, TooltipContentProps>(
-  ({ className, sideOffset = 4, size, variant, ...props }, ref) => (
-    <TooltipPrimitive.Content
-      ref={ref}
-      sideOffset={sideOffset}
-      className={cn(tooltipContentVariants({ size, variant }), className)}
-      {...props}
-    />
-  ),
+const TooltipContent = ({ className, sideOffset = 4, size, variant, ref, ...props }: TooltipContentProps) => (
+  <TooltipPrimitive.Content
+    ref={ref}
+    sideOffset={sideOffset}
+    className={cn(tooltipContentVariants({ size, variant }), className)}
+    {...props}
+  />
 );
 TooltipContent.displayName = TooltipPrimitive.Content.displayName;
 

--- a/packages/marketing/components/ui/tooltip.tsx
+++ b/packages/marketing/components/ui/tooltip.tsx
@@ -33,7 +33,7 @@ interface TooltipContentProps
   extends React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>,
     VariantProps<typeof tooltipContentVariants> {}
 
-const TooltipContent = React.forwardRef<React.ElementRef<typeof TooltipPrimitive.Content>, TooltipContentProps>(
+const TooltipContent = React.forwardRef<React.ComponentRef<typeof TooltipPrimitive.Content>, TooltipContentProps>(
   ({ className, sideOffset = 4, size, variant, ...props }, ref) => (
     <TooltipPrimitive.Content
       ref={ref}


### PR DESCRIPTION
forwardRef  and ElementRef has been deprecated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Refactor**
  - Simplified UI components by removing explicit use of React.forwardRef, now accepting refs as normal props.
  - Maintained all existing behaviors, styling, and rendering across components including Accordion, Avatar, Checkbox, Command, Dialog, DropdownMenu, Label, Popover, Select, Separator, Sheet, Sidebar, Switch, Tabs, Toast, Toggle, Tooltip, LoadingSpinner, TipTapEditor, Alert, Button, Card, Chart, Input, Table, and Textarea.
  - Minor internal adjustments with no impact on user experience or functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->