### PR TITLE
feat: implement dynamic bulk actions with toast notifications

### DIFF
--- a/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/list/conversationList.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/list/conversationList.tsx
@@ -72,10 +72,12 @@ export const List = () => {
     }
   };
 
-  const handleBulkUpdate = (status: "closed" | "spam") => {
+  const handleBulkUpdate = (status: "open" | "closed" | "spam") => {
     setIsBulkUpdating(true);
     try {
       const conversationFilter = allConversationsSelected ? conversations.map((c) => c.id) : selectedConversations;
+      const selectedCount = allConversationsSelected ? conversations.length : selectedConversations.length;
+
       bulkUpdate(
         {
           conversationFilter,
@@ -88,7 +90,13 @@ export const List = () => {
             setSelectedConversations([]);
             void utils.mailbox.conversations.list.invalidate();
             void utils.mailbox.conversations.count.invalidate();
-            if (!updatedImmediately) {
+
+            if (updatedImmediately) {
+              const actionText = status === "open" ? "re-opened" : status === "closed" ? "closed" : "marked as spam";
+              toast({
+                title: `${selectedCount} ticket${selectedCount === 1 ? "" : "s"} ${actionText}`,
+              });
+            } else {
               toast({ title: "Starting update, refresh to see status." });
             }
           },
@@ -204,22 +212,35 @@ export const List = () => {
                   </Tooltip>
                 </TooltipProvider>
                 <div className="flex items-center gap-2">
-                  <Button
-                    variant="link"
-                    className="h-auto"
-                    onClick={() => handleBulkUpdate("closed")}
-                    disabled={isBulkUpdating}
-                  >
-                    Close
-                  </Button>
-                  <Button
-                    variant="link"
-                    className="h-auto"
-                    onClick={() => handleBulkUpdate("spam")}
-                    disabled={isBulkUpdating}
-                  >
-                    Mark as spam
-                  </Button>
+                  {searchParams.status === "closed" ? (
+                    <Button
+                      variant="link"
+                      className="h-auto"
+                      onClick={() => handleBulkUpdate("open")}
+                      disabled={isBulkUpdating}
+                    >
+                      Re-open
+                    </Button>
+                  ) : (
+                    <Button
+                      variant="link"
+                      className="h-auto"
+                      onClick={() => handleBulkUpdate("closed")}
+                      disabled={isBulkUpdating}
+                    >
+                      Close
+                    </Button>
+                  )}
+                  {searchParams.status !== "spam" && (
+                    <Button
+                      variant="link"
+                      className="h-auto"
+                      onClick={() => handleBulkUpdate("spam")}
+                      disabled={isBulkUpdating}
+                    >
+                      Mark as spam
+                    </Button>
+                  )}
                 </div>
               </div>
             </div>

--- a/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/list/conversationList.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/list/conversationList.tsx
@@ -92,7 +92,7 @@ export const List = () => {
             void utils.mailbox.conversations.count.invalidate();
 
             if (updatedImmediately) {
-              const actionText = status === "open" ? "re-opened" : status === "closed" ? "closed" : "marked as spam";
+              const actionText = status === "open" ? "reopened" : status === "closed" ? "closed" : "marked as spam";
               toast({
                 title: `${selectedCount} ticket${selectedCount === 1 ? "" : "s"} ${actionText}`,
               });
@@ -219,7 +219,7 @@ export const List = () => {
                       onClick={() => handleBulkUpdate("open")}
                       disabled={isBulkUpdating}
                     >
-                      Re-open
+                      Reopen
                     </Button>
                   ) : (
                     <Button


### PR DESCRIPTION
When filtering to show only closed tickets, users would see an irrelevant "Close" button in the bulk actions toolbar. This created a poor UX since users **couldn't close already-closed tickets**, and there was no way to bulk re-open closed tickets.

## 🎯 **Fix**
Implemented dynamic bulk actions that change based on the current status filter:

- **When filtering closed tickets** → Show "Re-open" button
- **When filtering open tickets or no filter** → Show "Close" button  

Added comprehensive toast notifications to provide clear feedback about bulk operation results.

## ✨ **Features Implemented**

### 🔄 Dynamic Bulk Actions
- [x] Context-aware bulk action buttons based on status filter
- [x] "Re-open" button for closed ticket views
- [x] "Close" button for open ticket views


### 🔔 Toast Notifications
- [x] Success toasts with dynamic messaging:
  - `"X tickets re-opened"` for reopening actions
  - `"X tickets closed"` for closing actions
- [x] Proper pluralization (1 ticket vs X tickets)
- [x] Background processing notifications for large batches (≥25 tickets)
- [x] Error handling with descriptive error messages

## 🎥 **Demo**

### Before (❌ Poor UX)

https://github.com/user-attachments/assets/5366d945-6967-4bc2-a1d1-f7bcf6e929cf

### After (✅ Improved UX)

https://github.com/user-attachments/assets/51caac5f-c853-47d5-ab62-4f71462453ee

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to bulk re-open conversations directly from the conversation list.
  * Toast notifications now specify the number of conversations affected and the action taken (re-opened, closed, or marked as spam).

* **Refactor**
  * Bulk action buttons are now contextually displayed based on the current status filter, improving usability and reducing clutter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->