### PR TITLE
fix: make sidebar width on mobile consistent

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -170,9 +170,9 @@
   }
 
   .dark {
-    --sidebar-width: 12rem;
+    --sidebar-width: 16rem;
     --sidebar-width-icon: 3rem;
-    --sidebar-width-mobile: 90%;
+    --sidebar-width-mobile: 60%; /* Mobile sidebar width */
     --sidebar-background: hsl(0 58% 10%); /* Updated to match background color */
     --sidebar-foreground: hsl(0 0% 100%);
     --sidebar-primary: hsl(0 58% 10%);

--- a/lib/themes.ts
+++ b/lib/themes.ts
@@ -42,8 +42,6 @@ export const buildThemeCss = (theme: MailboxTheme) => {
     :root,
     .light,
     .dark {
-      --sidebar-width: 280px;
-      --sidebar-width-mobile: 100%;
       --sidebar-background: ${sidebarBackground};
       --sidebar-foreground: ${sidebarForeground};
       --sidebar-primary: ${sidebarBackground};

--- a/packages/marketing/app/globals.css
+++ b/packages/marketing/app/globals.css
@@ -169,7 +169,7 @@
 
   .dark {
     --sidebar-width: 20rem; /* Sidebar width */
-    --sidebar-width-mobile: 90%; /* Mobile sidebar width */
+    --sidebar-width-mobile: 60%; /* Mobile sidebar width */
     --sidebar-background: hsl(0 69% 10%); /* Updated to match #290B0A */
     --sidebar-foreground: hsl(0 0% 100%);
     --sidebar-primary: hsl(0 69% 10%); /* Updated to match sidebar background */


### PR DESCRIPTION
I've noticed that the sidebar width is quite inconsistent on smaller screens, for example it's 60% wide on light mode but 90% wide on dark mode. When I enable the custom theme feature, it becomes 100% wide. This PR fixes this seemingly unintentional behavior.

Before:

https://github.com/user-attachments/assets/1c95fe1f-85ba-4450-a71b-3cf4e170ad16

After:

https://github.com/user-attachments/assets/6c373948-77f5-4675-bff1-6bd25deca8a4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated dark mode sidebar width to match light mode for both desktop and mobile views.
  * Adjusted sidebar background color variable in dark mode for consistency.
  * Improved comments for clarity regarding sidebar styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->