### PR TITLE
feat: confirmation dialog for command bar actions

### DIFF
--- a/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/conversation/messageActions.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/conversation/messageActions.tsx
@@ -1,4 +1,4 @@
-import { Dialog, DialogContent, DialogDescription } from "@radix-ui/react-dialog";
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader } from "@/components/ui/dialog";
 import { isMacOS } from "@tiptap/core";
 import { CornerUpLeft } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";


### PR DESCRIPTION
This adds confirmation dialog for 3 actions in conversations page : 'Mark as Spam', 'Close Ticket', 'Reopen Ticket'.

Handles all 3 cases:
- keyboard shortcuts 'C', 'Z', 'S'
- navigation through keyboard down arrow key and press enter for selection
- select and click by cursor

PS: I haven't added any e2e tests, let me know if that's required.

https://github.com/user-attachments/assets/5afa2d5e-f739-4236-a662-629e5df81ef0





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added confirmation dialogs before changing ticket statuses (close, mark as spam, or reopen) in both message actions and command bar interfaces.

* **Refactor**
  * Updated keyboard shortcuts and action buttons to trigger confirmation dialogs instead of performing immediate status changes.
  * Improved command bar structure and handlers to support the new confirmation workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->