### PR TITLE
feat (conversations): add clear all filters button

### DIFF
--- a/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/list/conversationFilters.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/list/conversationFilters.tsx
@@ -142,7 +142,7 @@ export const ConversationFilters = ({
       <PromptFilter isPrompt={filterValues.isPrompt} onChange={(isPrompt) => onUpdateFilter({ isPrompt })} />
       {activeFilterCount > 0 && (
         <Button variant="ghost" onClick={onClearFilters}>
-          Clear
+          Clear filters
         </Button>
       )}
     </div>

--- a/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/list/conversationFilters.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/list/conversationFilters.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import { Button } from "@/components/ui/button";
 import { useDebouncedCallback } from "@/components/useDebouncedCallback";
 import { useConversationsListInput } from "../shared/queries";
 import { AssigneeFilter } from "./filters/assigneeFilter";
@@ -25,6 +26,8 @@ interface FilterValues {
 interface ConversationFiltersProps {
   filterValues: FilterValues;
   onUpdateFilter: (updates: Partial<FilterValues>) => void;
+  onClearFilters: () => void;
+  activeFilterCount: number;
 }
 
 export const useConversationFilters = () => {
@@ -78,17 +81,40 @@ export const useConversationFilters = () => {
     debouncedSetFilters(updates);
   };
 
+  const clearFilters = () => {
+    const clearedFilters = {
+      assignee: null,
+      createdAfter: null,
+      createdBefore: null,
+      repliedBy: null,
+      customer: null,
+      isVip: null,
+      isPrompt: null,
+      reactionType: null,
+      events: null,
+    };
+    setSearchParams((prev) => ({ ...prev, ...clearedFilters }));
+  };
+
   return {
     filterValues,
     activeFilterCount,
     updateFilter,
+    clearFilters,
   };
 };
 
-export const ConversationFilters = ({ filterValues, onUpdateFilter }: ConversationFiltersProps) => {
+export const ConversationFilters = ({
+  filterValues,
+  onUpdateFilter,
+  activeFilterCount,
+  onClearFilters,
+}: ConversationFiltersProps) => {
   return (
-    <div className="flex flex-wrap justify-center gap-1 md:gap-2">
+    <div className="flex flex-wrap items-center justify-center gap-1 md:gap-2">
       <DateFilter
+        // A hack to force the date filter to re-render when the date changes
+        key={`${filterValues.createdAfter}-${filterValues.createdBefore}`}
         initialStartDate={filterValues.createdAfter}
         initialEndDate={filterValues.createdBefore}
         onSelect={(startDate, endDate) => {
@@ -114,6 +140,11 @@ export const ConversationFilters = ({ filterValues, onUpdateFilter }: Conversati
       />
       <EventFilter selectedEvents={filterValues.events} onChange={(events) => onUpdateFilter({ events })} />
       <PromptFilter isPrompt={filterValues.isPrompt} onChange={(isPrompt) => onUpdateFilter({ isPrompt })} />
+      {activeFilterCount > 0 && (
+        <Button variant="ghost" onClick={onClearFilters}>
+          Clear
+        </Button>
+      )}
     </div>
   );
 };

--- a/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/list/conversationList.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/list/conversationList.tsx
@@ -29,7 +29,7 @@ export const List = () => {
     useConversationListContext();
 
   const [showFilters, setShowFilters] = useState(false);
-  const { filterValues, activeFilterCount, updateFilter } = useConversationFilters();
+  const { filterValues, activeFilterCount, updateFilter, clearFilters } = useConversationFilters();
   const [selectedConversations, setSelectedConversations] = useState<number[]>([]);
   const [allConversationsSelected, setAllConversationsSelected] = useState(false);
   const [isBulkUpdating, setIsBulkUpdating] = useState(false);
@@ -224,7 +224,14 @@ export const List = () => {
               </div>
             </div>
           )}
-          {showFilters && <ConversationFilters filterValues={filterValues} onUpdateFilter={updateFilter} />}
+          {showFilters && (
+            <ConversationFilters
+              filterValues={filterValues}
+              onUpdateFilter={updateFilter}
+              onClearFilters={clearFilters}
+              activeFilterCount={activeFilterCount}
+            />
+          )}
         </div>
       </div>
       {isPending ? (


### PR DESCRIPTION
This PR introduces a nice clear all filters button in the mailboxes page. I think it's a needed feature considering the fact that the alternative is either clearing all filters one by one or refreshing the page.

Video:

https://github.com/user-attachments/assets/d806ff75-6abe-4310-8a7f-29067d0d2f77



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a "Clear filters" button to reset all active conversation filters simultaneously.
  - Displayed the count of active filters within the filter interface.

- **Style**
  - Enhanced vertical alignment of filter controls for improved visual consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->