### PR TITLE
refactor: introduce `route-handler` utility

### DIFF
--- a/app/api/chat/conversation/route.ts
+++ b/app/api/chat/conversation/route.ts
@@ -1,43 +1,56 @@
+import type { NextRequest } from "next/server";
+import { z } from "zod";
 import { createApiHandler } from "@/app/api/route-handler";
-import { authenticateWidget, corsOptions, corsResponse } from "@/app/api/widget/utils";
+import { corsOptions, corsResponse } from "@/app/api/widget/utils";
 import { CHAT_CONVERSATION_SUBJECT, createConversation } from "@/lib/data/conversation";
 import { getPlatformCustomer } from "@/lib/data/platformCustomer";
 
 const VIP_INITIAL_STATUS = "open";
 const DEFAULT_INITIAL_STATUS = "closed";
 
+const requestSchema = z.object({
+  isPrompt: z.boolean(),
+});
+
 export function OPTIONS() {
   return corsOptions();
 }
 
-export async function handler(request: Request) {
-  const { isPrompt } = await request.json();
-  const isVisitor = authResult.session.isAnonymous;
-  let status = DEFAULT_INITIAL_STATUS;
+export const POST = createApiHandler(
+  async (
+    context: { request: NextRequest; params?: Record<string, string>; mailbox: any; session: any },
+    validatedBody: z.infer<typeof requestSchema>,
+  ) => {
+    const { isPrompt } = validatedBody;
+    const { mailbox, session } = context;
 
-  if (isVisitor && authResult.session.email) {
-    const platformCustomer = await getPlatformCustomer(authResult.mailbox.id, authResult.session.email);
-    if (platformCustomer?.isVip && !isPrompt) {
-      status = VIP_INITIAL_STATUS;
+    const isVisitor = session.isAnonymous;
+    let status = DEFAULT_INITIAL_STATUS;
+
+    if (isVisitor && session.email) {
+      const platformCustomer = await getPlatformCustomer(mailbox.id, session.email);
+      if (platformCustomer?.isVip && !isPrompt) {
+        status = VIP_INITIAL_STATUS;
+      }
     }
-  }
 
-  const newConversation = await createConversation({
-    emailFrom: isVisitor || !authResult.session.email ? null : authResult.session.email,
-    mailboxId: authResult.mailbox.id,
-    subject: CHAT_CONVERSATION_SUBJECT,
-    closedAt: status === DEFAULT_INITIAL_STATUS ? new Date() : undefined,
-    status: status as "open" | "closed",
-    source: "chat",
-    isPrompt,
-    isVisitor,
-    assignedToAI: true,
-    anonymousSessionId: authResult.session.isAnonymous ? authResult.session.anonymousSessionId : undefined,
-  });
+    const newConversation = await createConversation({
+      emailFrom: isVisitor || !session.email ? null : session.email,
+      mailboxId: mailbox.id,
+      subject: CHAT_CONVERSATION_SUBJECT,
+      closedAt: status === DEFAULT_INITIAL_STATUS ? new Date() : undefined,
+      status: status as "open" | "closed",
+      source: "chat",
+      isPrompt,
+      isVisitor,
+      assignedToAI: true,
+      anonymousSessionId: isVisitor ? session.anonymousSessionId : undefined,
+    });
 
-  return corsResponse({ conversationSlug: newConversation.slug });
-}
-
-export const POST = createApiHandler(handler, {
-  requiresAuth: true,
-});
+    return corsResponse({ conversationSlug: newConversation.slug });
+  },
+  {
+    requiresAuth: true,
+    requestSchema,
+  },
+);

--- a/app/api/chat/conversation/route.ts
+++ b/app/api/chat/conversation/route.ts
@@ -1,3 +1,4 @@
+import { createApiHandler } from "@/app/api/route-handler";
 import { authenticateWidget, corsOptions, corsResponse } from "@/app/api/widget/utils";
 import { CHAT_CONVERSATION_SUBJECT, createConversation } from "@/lib/data/conversation";
 import { getPlatformCustomer } from "@/lib/data/platformCustomer";
@@ -9,12 +10,7 @@ export function OPTIONS() {
   return corsOptions();
 }
 
-export async function POST(request: Request) {
-  const authResult = await authenticateWidget(request);
-  if (!authResult.success) {
-    return corsResponse({ error: authResult.error }, { status: 401 });
-  }
-
+export async function handler(request: Request) {
   const { isPrompt } = await request.json();
   const isVisitor = authResult.session.isAnonymous;
   let status = DEFAULT_INITIAL_STATUS;
@@ -41,3 +37,7 @@ export async function POST(request: Request) {
 
   return corsResponse({ conversationSlug: newConversation.slug });
 }
+
+export const POST = createApiHandler(handler, {
+  requiresAuth: true,
+});

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -19,7 +19,7 @@ import { WidgetSessionPayload } from "@/lib/widgetSession";
 
 export const maxDuration = 60;
 
-const chatRequestBodySchema = z.object({
+const requestSchema = z.object({
   message: z.any(),
   token: z.string(),
   conversationSlug: z.string(),
@@ -50,70 +50,68 @@ export function OPTIONS() {
   return corsOptions();
 }
 
-async function handler(
-  request: Request,
-  context: { params?: Record<string, string>; mailbox: Mailbox; session: WidgetSessionPayload },
-  validatedBody: z.infer<typeof chatRequestBodySchema>,
-) {
-  const { message, conversationSlug, readPageTool, guideEnabled, isToolResult } = validatedBody;
-  const { session, mailbox } = context;
+export const POST = createApiHandler(
+  async (
+    request: Request,
+    context: { params?: Record<string, string>; mailbox: Mailbox; session: WidgetSessionPayload },
+    validatedBody: z.infer<typeof chatRequestBodySchema>,
+  ) => {
+    const { message, conversationSlug, readPageTool, guideEnabled, isToolResult } = validatedBody;
+    const { session, mailbox } = context;
 
-  const conversation = await getConversation(conversationSlug, session, mailbox);
+    const conversation = await getConversation(conversationSlug, session, mailbox);
 
-  const userEmail = session.isAnonymous ? null : session.email || null;
-  const screenshotData = message.experimental_attachments?.[0]?.url;
+    const userEmail = session.isAnonymous ? null : session.email || null;
+    const screenshotData = message.experimental_attachments?.[0]?.url;
 
-  if (
-    (message.experimental_attachments ?? []).length > 1 ||
-    (screenshotData && !screenshotData.startsWith("data:image/png;base64,"))
-  ) {
-    return corsResponse(
-      { error: "Only a single PNG image attachment sent via data URL is supported" },
-      { status: 400 },
+    if (
+      (message.experimental_attachments ?? []).length > 1 ||
+      (screenshotData && !screenshotData.startsWith("data:image/png;base64,"))
+    ) {
+      return corsResponse(
+        { error: "Only a single PNG image attachment sent via data URL is supported" },
+        { status: 400 },
+      );
+    }
+
+    const userMessage = await createUserMessage(
+      conversation.id,
+      userEmail,
+      message.content,
+      screenshotData?.replace("data:image/png;base64,", ""),
     );
-  }
 
-  const userMessage = await createUserMessage(
-    conversation.id,
-    userEmail,
-    message.content,
-    screenshotData?.replace("data:image/png;base64,", ""),
-  );
+    const supabase = await createClient();
+    let isHelperUser = false;
+    if ((await supabase.auth.getUser()).data.user?.id) {
+      isHelperUser = true;
+    }
 
-  const supabase = await createClient();
-  let isHelperUser = false;
-  if ((await supabase.auth.getUser()).data.user?.id) {
-    isHelperUser = true;
-  }
-
-  return await respondWithAI({
-    conversation,
-    mailbox,
-    userEmail,
-    message,
-    messageId: userMessage.id,
-    readPageTool,
-    guideEnabled,
-    sendEmail: false,
-    reasoningEnabled: false,
-    isHelperUser,
-    onResponse: ({ messages, isPromptConversation, isFirstMessage, humanSupportRequested }) => {
-      if (
-        (!isPromptConversation && conversation.subject === CHAT_CONVERSATION_SUBJECT) ||
-        (isPromptConversation && !isFirstMessage && conversation.subject === messages[0]?.content) ||
-        humanSupportRequested
-      ) {
-        waitUntil(generateConversationSubject(conversation.id, messages, mailbox));
-      } else if (isPromptConversation && conversation.subject === CHAT_CONVERSATION_SUBJECT) {
-        waitUntil(
-          db.update(conversations).set({ subject: message.content }).where(eq(conversations.id, conversation.id)),
-        );
-      }
-    },
-  });
-}
-
-export const POST = createApiHandler(handler, {
-  requiresAuth: true,
-  requestSchema: chatRequestBodySchema,
-});
+    return await respondWithAI({
+      conversation,
+      mailbox,
+      userEmail,
+      message,
+      messageId: userMessage.id,
+      readPageTool,
+      guideEnabled,
+      sendEmail: false,
+      reasoningEnabled: false,
+      isHelperUser,
+      onResponse: ({ messages, isPromptConversation, isFirstMessage, humanSupportRequested }) => {
+        if (
+          (!isPromptConversation && conversation.subject === CHAT_CONVERSATION_SUBJECT) ||
+          (isPromptConversation && !isFirstMessage && conversation.subject === messages[0]?.content) ||
+          humanSupportRequested
+        ) {
+          waitUntil(generateConversationSubject(conversation.id, messages, mailbox));
+        } else if (isPromptConversation && conversation.subject === CHAT_CONVERSATION_SUBJECT) {
+          waitUntil(
+            db.update(conversations).set({ subject: message.content }).where(eq(conversations.id, conversation.id)),
+          );
+        }
+      },
+    });
+  },
+  { requiresAuth: true, requestSchema },
+);

--- a/app/api/guide/event/route.ts
+++ b/app/api/guide/event/route.ts
@@ -15,7 +15,7 @@ const eventSchema = z.object({
 
 const requestSchema = z.object({
   sessionId: z.string().min(1),
-  events: z.array(z.any()),
+  events: z.array(eventSchema),
   metadata: z.record(z.string(), z.unknown()).optional(),
   isRecording: z.boolean().optional(),
 });

--- a/app/api/guide/event/route.ts
+++ b/app/api/guide/event/route.ts
@@ -26,6 +26,7 @@ export function OPTIONS() {
 
 export const POST = createApiHandler(
   async (
+    request: Request,
     context: { params?: Record<string, string>; mailbox: any; session: any },
     validatedBody: z.infer<typeof requestSchema>,
   ) => {

--- a/app/api/route-handler.ts
+++ b/app/api/route-handler.ts
@@ -1,0 +1,81 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+import { authenticateWidget, corsResponse } from "@/app/api/widget/utils";
+import type { Mailbox } from "@/db/schema";
+import { captureExceptionAndLog } from "@/lib/shared/sentry";
+import type { WidgetSession } from "@/lib/widgetSession";
+
+interface AuthenticatedRequestContext {
+  request: NextRequest;
+  params?: Record<string, string>;
+  mailbox: Mailbox;
+  session: WidgetSession;
+}
+
+interface ApiHandlerOptions<TBodySchema extends z.ZodSchema = z.ZodSchema> {
+  requiresAuth?: boolean;
+  requestSchema?: TBodySchema;
+}
+
+export function createApiHandler<TBodySchema extends z.ZodSchema>(
+  handler: (
+    req: NextRequest,
+    context: { params?: Record<string, string> },
+    validatedBody: z.infer<TBodySchema>,
+  ) => Promise<NextResponse | Response>,
+  options: ApiHandlerOptions<TBodySchema> & { requiresAuth?: false },
+): (req: NextRequest, context: { params?: Record<string, string> }) => Promise<NextResponse | Response>;
+
+export function createApiHandler<TBodySchema extends z.ZodSchema>(
+  handler: (
+    req: NextRequest,
+    context: AuthenticatedRequestContext,
+    validatedBody: z.infer<TBodySchema>,
+  ) => Promise<NextResponse | Response>,
+  options: ApiHandlerOptions<TBodySchema> & { requiresAuth: true },
+): (req: NextRequest, context: { params?: Record<string, string> }) => Promise<NextResponse | Response>;
+
+export function createApiHandler<TBodySchema extends z.ZodSchema = z.ZodSchema>(
+  handler: (
+    req: NextRequest,
+    context: { params?: Record<string, string> } | AuthenticatedRequestContext,
+    validatedBody: z.infer<TBodySchema>,
+  ) => Promise<NextResponse | Response>,
+  options?: ApiHandlerOptions<TBodySchema>,
+): (req: NextRequest, context: { params?: Record<string, string> }) => Promise<NextResponse | Response> {
+  return async (req: NextRequest, context: { params?: Record<string, string> }) => {
+    try {
+      let validatedBody: z.infer<TBodySchema> | undefined;
+      if (options?.requestSchema) {
+        const body = await req.json();
+        const result = options.requestSchema.safeParse(body);
+        if (!result.success) {
+          return NextResponse.json(
+            { error: "Invalid request parameters", details: result.error.errors },
+            { status: 400 },
+          );
+        }
+        validatedBody = result.data;
+      }
+
+      let authContext: AuthenticatedRequestContext | undefined;
+      if (options?.requiresAuth) {
+        const authResult = await authenticateWidget(req);
+        if (!authResult.success) {
+          return corsResponse({ error: authResult.error }, { status: 401 });
+        }
+        authContext = { ...context, request: req, mailbox: authResult.mailbox, session: authResult.session };
+      }
+
+      const finalContext = options?.requiresAuth ? authContext! : { request: req, ...context };
+      return await handler(req, finalContext as any, validatedBody as any);
+    } catch (error) {
+      captureExceptionAndLog(error);
+
+      if (req.url.includes("/api/widget/")) {
+        return corsResponse({ error: "An unexpected error occurred" }, { status: 500 });
+      }
+      return NextResponse.json({ message: "Internal Server Error" }, { status: 500 });
+    }
+  };
+}

--- a/app/api/route-handler.ts
+++ b/app/api/route-handler.ts
@@ -17,24 +17,6 @@ interface ApiHandlerOptions<TBodySchema extends z.ZodSchema = z.ZodSchema> {
   requestSchema?: TBodySchema;
 }
 
-export function createApiHandler<TBodySchema extends z.ZodSchema>(
-  handler: (
-    req: NextRequest,
-    context: { params?: Record<string, string> },
-    validatedBody: z.infer<TBodySchema>,
-  ) => Promise<NextResponse | Response>,
-  options: ApiHandlerOptions<TBodySchema> & { requiresAuth?: false },
-): (req: NextRequest, context: { params?: Record<string, string> }) => Promise<NextResponse | Response>;
-
-export function createApiHandler<TBodySchema extends z.ZodSchema>(
-  handler: (
-    req: NextRequest,
-    context: AuthenticatedRequestContext,
-    validatedBody: z.infer<TBodySchema>,
-  ) => Promise<NextResponse | Response>,
-  options: ApiHandlerOptions<TBodySchema> & { requiresAuth: true },
-): (req: NextRequest, context: { params?: Record<string, string> }) => Promise<NextResponse | Response>;
-
 export function createApiHandler<TBodySchema extends z.ZodSchema = z.ZodSchema>(
   handler: (
     req: NextRequest,


### PR DESCRIPTION
## Description

This PR introduces a `createApiHandler` utility to streamline API route definitions and reduce boilerplate, and refactors `/chat/*` routes as a showcase.

### Why this was added:

Many of our Next.js API routes (`app/api/**/*.ts`) shared repetitive logic for:
- HTTP method validation.
- Request body parsing and Zod schema validation.
- Widget authentication.
- Standardized error handling and responses.

This duplication made routes verbose and harder to maintain.

### What was changed:

- implement `createApiHandler`:  
  A new utility, `createApiHandler` was created. This function wraps API route logic, automatically handling method checks, request body validation (using Zod), and widget authentication, as well as centralized error logging and response formatting.
- Refactor chat routes with `createApiHandler`:  
    - `/chat`
    - `/chat/contact`
    - `/chat/conversation`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined API endpoints for chat, conversation, contact forms, guide actions, guide events, and widget sessions to use a unified handler, improving consistency in authentication, validation, and error handling.

* **New Features**
  * Introduced a centralized utility that automatically validates and authenticates API requests, enhancing reliability and security.

* **Bug Fixes**
  * Improved error handling for API endpoints, delivering clearer and more consistent responses to users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->