### PR TITLE
feat (conversations): add confirmation dialog for bulk actions

### DIFF
--- a/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/list/conversationList.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/list/conversationList.tsx
@@ -3,6 +3,7 @@ import { useParams } from "next/navigation";
 import { useQueryState } from "nuqs";
 import { useEffect, useRef, useState } from "react";
 import { ConversationListItem as ConversationItem } from "@/app/types/global";
+import { ConfirmationDialog } from "@/components/confirmationDialog";
 import { toast } from "@/components/hooks/use-toast";
 import LoadingSpinner from "@/components/loadingSpinner";
 import { Button } from "@/components/ui/button";
@@ -190,6 +191,8 @@ export const List = () => {
     });
   });
 
+  const selectedCount = allConversationsSelected ? conversations.length : selectedConversations.length;
+
   return (
     <div className="flex flex-col w-full h-full">
       <div className="px-3 md:px-6 py-2 md:py-4 shrink-0 border-b border-border">
@@ -218,33 +221,42 @@ export const List = () => {
                 </TooltipProvider>
                 <div className="flex items-center gap-2">
                   {searchParams.status === "closed" ? (
-                    <Button
-                      variant="link"
-                      className="h-auto"
-                      onClick={() => handleBulkUpdate("open")}
-                      disabled={isBulkUpdating}
+                    <ConfirmationDialog
+                      message={`Are you sure you want to reopen ${selectedCount} conversation${
+                        selectedCount === 1 ? "" : "s"
+                      }?`}
+                      onConfirm={() => handleBulkUpdate("open")}
+                      confirmLabel="Yes, reopen"
                     >
-                      Reopen
-                    </Button>
+                      <Button variant="link" className="h-auto" disabled={isBulkUpdating}>
+                        Reopen
+                      </Button>
+                    </ConfirmationDialog>
                   ) : (
-                    <Button
-                      variant="link"
-                      className="h-auto"
-                      onClick={() => handleBulkUpdate("closed")}
-                      disabled={isBulkUpdating}
+                    <ConfirmationDialog
+                      message={`Are you sure you want to close ${selectedCount} conversation${
+                        selectedCount === 1 ? "" : "s"
+                      }?`}
+                      onConfirm={() => handleBulkUpdate("closed")}
+                      confirmLabel="Yes, close"
                     >
-                      Close
-                    </Button>
+                      <Button variant="link" className="h-auto" disabled={isBulkUpdating}>
+                        Close
+                      </Button>
+                    </ConfirmationDialog>
                   )}
                   {searchParams.status !== "spam" && (
-                    <Button
-                      variant="link"
-                      className="h-auto"
-                      onClick={() => handleBulkUpdate("spam")}
-                      disabled={isBulkUpdating}
+                    <ConfirmationDialog
+                      message={`Are you sure you want to mark ${selectedCount} conversation${
+                        selectedCount === 1 ? "" : "s"
+                      } as spam?`}
+                      onConfirm={() => handleBulkUpdate("spam")}
+                      confirmLabel="Yes, mark as spam"
                     >
-                      Mark as spam
-                    </Button>
+                      <Button variant="link" className="h-auto" disabled={isBulkUpdating}>
+                        Mark as spam
+                      </Button>
+                    </ConfirmationDialog>
                   )}
                 </div>
               </div>


### PR DESCRIPTION
This PR adds confirmation dialogs for bulk actions (close, reopen, mark as spam) in the conversations page.

I did not add E2E tests for this PR since it doesn't have drastic changes, but do let me know if I need to add some!

Here's how it looks in action:

https://github.com/user-attachments/assets/b957c6d5-78ac-42ad-bd49-b1200bbe2626
