### PR TITLE
feat: set the correct folder permissions in linux/wsl environment when generating ssl certificates

### DIFF
--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -47,7 +47,8 @@ if [ ! -f "scripts/docker/local-nginx/certs/helperai_dev.crt" ]; then
         IS_WSL=false
 
         # Detect WSL via /proc/version (works for WSL1 and WSL2)
-        if grep -qi microsoft /proc/version 2>/dev/null || grep -qi wsl /proc/sys/kernel/osrelease 2>/dev/null; then
+        # and any future variant with similar kernel signatures.
+        if grep -qiE 'microsoft|wsl' /proc/version 2>/dev/null; then
             IS_WSL=true
         fi
 

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -40,6 +40,25 @@ pnpm install
 
 if [ ! -f "scripts/docker/local-nginx/certs/helperai_dev.crt" ]; then
     pnpm generate-ssl-certificates
+
+    # Check if uname exists (to avoid errors on native Windows)
+    if command -v uname >/dev/null 2>&1; then
+        OS_TYPE="$(uname)"
+        IS_WSL=false
+
+        # Detect WSL via /proc/version (works for WSL1 and WSL2)
+        if grep -qi microsoft /proc/version 2>/dev/null || grep -qi wsl /proc/sys/kernel/osrelease 2>/dev/null; then
+            IS_WSL=true
+        fi
+
+        # Run chown on native Linux or WSL
+        # Set correct ownership
+        if [[ "$OS_TYPE" == "Linux" || "$IS_WSL" == true ]]; then
+            chown -R "$USER:$USER" scripts/docker/local-nginx/certs
+        fi
+    else
+        echo "Skipping chown: 'uname' not available (likely native Windows)"
+    fi
 fi
 
 # Check if .env.local exists


### PR DESCRIPTION
**Based on discussion started here:** [#discussion-link](https://github.com/antiwork/helper/discussions/409#discussioncomment-13116328)

---

### Improve `scripts/dev.sh`: Add OS checks before running `chown`

When setting up a local development environment in a Linux environment or in a WSL environment, `mkdir -p scripts/docker/local-nginx/certs` in `generate-ssl-certificates.sh` file creates a folder with `root:root` user and permissions. This results in the error `ERROR: failed to save certificate: open ./helperai.dev+1.pem: permission denied`

This update improves the `scripts/dev.sh` script by adding safe, cross-platform checks to determine whether it's running on a supported Linux environment before executing `chown`.

#### What’s changed:
- Added a check to ensure `uname` exists before using it (prevents errors in native Windows environments where `uname` isn't available).
- Detects whether the script is running in:
  - **Native Linux**
  - **WSL (Windows Subsystem for Linux)** — by checking `/proc/version` and `/proc/sys/kernel/osrelease` for `"Microsoft"` or `"WSL"`.
- Skips `chown` on unsupported platforms like:
  - macOS (`Darwin`)
  - Native Windows shells (e.g., CMD, PowerShell)

#### Why:
Running `chown` in unsupported environments can lead to permission errors or unintended behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved handling of SSL certificate file permissions to ensure compatibility across different operating systems, including Linux, WSL, and Windows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->