### PR TITLE
feat: remove mailbox switcher dropdown and mailboxes.list procedure | Remove mailbox switching #489

### DIFF
--- a/app/(dashboard)/mailboxes/[mailbox_slug]/appSidebar.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/appSidebar.tsx
@@ -91,7 +91,7 @@ export function AppSidebar({ mailboxSlug }: { mailboxSlug: string }) {
           </SidebarMenu>
         ) : (
           <div className="flex items-center gap-2 w-full h-10 px-2 rounded-lg">
-            <Avatar src={undefined} fallback={mailbox?.name || ""} size="sm" />
+            <Avatar src={undefined} fallback={mailbox?.name || "G"} size="sm" />
             <span className="truncate text-base group-data-[collapsible=icon]:hidden">{mailbox?.name}</span>
           </div>
         )}

--- a/app/(dashboard)/mailboxes/[mailbox_slug]/appSidebar.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/appSidebar.tsx
@@ -3,8 +3,6 @@
 import {
   BarChart,
   BookOpen,
-  CheckCircle,
-  ChevronDown,
   ChevronLeft,
   Inbox,
   Link as LinkIcon,
@@ -21,13 +19,6 @@ import { usePathname, useRouter } from "next/navigation";
 import { useRef } from "react";
 import { AccountDropdown } from "@/app/(dashboard)/mailboxes/[mailbox_slug]/accountDropdown";
 import { Avatar } from "@/components/ui/avatar";
-import { Button } from "@/components/ui/button";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
 import {
   Sidebar,
   SidebarContent,
@@ -61,9 +52,8 @@ export function AppSidebar({ mailboxSlug }: { mailboxSlug: string }) {
   const pathname = usePathname();
   const router = useRouter();
   const previousAppUrlRef = useRef<string | null>(null);
-  const { data: mailboxes } = api.mailbox.list.useQuery();
   const { data: openCounts } = api.mailbox.openCount.useQuery({ mailboxSlug });
-  const currentMailbox = mailboxes?.find((m) => m.slug === mailboxSlug);
+  const { data: mailbox } = api.mailbox.get.useQuery({ mailboxSlug });
   const isSettingsPage = pathname.startsWith(`/mailboxes/${mailboxSlug}/settings`);
   const { isMobile, setOpenMobile } = useSidebar();
 
@@ -100,38 +90,10 @@ export function AppSidebar({ mailboxSlug }: { mailboxSlug: string }) {
             </SidebarMenuItem>
           </SidebarMenu>
         ) : (
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant="sidebar"
-                size="sm"
-                className="flex items-center gap-2 w-full h-10 px-2 rounded-lg transition-colors hover:bg-sidebar-accent/80 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0"
-              >
-                <Avatar src={undefined} fallback={currentMailbox?.name || ""} size="sm" />
-                <span className="truncate text-base group-data-[collapsible=icon]:hidden">{currentMailbox?.name}</span>
-                <ChevronDown className="ml-auto h-4 w-4 group-data-[collapsible=icon]:hidden" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent side="bottom" align="start" className="min-w-[180px]">
-              {mailboxes?.map((mailbox) => (
-                <DropdownMenuItem
-                  key={mailbox.slug}
-                  onClick={() => {
-                    const currentView = /\/mailboxes\/[^/]+\/([^/]+)/.exec(pathname)?.[1] || "conversations";
-                    router.push(`/mailboxes/${mailbox.slug}/${currentView}`);
-                    handleItemClick();
-                  }}
-                  className="flex items-center gap-2 cursor-pointer"
-                >
-                  <Avatar src={undefined} fallback={mailbox.name} size="sm" />
-                  <span className="truncate text-base">{mailbox.name}</span>
-                  <span className="ml-auto">
-                    {mailbox.slug === currentMailbox?.slug && <CheckCircle className="text-foreground w-4 h-4" />}
-                  </span>
-                </DropdownMenuItem>
-              ))}
-            </DropdownMenuContent>
-          </DropdownMenu>
+          <div className="flex items-center gap-2 w-full h-10 px-2 rounded-lg">
+            <Avatar src={undefined} fallback={mailbox?.name || ""} size="sm" />
+            <span className="truncate text-base group-data-[collapsible=icon]:hidden">{mailbox?.name}</span>
+          </div>
         )}
       </SidebarHeader>
 

--- a/app/(dashboard)/mailboxes/[mailbox_slug]/dashboard/page.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/dashboard/page.tsx
@@ -8,10 +8,10 @@ type PageProps = {
 
 const DashboardPage = async (props: { params: Promise<PageProps> }) => {
   const params = await props.params;
-  const mailboxes = await api.mailbox.list();
-  const currentMailbox = mailboxes.find((m) => m.slug === params.mailbox_slug);
 
-  if (!currentMailbox) {
+  try {
+    await api.mailbox.get({ mailboxSlug: params.mailbox_slug });
+  } catch (_) {
     return redirect("/mailboxes");
   }
 

--- a/app/(dashboard)/mailboxes/[mailbox_slug]/settings/preferences/mailboxNameSetting.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/settings/preferences/mailboxNameSetting.tsx
@@ -19,7 +19,6 @@ const MailboxNameSetting = ({ mailbox }: { mailbox: RouterOutputs["mailbox"]["ge
   const { mutate: update } = api.mailbox.update.useMutation({
     onSuccess: () => {
       utils.mailbox.get.invalidate({ mailboxSlug: mailbox.slug });
-      utils.mailbox.list.invalidate();
       savingIndicator.setState("saved");
     },
     onError: (error) => {

--- a/app/(dashboard)/mailboxes/page.tsx
+++ b/app/(dashboard)/mailboxes/page.tsx
@@ -1,7 +1,6 @@
 import { redirect } from "next/navigation";
 import { captureExceptionAndLog } from "@/lib/shared/sentry";
 import { createClient } from "@/lib/supabase/server";
-import { api } from "@/trpc/server";
 
 const Page = async () => {
   const supabase = await createClient();
@@ -12,11 +11,9 @@ const Page = async () => {
   if (error) captureExceptionAndLog(error);
   if (!user) return redirect("/login");
 
-  const mailboxes = await api.mailbox.list();
-  if (mailboxes.find(({ slug }) => slug === user.user_metadata.lastMailboxSlug))
-    return redirect(`/mailboxes/${user.user_metadata.lastMailboxSlug}/mine`);
-  else if (mailboxes[0]) return redirect(`/mailboxes/${mailboxes[0].slug}/mine`);
-  return redirect("/login");
+  // Since we removed mailbox switching, redirect to the default mailbox
+  const mailboxSlug = user.user_metadata.lastMailboxSlug || "mailbox";
+  return redirect(`/mailboxes/${mailboxSlug}/mine`);
 };
 
 export default Page;

--- a/tests/trpc/router/mailbox.test.ts
+++ b/tests/trpc/router/mailbox.test.ts
@@ -1,5 +1,4 @@
 import { conversationFactory } from "@tests/support/factories/conversations";
-import { mailboxFactory } from "@tests/support/factories/mailboxes";
 import { userFactory } from "@tests/support/factories/users";
 import { createTestTRPCContext } from "@tests/support/trpcUtils";
 import { eq } from "drizzle-orm";
@@ -21,31 +20,6 @@ vi.mock("@/lib/data/user", () => ({
 }));
 
 describe("mailboxRouter", () => {
-  describe("list", () => {
-    it("returns a list of mailboxes for the user's organization", async () => {
-      const { user, mailbox } = await userFactory.createRootUser();
-      const { mailbox: mailbox2 } = await mailboxFactory.create();
-
-      const caller = createCaller(createTestTRPCContext(user));
-
-      const result = await caller.mailbox.list();
-
-      expect(result).toHaveLength(2);
-      expect(result).toEqual([
-        {
-          id: mailbox.id,
-          name: mailbox.name,
-          slug: mailbox.slug,
-        },
-        {
-          id: mailbox2.id,
-          name: mailbox2.name,
-          slug: mailbox2.slug,
-        },
-      ]);
-    });
-  });
-
   describe("update", () => {
     it("updates slack settings", async () => {
       const { user, mailbox } = await userFactory.createRootUser();

--- a/trpc/router/mailbox/index.ts
+++ b/trpc/router/mailbox/index.ts
@@ -1,5 +1,5 @@
 import { TRPCError, type TRPCRouterRecord } from "@trpc/server";
-import { and, count, eq, isNotNull, isNull, sql, SQL } from "drizzle-orm";
+import { and, count, eq, isNotNull, isNull, SQL } from "drizzle-orm";
 import { z } from "zod";
 import { db } from "@/db/client";
 import { conversations, mailboxes } from "@/db/schema";
@@ -7,7 +7,6 @@ import { triggerEvent } from "@/jobs/trigger";
 import { getLatestEvents } from "@/lib/data/dashboardEvent";
 import { getGuideSessionsForMailbox } from "@/lib/data/guide";
 import { getMailboxInfo } from "@/lib/data/mailbox";
-import { protectedProcedure } from "@/trpc/trpc";
 import { conversationsRouter } from "./conversations/index";
 import { customersRouter } from "./customers";
 import { faqsRouter } from "./faqs";
@@ -23,17 +22,6 @@ import { websitesRouter } from "./websites";
 export { mailboxProcedure };
 
 export const mailboxRouter = {
-  list: protectedProcedure.query(async () => {
-    const allMailboxes = await db.query.mailboxes.findMany({
-      where: isNull(sql`${mailboxes.preferences}->>'disabled'`),
-      columns: {
-        id: true,
-        name: true,
-        slug: true,
-      },
-    });
-    return allMailboxes;
-  }),
   openCount: mailboxProcedure.query(async ({ ctx }) => {
     const countOpenStatus = async (where?: SQL) => {
       const result = await db


### PR DESCRIPTION
I implemented the subtask based on my understanding of the feature. If there’s anything you’d like me to adjust or improve, I’d be happy to update it.

#489 for second sub-issue -> Remove the mailbox switcher dropdown and the mailboxes.list procedure

before:
![before-dropdown](https://github.com/user-attachments/assets/57407d9e-21c9-4732-bbcd-19110b46a1e4)



after:
![after-dropdown](https://github.com/user-attachments/assets/eccfad6c-ac16-4c59-8331-3261bcb1f693)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Simplified mailbox sidebar to display only the current mailbox name and avatar without a dropdown or switching option.

* **Refactor**
  * Improved mailbox validation and navigation by directly fetching mailboxes by slug instead of retrieving the full mailbox list.
  * Updated cache invalidation to target only the current mailbox after updates.

* **Bug Fixes**
  * Enhanced error handling and redirection when accessing mailboxes that do not exist.

* **Tests**
  * Removed tests related to listing all mailboxes.

* **Chores**
  * Removed unused code, imports, and the mailbox list query from the backend.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->