### PR TITLE
fix(UI): scroll to top button and navbar ui shift when selecting filters

### DIFF
--- a/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/conversation/conversation.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/conversation/conversation.tsx
@@ -153,7 +153,7 @@ const ScrollToTopButton = ({
           className={cn(
             "absolute bottom-4 left-4 transition-all duration-200 h-8 w-8 p-0 rounded-full",
             "flex items-center justify-center",
-            "bg-background border border-border shadow-xs",
+            "bg-background border border-border shadow-xs cursor-pointer",
             "hover:border-primary hover:shadow-md hover:bg-muted",
             show ? "translate-y-0 opacity-100" : "translate-y-4 opacity-0 pointer-events-none",
           )}

--- a/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/conversation/messageThread.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/conversation/messageThread.tsx
@@ -17,7 +17,7 @@ export const MessageThread = ({
 }) => {
   return (
     <div className="flex h-full flex-col">
-      <div className="flex flex-1 flex-col gap-8 pb-4">
+      <div className="flex flex-1 flex-col gap-8 pb-4 mb-4">
         {conversation.isPrompt && (
           <div className="flex items-center justify-center gap-1 text-sm text-muted-foreground">
             <HelpCircle className="h-4 w-4 text-muted-foreground" />

--- a/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/list/conversationSearchBar.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/list/conversationSearchBar.tsx
@@ -160,7 +160,7 @@ export const ConversationSearchBar = ({
         {statusOptions.length > 0 && (
           <button
             onClick={toggleAllConversations}
-            className="hidden md:block text-sm text-muted-foreground hover:text-foreground cursor-pointer"
+            className="hidden md:block text-sm text-muted-foreground hover:text-foreground cursor-pointer min-w-[80px] text-left"
           >
             {allConversationsSelected ? "Select none" : "Select all"}
           </button>
@@ -190,7 +190,7 @@ export const ConversationSearchBar = ({
       <Select value={sortOptions.find(({ selected }) => selected)?.value || ""} onValueChange={handleSortChange}>
         <SelectTrigger
           variant="bare"
-          className="w-auto text-foreground [&>svg]:text-foreground text-sm"
+          className="w-auto text-foreground [&>svg]:text-foreground text-sm min-w-[110px] justify-center"
           hideArrow="mobileOnly"
         >
           <SelectValue


### PR DESCRIPTION
**ISSUE 1:** Navbar UI was shifting when filters were changed.

https://github.com/user-attachments/assets/c106d3d2-4a4e-45f2-8fb2-3ad758073c27

Fixed

https://github.com/user-attachments/assets/351fbfec-7963-487c-bd49-a7f2922dafc8

**ISSUE 2**: scroll to top button was overlapping over time text

<img width="447" alt="image" src="https://github.com/user-attachments/assets/2d8e6e13-cc30-454e-b8ef-64c6e74efe40" />
</br>

Fixed:

<img width="275" alt="image" src="https://github.com/user-attachments/assets/1296456a-6de5-4482-bc7f-7e8dbeb773c2" />
