### PR TITLE
fix: tweak generate knowledge toast action

### DIFF
--- a/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/conversation/messageActions.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/conversation/messageActions.tsx
@@ -294,9 +294,10 @@ export const MessageActions = () => {
         triggerMailboxConfetti();
       }
       toast({
+        duration: 10000,
         title: close ? "Replied and closed" : "Message sent!",
         variant: "success",
-        action: (
+        description: (
           <div className="flex gap-2 items-center">
             {close && (
               <ToastAction
@@ -315,7 +316,7 @@ export const MessageActions = () => {
                 setShowKnowledgeBankDialog(true);
               }}
             >
-              💡 Save
+              Generate knowledge
             </ToastAction>
             <ToastAction
               altText="Undo"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Toast notifications after sending a message now display for a fixed duration of 10 seconds.
  - The "Generate knowledge" action button in the toast now displays as "Generate knowledge" instead of "💡 Save".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->