### PR TITLE
Show Filtered Empty State Message Independently from Onboarding/Setup Dialog

### DIFF
--- a/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/list/conversationList.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/list/conversationList.tsx
@@ -239,7 +239,7 @@ export const List = () => {
           <LoadingSpinner size="lg" />
         </div>
       ) : conversations.length === 0 ? (
-        <NoConversations filtered={Object.values(filterValues).some(Boolean) || !!input.search} />
+        <NoConversations filtered={activeFilterCount > 0 || !!input.search} />
       ) : (
         <div ref={resultsContainerRef} className="flex-1 overflow-y-auto">
           {conversations.map((conversation) => (

--- a/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/list/conversationList.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/list/conversationList.tsx
@@ -23,6 +23,7 @@ import NewConversationModalContent from "./newConversationModal";
 type ListItem = ConversationItem & { isNew?: boolean };
 
 export const List = () => {
+  console.log("[ConversationList] Rendering List component");
   const [conversationSlug] = useQueryState("id");
   const { searchParams, input } = useConversationsListInput();
   const { conversationListData, navigateToConversation, isPending, isFetchingNextPage, hasNextPage, fetchNextPage } =
@@ -239,7 +240,7 @@ export const List = () => {
           <LoadingSpinner size="lg" />
         </div>
       ) : conversations.length === 0 ? (
-        <NoConversations />
+        <NoConversations filtered={Object.values(filterValues).some(Boolean) || !!input.search} />
       ) : (
         <div ref={resultsContainerRef} className="flex-1 overflow-y-auto">
           {conversations.map((conversation) => (

--- a/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/list/conversationList.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/list/conversationList.tsx
@@ -23,7 +23,6 @@ import NewConversationModalContent from "./newConversationModal";
 type ListItem = ConversationItem & { isNew?: boolean };
 
 export const List = () => {
-  console.log("[ConversationList] Rendering List component");
   const [conversationSlug] = useQueryState("id");
   const { searchParams, input } = useConversationsListInput();
   const { conversationListData, navigateToConversation, isPending, isFetchingNextPage, hasNextPage, fetchNextPage } =

--- a/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/list/emptyState.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/list/emptyState.tsx
@@ -6,7 +6,7 @@ import { useConversationListContext } from "@/app/(dashboard)/mailboxes/[mailbox
 import { useConversationsListInput } from "@/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/shared/queries";
 import { cn } from "@/lib/utils";
 
-export const NoConversations = () => {
+export const NoConversations = ({ filtered }: { filtered?: boolean }) => {
   const { input } = useConversationsListInput();
   const { conversationListData } = useConversationListContext();
 
@@ -15,6 +15,15 @@ export const NoConversations = () => {
     !onboardingState?.hasResend || !onboardingState?.hasWidgetHost || !onboardingState?.hasGmailSupportEmail;
 
   const shouldShowNoTickets = !input.status?.length || input.status?.[0] === "open";
+
+  if (filtered) {
+    return (
+      <div className="flex-1 flex flex-col items-center justify-center">
+        <h2 className="font-semibold mb-2">No conversations found for this filter</h2>
+        <p className="text-sm text-muted-foreground">Try adjusting your filters or search.</p>
+      </div>
+    );
+  }
 
   if (isOnboarding) {
     return (


### PR DESCRIPTION
### Summary

This PR updates the mailbox conversation list empty state logic to improve user experience when filters or search are applied:

- **Filtered empty state message** ("No conversations found for this filter") is now shown whenever a filter or search is active and there are no results, regardless of the mailbox onboarding/setup state.
- **Onboarding/setup dialog** is only shown when there are no filters/search and the mailbox is not fully set up.
- **No open tickets** and **default empty state** messages remain unchanged for their respective scenarios.
- All debug logs have been removed.

### Motivation

Previously, the onboarding dialog would always take precedence, even when a user applied a filter or search. This could be confusing, as users would not see feedback that their filter/search returned no results. Now, the UI always provides clear feedback for filtered empty states, improving clarity and usability.

### Acceptance Criteria

- [x] When a filter/search is applied and there are no results, the user sees the filtered empty state message.
- [x] When there are no filters/search and the mailbox is not set up, the user sees the onboarding/setup dialog.
- [x] When there are no open tickets and no filters, the user sees the "No open tickets" message.
- [x] All debug logs are removed.

### Related Issue

Closes [#593](https://github.com/antiwork/helper/issues/593)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved empty state messaging in conversations list to clearly indicate when no conversations match the current filters or search criteria.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->