### PR TITLE
fix: modal overlay lighter for better UI/UX

### DIFF
--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -17,7 +17,7 @@ const DialogOverlay = ({ className, ref, ...props }: React.ComponentPropsWithRef
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-50 bg-black/60  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className,
     )}
     {...props}


### PR DESCRIPTION
the faded background behind modal is looking so blackish.

before:

![Screenshot From 2025-07-04 01-41-55](https://github.com/user-attachments/assets/a43c1768-1be8-4c3e-8ae7-c4983fe0e749)

after:
![Screenshot From 2025-07-04 01-49-05](https://github.com/user-attachments/assets/3f62e5ba-f439-4ac1-8e26-ab7f69ef5da1)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the dialog overlay background to use a lighter opacity for improved visual appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->