### PR TITLE
feat(right-message-bar): text floating is resolved for too long strings

### DIFF
--- a/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/conversation/assignPopoverButton.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/conversation/assignPopoverButton.tsx
@@ -76,7 +76,7 @@ export const AssignPopoverButton = ({
         <PopoverTrigger asChild>
           <button
             className={cn(
-              "flex items-center gap-1 hover:underline",
+              "flex items-center gap-1 hover:underline min-w-0 w-full text-left",
               !currentAssignee && !assignedToAI && "text-muted-foreground",
             )}
             title={currentAssignee ? currentAssignee.displayName : assignedToAI ? "Helper agent" : "Unassigned"}
@@ -84,12 +84,12 @@ export const AssignPopoverButton = ({
             {assignedToAI ? (
               <>
                 <Bot className="h-4 w-4 flex-shrink-0" />
-                <span className="truncate">Helper agent</span>
+                <span className="truncate min-w-0">Helper agent</span>
               </>
             ) : (
               <>
                 <User className="h-4 w-4 flex-shrink-0" />
-                <span className="truncate">{currentAssignee ? currentAssignee.displayName : "Unassigned"}</span>
+                <span className="truncate min-w-0">{currentAssignee ? currentAssignee.displayName : "Unassigned"}</span>
               </>
             )}
           </button>

--- a/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/conversation/conversationSidebar.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/conversation/conversationSidebar.tsx
@@ -111,10 +111,12 @@ const ConversationSidebar = ({ mailboxSlug, conversation }: ConversationSidebarP
             <Badge>{conversation.status || "open"}</Badge>
           </div>
           <span className="text-muted-foreground">Assignee</span>
-          <AssignPopoverButton
-            initialAssignedToId={conversation.assignedToId}
-            assignedToAI={conversation.assignedToAI}
-          />
+          <div className="min-w-0">
+            <AssignPopoverButton
+              initialAssignedToId={conversation.assignedToId}
+              assignedToAI={conversation.assignedToAI}
+            />
+          </div>
         </div>
       </div>
 
@@ -157,10 +159,10 @@ const ConversationSidebar = ({ mailboxSlug, conversation }: ConversationSidebarP
                     })
               }
             >
-              <div className="col-start-2 text-primary flex cursor-pointer items-center gap-2">
-                <Mail className="h-4 w-4" />
+              <div className="col-start-2 text-primary flex cursor-pointer items-center gap-2 min-w-0">
+                <Mail className="h-4 w-4 flex-shrink-0" />
                 <a
-                  className="overflow-hidden text-ellipsis whitespace-nowrap hover:underline"
+                  className="overflow-hidden text-ellipsis whitespace-nowrap hover:underline min-w-0 flex-1"
                   title={conversation.emailFrom ?? ""}
                 >
                   {conversation.emailFrom}


### PR DESCRIPTION
Floating of long texts is prevented for right bar.

- Conversation Assignee
- Customer Name
- Customer Email

Before:
![chat-left-bar-before](https://github.com/user-attachments/assets/b4026389-f113-444b-b494-10558d1e0ccb)

After:
![chat-left-bar-after](https://github.com/user-attachments/assets/407aca3c-629f-4cd5-a30e-3f4e82248c1c)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved layout and text truncation for the assign popover button and sidebar elements to ensure better display within flexible containers.
  * Enhanced visual consistency for labels and clickable email sections by refining minimum width and flex properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->