### PR TITLE
feat: add closed by filter (ai or human), trigger from the statusByTypeChart

### DIFF
--- a/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/list/filters/closedByFilter.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/list/filters/closedByFilter.tsx
@@ -1,0 +1,39 @@
+import { UserCheck } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+export function ClosedByFilter({
+  closedBy,
+  onChange,
+}: {
+  closedBy: "ai" | "human" | null;
+  onChange: (closedBy: "ai" | "human" | null) => void;
+}) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant={closedBy ? "bright" : "outlined_subtle"} className="whitespace-nowrap">
+          <UserCheck className="h-4 w-4 mr-2" />
+          {closedBy === "ai" ? "Closed by AI" : closedBy === "human" ? "Closed manually" : "Closed by"}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start">
+        <DropdownMenuRadioGroup
+          value={closedBy ?? "null"}
+          onValueChange={(value) => onChange(value === "null" ? null : (value as "ai" | "human"))}
+          className="flex flex-col"
+        >
+          <DropdownMenuRadioItem value="null">Any</DropdownMenuRadioItem>
+          <DropdownMenuRadioItem value="ai">Closed by AI</DropdownMenuRadioItem>
+          <DropdownMenuRadioItem value="human">Closed manually</DropdownMenuRadioItem>
+        </DropdownMenuRadioGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/shared/queries.ts
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/shared/queries.ts
@@ -19,6 +19,7 @@ export const useConversationsListInput = () => {
     isPrompt: parseAsBoolean,
     reactionType: parseAsStringEnum(["thumbs-up", "thumbs-down"] as const),
     events: parseAsArrayOf(parseAsStringEnum(["request_human_support", "resolved_by_ai"] as const)),
+    closedBy: parseAsStringEnum(["ai", "human"] as const),
   });
 
   const input = {
@@ -36,6 +37,7 @@ export const useConversationsListInput = () => {
     isPrompt: searchParams.isPrompt ?? undefined,
     reactionType: searchParams.reactionType ?? undefined,
     events: searchParams.events ?? undefined,
+    closedBy: searchParams.closedBy ?? undefined,
   };
 
   return { input, searchParams, setSearchParams };

--- a/lib/data/conversation/searchSchema.ts
+++ b/lib/data/conversation/searchSchema.ts
@@ -33,6 +33,10 @@ export const searchSchema = z.object({
     .array(z.enum(["request_human_support", "resolved_by_ai"]))
     .optional()
     .describe("Filter tickets that were escalated to humans or resolved by AI"),
+  closedBy: z
+    .enum(["ai", "human"])
+    .optional()
+    .describe("Filter tickets by whether they were closed by AI or manually by a human"),
 
   closed: z
     .object({


### PR DESCRIPTION
This PR adds a nice "Closed by" filter that is visible when the status filter is set to "Closed". It lets the user filter whether the ticket was closed manually or by AI.

It also integrates the Ticket Status chart in the dashboard so that whenever the user clicks on a slice, they're redirected to the conversations page with the filter already applied.

Demo:

https://github.com/user-attachments/assets/f4f6290d-d639-422a-bbd8-fc8bf811b421

