### PR TITLE
fix: improve dashboard graphs styling and layout

### DIFF
--- a/app/(dashboard)/mailboxes/[mailbox_slug]/dashboard/dashboardContent.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/dashboard/dashboardContent.tsx
@@ -49,19 +49,23 @@ export function DashboardContent({ mailboxSlug, currentMailbox }: Props) {
             />
           </div>
           <div className="grid md:grid-cols-3 gap-6">
-            <Panel className="h-[800px] md:h-[400px] md:col-span-2">
-              <div className="grid md:grid-cols-2 gap-6">
-                <div className="flex flex-col">
-                  <h4 className="scroll-m-20 mb-2 text-sm font-semibold tracking-tight uppercase">Ticket Status</h4>
-                  <StatusByTypeChart mailboxSlug={mailboxSlug} timeRange={timeRange} customDate={customDate} />
+            <Panel className="h-[500px] md:h-[450px] md:col-span-2">
+              <div className="grid md:grid-cols-2 gap-6 h-full">
+                <div className="flex flex-col min-h-0">
+                  <h4 className="scroll-m-20 mb-4 text-sm font-semibold tracking-tight uppercase">Ticket Status</h4>
+                  <div className="flex-1 min-h-0">
+                    <StatusByTypeChart mailboxSlug={mailboxSlug} timeRange={timeRange} customDate={customDate} />
+                  </div>
                 </div>
-                <div className="flex flex-col">
-                  <h4 className="scroll-m-20 mb-2 text-sm font-semibold tracking-tight uppercase">Replies by Agent</h4>
-                  <PeopleTable mailboxSlug={mailboxSlug} timeRange={timeRange} customDate={customDate} />
+                <div className="flex flex-col min-h-0">
+                  <h4 className="scroll-m-20 mb-4 text-sm font-semibold tracking-tight uppercase">Replies by Agent</h4>
+                  <div className="flex-1 min-h-0">
+                    <PeopleTable mailboxSlug={mailboxSlug} timeRange={timeRange} customDate={customDate} />
+                  </div>
                 </div>
               </div>
             </Panel>
-            <Panel title="Reactions" className="h-[400px] md:-order-1">
+            <Panel title="Reactions" className="h-[450px] md:-order-1">
               <ReactionsChart mailboxSlug={mailboxSlug} timeRange={timeRange} customDate={customDate} />
             </Panel>
           </div>

--- a/app/(dashboard)/mailboxes/[mailbox_slug]/dashboard/peopleTable.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/dashboard/peopleTable.tsx
@@ -27,48 +27,58 @@ export const PeopleTable = ({ mailboxSlug, timeRange, customDate }: Props) => {
 
   if (isLoading) {
     return (
-      <div className="flex flex-col gap-4">
-        <Table>
-          <TableBody>
-            {Array.from({ length: 5 }).map((_, i) => (
-              <TableRow key={i}>
-                <TableCell>
-                  <Skeleton className="h-4 w-[120px]" />
-                </TableCell>
-                <TableCell>
-                  <Skeleton className="h-4 w-[60px]" />
-                </TableCell>
+      <div className="flex flex-col w-full h-full">
+        <div className="flex-1 min-h-0">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="px-0 text-xs font-medium text-muted-foreground uppercase tracking-wide">Name</TableHead>
+                <TableHead className="px-0 text-xs font-medium text-muted-foreground uppercase tracking-wide text-right">Replies</TableHead>
               </TableRow>
-            ))}
-          </TableBody>
-        </Table>
+            </TableHeader>
+            <TableBody>
+              {Array.from({ length: 5 }).map((_, i) => (
+                <TableRow key={i}>
+                  <TableCell className="px-0 py-3">
+                    <Skeleton className="h-4 w-[120px]" />
+                  </TableCell>
+                  <TableCell className="px-0 py-3 text-right">
+                    <Skeleton className="h-4 w-[60px] ml-auto" />
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
       </div>
     );
   }
 
   return (
-    <div className="flex flex-col gap-4">
+    <div className="flex flex-col w-full h-full">
       {members?.length ? (
-        <div className="max-h-[350px] md:max-h-[300px] overflow-y-auto">
+        <div className="flex-1 min-h-0 overflow-y-auto">
           <Table>
-            <TableHeader>
+            <TableHeader className="sticky top-0 bg-background">
               <TableRow>
-                <TableHead className="px-0">Name</TableHead>
-                <TableHead className="px-0">Replies</TableHead>
+                <TableHead className="px-0 text-xs font-medium text-muted-foreground uppercase tracking-wide">Name</TableHead>
+                <TableHead className="px-0 text-xs font-medium text-muted-foreground uppercase tracking-wide text-right">Replies</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
               {members.map((member: Member) => (
-                <TableRow key={member.id}>
-                  <TableCell className="px-0">{member.displayName}</TableCell>
-                  <TableCell className="px-0">{member.replyCount}</TableCell>
+                <TableRow key={member.id} className="hover:bg-muted/50 transition-colors">
+                  <TableCell className="px-0 py-3 font-medium">{member.displayName}</TableCell>
+                  <TableCell className="px-0 py-3 text-right font-mono text-sm">{member.replyCount.toLocaleString()}</TableCell>
                 </TableRow>
               ))}
             </TableBody>
           </Table>
         </div>
       ) : (
-        <div>No data available.</div>
+        <div className="flex items-center justify-center flex-1 text-muted-foreground">
+          No data available.
+        </div>
       )}
     </div>
   );

--- a/app/(dashboard)/mailboxes/[mailbox_slug]/dashboard/reactionsChart.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/dashboard/reactionsChart.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useState } from "react";
 import { DateRange } from "react-day-picker";
-import { Bar, BarChart, ReferenceLine, XAxis, YAxis } from "recharts";
+import { Bar, BarChart, ReferenceLine, ResponsiveContainer, XAxis, YAxis } from "recharts";
 import ConversationsModal from "@/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/conversationsModal";
 import { timeRangeToQuery } from "@/app/(dashboard)/mailboxes/[mailbox_slug]/dashboard/timeRangeSelector";
 import {
@@ -90,37 +90,56 @@ export function ReactionsChart({
   };
 
   return (
-    <>
-      <ChartContainer config={chartConfig} className="h-[300px]">
-        <BarChart data={Object.values(chartData)} stackOffset="sign" barGap={16}>
-          <XAxis dataKey="label" axisLine={false} tickLine={false} />
-          <YAxis width={20} domain={["dataMin", "dataMax"]} axisLine={false} tickLine={false} />
-          <ReferenceLine y={0} stroke="var(--border)" strokeWidth={1} />
-          <ChartTooltip
-            position={{ y: 0 }}
-            content={<ChartTooltipContent valueFormatter={(value) => Math.abs(value).toLocaleString()} />}
-          />
-          <ChartLegend content={<ChartLegendContent />} />
-          <Bar
-            stackId="feedback"
-            dataKey="positive"
-            fill="var(--color-positive)"
-            maxBarSize={32}
-            radius={[4, 4, 0, 0]}
-            onClick={(data) => handleBarClick(data, "positive")}
-            className="cursor-pointer hover:opacity-90 transition-opacity duration-100"
-          />
-          <Bar
-            stackId="feedback"
-            dataKey="negative"
-            fill="var(--color-negative)"
-            maxBarSize={32}
-            radius={[4, 4, 0, 0]}
-            onClick={(data) => handleBarClick(data, "negative")}
-            className="cursor-pointer hover:opacity-90 transition-opacity duration-100"
-          />
-        </BarChart>
-      </ChartContainer>
+    <div className="flex flex-col w-full h-full">
+      <div className="relative flex-1 min-h-0">
+        <ChartContainer config={chartConfig} className="w-full h-full">
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={Object.values(chartData)} stackOffset="sign" barGap={16} margin={{ top: 20, right: 10, left: 10, bottom: 40 }}>
+              <XAxis 
+                dataKey="label" 
+                axisLine={false} 
+                tickLine={false} 
+                tick={{ fontSize: 12 }}
+                height={60}
+              />
+              <YAxis 
+                width={40} 
+                domain={["dataMin", "dataMax"]} 
+                axisLine={false} 
+                tickLine={false}
+                tick={{ fontSize: 12 }}
+              />
+              <ReferenceLine y={0} stroke="var(--border)" strokeWidth={1} />
+              <ChartTooltip
+                position={{ y: 0 }}
+                content={<ChartTooltipContent valueFormatter={(value) => Math.abs(value).toLocaleString()} />}
+              />
+              <ChartLegend 
+                content={<ChartLegendContent />} 
+                wrapperStyle={{ paddingTop: '8px' }}
+              />
+              <Bar
+                stackId="feedback"
+                dataKey="positive"
+                fill="var(--color-positive)"
+                maxBarSize={32}
+                radius={[4, 4, 0, 0]}
+                onClick={(data) => handleBarClick(data, "positive")}
+                className="cursor-pointer hover:opacity-90 transition-opacity duration-100"
+              />
+              <Bar
+                stackId="feedback"
+                dataKey="negative"
+                fill="var(--color-negative)"
+                maxBarSize={32}
+                radius={[4, 4, 0, 0]}
+                onClick={(data) => handleBarClick(data, "negative")}
+                className="cursor-pointer hover:opacity-90 transition-opacity duration-100"
+              />
+            </BarChart>
+          </ResponsiveContainer>
+        </ChartContainer>
+      </div>
 
       <ConversationsModal
         open={!!selectedBar}
@@ -130,6 +149,6 @@ export function ReactionsChart({
         conversations={selectedConversations?.conversations ?? []}
         isLoading={isLoadingConversations}
       />
-    </>
+    </div>
   );
 }

--- a/app/(dashboard)/mailboxes/[mailbox_slug]/dashboard/statusByTypeChart.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/dashboard/statusByTypeChart.tsx
@@ -70,10 +70,10 @@ export function StatusByTypeChart({ mailboxSlug, timeRange, customDate }: Status
   const totalTickets = chartData.reduce((acc, curr) => acc + curr.value, 0);
 
   return (
-    <div className="flex flex-col w-full h-full min-h-[300px]">
-      <div className="relative flex-1">
-        <ResponsiveContainer width="100%" height="100%">
-          <ChartContainer className="mx-auto aspect-square max-h-[400px]" config={chartConfig}>
+    <div className="flex flex-col w-full h-full">
+      <div className="relative flex-1 min-h-0">
+        <ChartContainer className="w-full h-full" config={chartConfig}>
+          <ResponsiveContainer width="100%" height="100%">
             <PieChart>
               <ChartTooltip
                 cursor={false}
@@ -91,8 +91,8 @@ export function StatusByTypeChart({ mailboxSlug, timeRange, customDate }: Status
                 nameKey="name"
                 cx="50%"
                 cy="50%"
-                innerRadius={60}
-                outerRadius={85}
+                innerRadius="30%"
+                outerRadius="70%"
                 startAngle={90}
                 endAngle={450}
               >
@@ -108,10 +108,10 @@ export function StatusByTypeChart({ mailboxSlug, timeRange, customDate }: Status
                     if (viewBox && "cx" in viewBox && "cy" in viewBox) {
                       return (
                         <text x={viewBox.cx} y={viewBox.cy} textAnchor="middle" dominantBaseline="middle">
-                          <tspan x={viewBox.cx} y={viewBox.cy} className="fill-foreground text-3xl font-bold">
+                          <tspan x={viewBox.cx} y={viewBox.cy} className="fill-foreground text-2xl font-bold">
                             {totalTickets.toLocaleString()}
                           </tspan>
-                          <tspan x={viewBox.cx} y={(viewBox.cy || 0) + 24} className="fill-muted-foreground">
+                          <tspan x={viewBox.cx} y={(viewBox.cy || 0) + 20} className="fill-muted-foreground text-sm">
                             Total
                           </tspan>
                         </text>
@@ -120,10 +120,15 @@ export function StatusByTypeChart({ mailboxSlug, timeRange, customDate }: Status
                   }}
                 />
               </Pie>
-              <ChartLegend content={<ChartLegendContent />} verticalAlign="bottom" className="text-xs" />
+              <ChartLegend 
+                content={<ChartLegendContent />} 
+                verticalAlign="bottom" 
+                className="text-xs mt-2" 
+                wrapperStyle={{ paddingTop: '8px' }}
+              />
             </PieChart>
-          </ChartContainer>
-        </ResponsiveContainer>
+          </ResponsiveContainer>
+        </ChartContainer>
       </div>
     </div>
   );

--- a/components/panel.tsx
+++ b/components/panel.tsx
@@ -12,11 +12,11 @@ export const Panel = ({
 }) => (
   <div
     className={cn(
-      "flex-1 border flex flex-col p-5 overflow-auto rounded-lg bg-white dark:bg-muted text-bright-foreground dark:text-muted-foreground",
+      "flex-1 border flex flex-col p-6 overflow-hidden rounded-lg bg-white dark:bg-muted text-bright-foreground dark:text-muted-foreground shadow-sm",
       className,
     )}
   >
-    {title && <h4 className="scroll-m-20 mb-2 text-sm font-semibold tracking-tight uppercase">{title}</h4>}
-    <div className="flex-1">{children}</div>
+    {title && <h4 className="scroll-m-20 mb-4 text-sm font-semibold tracking-tight uppercase text-foreground">{title}</h4>}
+    <div className="flex-1 min-h-0">{children}</div>
   </div>
 );


### PR DESCRIPTION
## Chart Improvements

### 📊 Pie Chart (Status)
- Remove restrictive aspect-square constraint that was causing sizing issues
- Use percentage-based innerRadius/outerRadius for better responsive scaling
- Improve text sizing and spacing in center label
- Better legend positioning with proper padding

### 📈 Bar Chart (Reactions)
- Replace fixed height with responsive container layout
- Add proper margins for axis labels and legend
- Improve axis sizing and font sizes for better readability
- Better spacing between chart elements
- Fix ResponsiveContainer import

### 📋 People Table
- Complete layout overhaul for better container fit
- Add sticky header for long lists
- Improve typography and spacing
- Add hover effects and better visual hierarchy
- Right-align numbers with monospace font
- Better loading state with consistent styling

## Layout Enhancements

### 🏗️ Panel Component
- Increase padding from p-5 to p-6 for better breathing room
- Change from overflow-auto to overflow-hidden to prevent unwanted scrollbars
- Add subtle shadow for better visual separation
- Better title styling and spacing

### 📐 Dashboard Layout
- Adjust panel heights for better proportion (450px vs 400px)
- Add proper flex layout with min-h-0 for overflow handling
- Better spacing between section titles and content
- Ensure all charts fill their containers properly

## Issues Fixed
- ✅ Charts no longer overflow their containers
- ✅ Pie chart displays properly without aspect ratio issues
- ✅ Bar chart fits responsively in its panel
- ✅ People table scrolls properly within its container
- ✅ Better visual hierarchy and spacing throughout
- ✅ Loading states consistent with final design
- ✅ Responsive design works across screen sizes
- ✅ Fixed ResponsiveContainer import error

These changes transform the dashboard from a cramped, poorly-fitted interface to a polished, professional analytics view.

Before Video:

https://github.com/user-attachments/assets/944c8011-0071-4047-866b-3c2a94913b85


After Video:

https://github.com/user-attachments/assets/e3229219-92e1-4186-9c96-5059982b30d3


