### PR TITLE
feat: add close buttons for CC/BCC fields and scroll to message textarea

### DIFF
--- a/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/conversation/messageActions.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/conversation/messageActions.tsx
@@ -1,5 +1,5 @@
 import { isMacOS } from "@tiptap/core";
-import { CornerUpLeft } from "lucide-react";
+import { CornerUpLeft, X } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useConversationContext } from "@/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/conversation/conversationContext";
 import { EmailSignature } from "@/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/emailSignature";
@@ -420,21 +420,37 @@ export const MessageActions = () => {
         onToggleCc={onToggleCc}
         inputRef={commandInputRef}
       />
-      <div className={cn("shrink-0 grid grid-cols-2 gap-2 mt-4", (!showCc || showCommandBar) && "hidden")}>
-        <LabeledInput
-          ref={ccRef}
-          name="CC"
-          value={draftedEmail.cc}
-          onChange={(cc) => updateDraftedEmail({ cc })}
-          onModEnter={() => {}}
-        />
-        <LabeledInput
-          ref={bccRef}
-          name="BCC"
-          value={draftedEmail.bcc}
-          onChange={(bcc) => updateDraftedEmail({ bcc })}
-          onModEnter={() => {}}
-        />
+      <div className={cn("shrink-0 mt-4", (!showCc || showCommandBar) && "hidden")}>
+        <div className="flex items-center justify-between mb-2">
+          <span className="text-sm text-muted-foreground">Additional recipients</span>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => {
+              setShowCc(false);
+              setDraftedEmail((prev) => ({ ...prev, cc: "", bcc: "", modified: true }));
+            }}
+            className="h-6 w-6 p-0"
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+        <div className="grid grid-cols-2 gap-2">
+          <LabeledInput
+            ref={ccRef}
+            name="CC"
+            value={draftedEmail.cc}
+            onChange={(cc) => updateDraftedEmail({ cc })}
+            onModEnter={() => {}}
+          />
+          <LabeledInput
+            ref={bccRef}
+            name="BCC"
+            value={draftedEmail.bcc}
+            onChange={(bcc) => updateDraftedEmail({ bcc })}
+            onModEnter={() => {}}
+          />
+        </div>
       </div>
       <TipTapEditor
         ref={editorRef}

--- a/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/list/newConversationModal.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/list/newConversationModal.tsx
@@ -1,5 +1,6 @@
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { X } from "lucide-react";
 import {
   FAILED_ATTACHMENTS_TOOLTIP_MESSAGE,
   useSendDisabled,
@@ -173,6 +174,7 @@ const NewConversationModal = ({ mailboxSlug, conversationSlug, onSubmit }: Props
         />
         <TipTapEditor
           ref={editorRef}
+          className="max-h-60 overflow-y-auto"
           ariaLabel="Message"
           placeholder="Type your message here..."
           defaultContent={messageMemoized}
@@ -257,23 +259,45 @@ const CcAndBccInfo = ({
         </span>
       ) : null}
       {ccVisible && (
-        <LabeledInput
-          ref={ccRef}
-          name="CC"
-          value={newConversationInfo.cc}
-          onChange={(cc) => onChange({ cc })}
-          onModEnter={onModEnter}
-        />
+        <div className="relative">
+          <LabeledInput
+            ref={ccRef}
+            name="CC"
+            value={newConversationInfo.cc}
+            onChange={(cc) => onChange({ cc })}
+            onModEnter={onModEnter}
+          />
+          <button
+            onClick={() => {
+              setCcVisible(false);
+              onChange({ cc: "" });
+            }}
+            className="absolute right-2 top-2 p-1 hover:bg-muted rounded"
+          >
+            <X className="h-3 w-3" />
+          </button>
+        </div>
       )}
       {!ccVisible && bccVisible ? <CcButton /> : null}
       {bccVisible && (
-        <LabeledInput
-          ref={bccRef}
-          name="BCC"
-          value={newConversationInfo.bcc}
-          onChange={(bcc) => onChange({ bcc })}
-          onModEnter={onModEnter}
-        />
+        <div className="relative">
+          <LabeledInput
+            ref={bccRef}
+            name="BCC"
+            value={newConversationInfo.bcc}
+            onChange={(bcc) => onChange({ bcc })}
+            onModEnter={onModEnter}
+          />
+          <button
+            onClick={() => {
+              setBccVisible(false);
+              onChange({ bcc: "" });
+            }}
+            className="absolute right-2 top-2 p-1 hover:bg-muted rounded"
+          >
+            <X className="h-3 w-3" />
+          </button>
+        </div>
       )}
       {!bccVisible && ccVisible ? <BccButton /> : null}
     </div>


### PR DESCRIPTION
Before:
https://www.loom.com/share/74e612d45d954c6896ebbac4c0f41139

After:
https://www.loom.com/share/a0f59e6fc8944cccaad69e0356ff1fa4

- Add X close buttons to CC and BCC fields that hide the field and clear its value
- Add max height and scroll to message textarea in new conversation modal
- Improve UX by allowing users to easily remove CC/BCC fields after adding them