### PR TITLE
feat: improve E2E test reliability and address last comments from #561

### DIFF
--- a/tests/e2e/conversations/conversations.spec.ts
+++ b/tests/e2e/conversations/conversations.spec.ts
@@ -77,7 +77,7 @@ test.describe("Working Conversation Management", () => {
   });
 
   test("should show account information", async ({ page }) => {
-    // Check for account-related buttons (improved specificity while maintaining compatibility)
+    // Check for account-related buttons (using working selectors)
     const gumroadButton = page.locator('button:has-text("Gumroad")').first();
     await expect(gumroadButton).toBeVisible();
 
@@ -226,20 +226,30 @@ test.describe("Working Conversation Management", () => {
   });
 
   test("should support keyboard navigation", async ({ page }) => {
+    // Test keyboard navigation by focusing and using key interactive elements
     const searchInput = page.locator('input[placeholder="Search conversations"]');
 
-    // Focus directly on the search input instead of relying on tab order
+    // Test that search input can be focused and used with keyboard
     await searchInput.focus();
+    await expect(searchInput).toBeFocused();
 
-    // Check if search input is focused
-    const focusedElement = await page.evaluate(() => document.activeElement?.getAttribute("placeholder"));
+    // Test keyboard input works
+    await page.keyboard.type("keyboard test");
+    await expect(searchInput).toHaveValue("keyboard test");
 
-    if (focusedElement === "Search conversations") {
-      expect(focusedElement).toBe("Search conversations");
-    } else {
-      // If tab doesn't focus search input, just verify we can type in it
-      await searchInput.fill("keyboard test");
-      await expect(searchInput).toHaveValue("keyboard test");
-    }
+    // Test navigation with Enter key (should work for form submission)
+    await page.keyboard.press("Escape"); // Clear any state
+
+    // Test tab navigation between interactive elements
+    await page.keyboard.press("Tab");
+
+    // Verify that tab navigation works by checking if focus moved
+    const activeElementAfterTab = await page.evaluate(() => document.activeElement?.tagName || "BODY");
+
+    // Should be able to tab to some interactive element (not just stay on body)
+    expect(["INPUT", "BUTTON", "A"].includes(activeElementAfterTab)).toBeTruthy();
+
+    // Clear for cleanup
+    await searchInput.clear();
   });
 });


### PR DESCRIPTION
Continuation of https://github.com/antiwork/helper/pull/561

cc @binary-koan 

## What?

Fixing few issues with e2e tests and removing those from vitest config.

## Test Plan

```
helper git:(feat/e2e-test-improvements) pnpm test:e2e

> helperai@0.3.0 test:e2e /Users/rakshittiwari/personal-projects/helper
> pnpm run with-dev-env playwright test


> helperai@0.3.0 with-dev-env /Users/rakshittiwari/personal-projects/helper
> dotenv -e ./.env.development.local -e ./.env.local -- playwright test


Running 18 tests using 6 workers
  18 passed (18.1s)

To open last HTML report run:

  pnpm exec playwright show-report
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved end-to-end tests for keyboard navigation and focus management in conversations, providing more explicit assertions and clearer test steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->