### PR TITLE
fix: improve conversation UI positioning and resize behavior

### DIFF
--- a/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/conversation/conversation.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/conversation/conversation.tsx
@@ -131,7 +131,7 @@ const ScrollToTopButton = ({
       <TooltipTrigger asChild>
         <a
           className={cn(
-            "absolute bottom-4 left-4 transition-all duration-200 h-8 w-8 p-0 rounded-full",
+            "sticky bottom-4 left-4 z-10 transition-all duration-200 h-8 w-8 p-0 rounded-full",
             "flex items-center justify-center",
             "bg-background border border-border shadow-xs",
             "hover:border-primary hover:shadow-md hover:bg-muted",
@@ -164,7 +164,6 @@ const MessageThreadPanel = ({
   return (
     <div className="grow overflow-y-auto relative" ref={scrollRef}>
       <div ref={contentRef as React.RefObject<HTMLDivElement>} className="relative">
-        <ScrollToTopButton scrollRef={scrollRef} />
         <div className="flex flex-col gap-8 px-4 py-4 h-full">
           {conversationInfo && (
             <MessageThread
@@ -178,6 +177,7 @@ const MessageThreadPanel = ({
           )}
         </div>
       </div>
+      <ScrollToTopButton scrollRef={scrollRef} />
     </div>
   );
 };
@@ -185,7 +185,7 @@ const MessageThreadPanel = ({
 const MessageActionsPanel = () => {
   return (
     <div
-      className="h-full bg-muted px-4 pb-4"
+      className="h-full overflow-y-auto bg-muted px-4 pb-4"
       onKeyDown={(e) => {
         // Prevent keypress events from triggering the global inbox view keyboard shortcuts
         e.stopPropagation();
@@ -460,9 +460,19 @@ const ConversationContent = () => {
             <ResizablePanel
               minSize={20}
               defaultSize={defaultSize}
-              maxSize={80}
+              maxSize={62.5}
               onResize={(size) => {
                 localStorage.setItem("conversationHeightRange", Math.floor(size).toString());
+
+                const scrollElement = scrollRef.current;
+                if (scrollElement) {
+                  const threshold = 50;
+                  const isAtBottom =
+                    scrollElement.scrollHeight - scrollElement.scrollTop - scrollElement.clientHeight <= threshold;
+                  if (isAtBottom) {
+                    scrollToBottom({ animation: "instant" });
+                  }
+                }
               }}
             >
               <div className="flex flex-col h-full">
@@ -492,7 +502,7 @@ const ConversationContent = () => {
               </div>
             </ResizablePanel>
             <ResizableHandle />
-            <ResizablePanel defaultSize={100 - defaultSize} minSize={20}>
+            <ResizablePanel defaultSize={100 - defaultSize} minSize={37.5} maxSize={80}>
               <MessageActionsPanel />
             </ResizablePanel>
           </ResizablePanelGroup>


### PR DESCRIPTION
## Before Video


https://github.com/user-attachments/assets/cb57d759-febc-4427-9bb0-dd6a0b0aee5a


## After Video

https://github.com/user-attachments/assets/ae82d9ee-c981-49b5-afb5-ba8436cfbe21



## ScrollToTop Button Improvements
- Change from absolute to sticky positioning for better visibility
- Move ScrollToTop button inside MessageThreadPanel for proper context
- Ensure button stays visible and correctly positioned during resizes

## Enhanced Panel Resize Logic
- Add smart scroll behavior that maintains bottom position during resize
- Auto-scroll to bottom when user was already at bottom before resize
- Use 50px threshold to detect if user is at conversation bottom

## Better Panel Size Constraints
- Update maxSize from 80 to 62.5 for better balance between panels
- Add minSize constraint of 37.5 for message actions panel
- Add maxSize constraint of 80 for message actions panel
- Prevent extreme resize scenarios that make interface unusable

## Message Actions Panel Enhancement
- Add overflow-y-auto for independent scrolling when content is tall
- Better handling of long compose/reply content

These changes fix several UX issues:
- ScrollToTop button no longer disappears during resize
- Conversation stays scrolled to bottom when user resizes panels
- Better balance between message thread and compose areas
- Independent scrolling for compose area when needed