### PR TITLE
feat (conversations): add date filter presets

### DIFF
--- a/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/list/filters/dateFilter.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/list/filters/dateFilter.tsx
@@ -1,9 +1,61 @@
+import { endOfDay, endOfMonth, endOfYear, startOfDay, startOfMonth, startOfYear, subDays, subMonths } from "date-fns";
 import { Calendar as CalendarIcon } from "lucide-react";
 import { useState } from "react";
 import { DateRange } from "react-day-picker";
 import { Button } from "@/components/ui/button";
 import { Calendar } from "@/components/ui/calendar";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+const DATE_PRESETS = [
+  {
+    value: "allTime",
+    label: "All time",
+    range: null,
+  },
+  {
+    value: "today",
+    label: "Today",
+    range: { from: startOfDay(new Date()), to: endOfDay(new Date()) },
+  },
+  {
+    value: "yesterday",
+    label: "Yesterday",
+    range: { from: startOfDay(subDays(new Date(), 1)), to: endOfDay(subDays(new Date(), 1)) },
+  },
+  {
+    value: "last7days",
+    label: "Last 7 days",
+    range: { from: startOfDay(subDays(new Date(), 6)), to: endOfDay(new Date()) },
+  },
+  {
+    value: "thisMonth",
+    label: "This month",
+    range: { from: startOfMonth(new Date()), to: endOfMonth(new Date()) },
+  },
+  {
+    value: "last30days",
+    label: "Last 30 days",
+    range: { from: startOfDay(subDays(new Date(), 29)), to: endOfDay(new Date()) },
+  },
+  {
+    value: "thisYear",
+    label: "This year",
+    range: { from: startOfYear(new Date()), to: endOfYear(new Date()) },
+  },
+  {
+    value: "custom",
+    label: "Custom",
+    range: null,
+  },
+] as const;
+
+type DatePresetValue = (typeof DATE_PRESETS)[number]["value"];
 
 export function DateFilter({
   initialStartDate,
@@ -14,59 +66,147 @@ export function DateFilter({
   initialEndDate: string | null;
   onSelect: (startDate: string | null, endDate: string | null) => void;
 }) {
-  const [date, setDate] = useState<DateRange | undefined>(
-    initialStartDate
+  const [selectedPreset, setSelectedPreset] = useState<DatePresetValue>(() => {
+    if (!initialStartDate) return "allTime";
+
+    // Try to match initial dates to a preset
+    const initialFrom = new Date(initialStartDate);
+    const initialTo = initialEndDate ? new Date(initialEndDate) : undefined;
+
+    for (const { value, range } of DATE_PRESETS) {
+      if (value === "custom") continue;
+      if (
+        range &&
+        range.from.getTime() === initialFrom.getTime() &&
+        range.to &&
+        initialTo &&
+        range.to.getTime() === initialTo.getTime()
+      ) {
+        return value;
+      }
+    }
+    return "custom";
+  });
+
+  const [customDate, setCustomDate] = useState<DateRange | undefined>(
+    initialStartDate && selectedPreset === "custom"
       ? { from: new Date(initialStartDate), to: initialEndDate ? new Date(initialEndDate) : undefined }
       : undefined,
   );
+
+  const [showCustomPicker, setShowCustomPicker] = useState(selectedPreset === "custom");
+
+  const handlePresetChange = (value: string) => {
+    const presetValue = value as DatePresetValue;
+
+    if (presetValue === "custom") {
+      setShowCustomPicker(true);
+      return;
+    }
+
+    setSelectedPreset(presetValue);
+    setShowCustomPicker(false);
+
+    const preset = DATE_PRESETS.find((p) => p.value === presetValue);
+    if (preset) {
+      onSelect(preset.range?.from.toISOString() ?? null, preset.range?.to.toISOString() ?? null);
+    }
+  };
+
+  const handleCustomDateSelect = (date: DateRange | undefined) => {
+    setCustomDate(date);
+    if (date?.from) {
+      setSelectedPreset("custom");
+      onSelect(date.from.toISOString(), date.to?.toISOString().replace("T00:00:00.000Z", "T23:59:59.999Z") ?? null);
+    }
+  };
+
+  const getButtonLabel = () => {
+    if (selectedPreset === "allTime") return "Created";
+
+    const preset = DATE_PRESETS.find((p) => p.value === selectedPreset);
+    if (!preset) return "Created";
+
+    if (selectedPreset === "custom" && customDate?.from) {
+      return customDate.to
+        ? `${customDate.from.toLocaleDateString()} - ${customDate.to.toLocaleDateString()}`
+        : customDate.from.toLocaleDateString();
+    }
+
+    return preset.label;
+  };
+
+  const clearFilter = () => {
+    setSelectedPreset("allTime");
+    setCustomDate(undefined);
+    setShowCustomPicker(false);
+    onSelect(null, null);
+  };
+
   return (
-    <Popover>
-      <PopoverTrigger asChild>
-        <Button variant={date ? "bright" : "outlined_subtle"} className="whitespace-nowrap">
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant={selectedPreset !== "allTime" ? "bright" : "outlined_subtle"} className="whitespace-nowrap">
           <CalendarIcon className="h-4 w-4 mr-2" />
-          {date?.from ? (
-            date.to ? (
-              <>
-                {date.from.toLocaleDateString()} - {date.to.toLocaleDateString()}
-              </>
-            ) : (
-              date.from.toLocaleDateString()
-            )
-          ) : (
-            "Created"
-          )}
+          {getButtonLabel()}
         </Button>
-      </PopoverTrigger>
-      <PopoverContent className="w-auto p-0" align="start">
-        <div>
-          <Calendar
-            autoFocus
-            mode="range"
-            defaultMonth={date?.from}
-            selected={date}
-            onSelect={(date) => {
-              setDate(date);
-              onSelect(
-                date?.from?.toISOString() ?? null,
-                date?.to?.toISOString().replace("T00:00:00.000Z", "T23:59:59.999Z") ?? null,
-              );
-            }}
-            numberOfMonths={2}
-          />
-          <div className="flex justify-center p-2">
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={() => {
-                setDate(undefined);
-                onSelect(null, null);
-              }}
-            >
-              Clear
-            </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="w-auto">
+        {!showCustomPicker ? (
+          <DropdownMenuRadioGroup
+            value={selectedPreset || "undefined"}
+            onValueChange={handlePresetChange}
+            className="flex flex-col"
+          >
+            {DATE_PRESETS.map((preset) => (
+              <DropdownMenuRadioItem
+                key={preset.value}
+                value={preset.value}
+                onSelect={(event) => {
+                  if (preset.value === "custom") {
+                    event.preventDefault();
+                  }
+                }}
+              >
+                {preset.label}
+              </DropdownMenuRadioItem>
+            ))}
+          </DropdownMenuRadioGroup>
+        ) : (
+          <div>
+            <Calendar
+              autoFocus
+              mode="range"
+              defaultMonth={customDate?.from}
+              selected={customDate}
+              onSelect={handleCustomDateSelect}
+              numberOfMonths={2}
+            />
+            <div className="flex justify-between p-2 border-t">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => {
+                  setShowCustomPicker(false);
+                }}
+              >
+                Back
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => {
+                  setCustomDate(undefined);
+                  clearFilter();
+                  setShowCustomPicker(false);
+                }}
+              >
+                Clear
+              </Button>
+            </div>
           </div>
-        </div>
-      </PopoverContent>
-    </Popover>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }


### PR DESCRIPTION
This PR adds handy date presets to the Created filter in the mailboxes page.

Let me know if these presets are too many or missing anything:
- All time
- Today
- Yesterday
- Last 7 days
- This month
- Last 30 days
- This year
- Custom

Before:

https://github.com/user-attachments/assets/521a8d43-e3a5-413f-9d5d-e99b9f2ea9ec

After:

https://github.com/user-attachments/assets/a8a0f8ec-cb48-469c-bf8c-f7b121c618bc


