### PR TITLE
fix: send message btn doesn't stick on smaller screens

### DIFF
--- a/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/list/conversationList.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/list/conversationList.tsx
@@ -309,7 +309,7 @@ const NewConversationModal = () => {
         <Button
           variant="default"
           iconOnly
-          className="absolute bottom-6 right-6 rounded-full text-primary-foreground dark:bg-bright dark:text-bright-foreground bg-bright hover:bg-bright/90 hover:text-background"
+          className="fixed z-50 bottom-6 right-6 rounded-full text-primary-foreground dark:bg-bright dark:text-bright-foreground bg-bright hover:bg-bright/90 hover:text-background"
         >
           <Send className="text-primary dark:text-primary-foreground h-4 w-4" />
         </Button>


### PR DESCRIPTION
This PR resolves an issue where the yellow "Send Message" button in the bottom-right corner fails to remain fixed during scrolling on smaller screens.

Before:

https://github.com/user-attachments/assets/a3aea66f-faf6-45bb-a632-82ca951fe0e1

After:

https://github.com/user-attachments/assets/a7aa6489-bcda-4116-ba9c-d9dcdab06331


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the positioning of the new conversation button to remain fixed on the screen with improved layering, ensuring it stays visible as you scroll.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->