### PR TITLE
Fix: Correct package build order in typecheck script

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "test": "pnpm run-on-packages test && pnpm test:unit",
     "test:unit": "pnpm run with-dev-env vitest",
     "test:watch": "pnpm test:unit --watch",
-    "typecheck": "pnpm run-on-packages typecheck && pnpm run with-dev-env pnpm run build; BUILD_EXIT=$?; tsc --noEmit && ([ $BUILD_EXIT -eq 0 ] && npm run db:check || exit $BUILD_EXIT)",
+    "typecheck": "pnpm run with-dev-env pnpm run build; BUILD_EXIT=$?; if [ $BUILD_EXIT -ne 0 ]; then exit $BUILD_EXIT; fi && pnpm run-on-packages typecheck && pnpm run with-dev-env tsc --noEmit && pnpm run db:check",
     "services:start": "pnpm with-dev-env pnpm supabase start && (docker ps | grep helperai-nginx || pnpm nginx:start)",
     "services:stop": "pnpm supabase stop && docker stop helperai-nginx || true",
     "nginx:start": "docker run -d --rm --name helperai-nginx -p 80:80 -p 443:443 --add-host host.docker.internal:host-gateway -v $(pwd)/scripts/docker/local-nginx/helperai_dev.conf:/etc/nginx/conf.d/default.conf -v $(pwd)/scripts/docker/local-nginx/certs:/etc/ssl/certs nginx:1.27.5",


### PR DESCRIPTION
Modified the root `package.json`'s `typecheck` script to ensure that all workspace packages are built before any package attempts to typecheck against them.

This change addresses issue MAN-002, where packages would fail typechecking due to missing declaration files from their workspace dependencies (e.g., TS2307 errors for @helperai/sdk and @helperai/react).

Testing showed that `packages/marketing` successfully resolved its types after this change. Full project typecheck was blocked by a missing environment variable, but the core fix for type resolution is believed to be effective.