### PR TITLE
refactor: replace getMailboxById/getMailboxBySlug with getMailbox

### DIFF
--- a/app/api/connect/github/callback/route.ts
+++ b/app/api/connect/github/callback/route.ts
@@ -3,7 +3,7 @@ import { NextResponse, type NextRequest } from "next/server";
 import { getBaseUrl } from "@/components/constants";
 import { db } from "@/db/client";
 import { mailboxes } from "@/db/schema";
-import { getMailboxBySlug } from "@/lib/data/mailbox";
+import { getMailbox } from "@/lib/data/mailbox";
 import { listRepositories } from "@/lib/github/client";
 import { captureExceptionAndThrowIfDevelopment } from "@/lib/shared/sentry";
 import { createClient } from "@/lib/supabase/server";
@@ -18,7 +18,7 @@ export async function GET(request: NextRequest) {
   if (!user) return NextResponse.redirect(`${getBaseUrl()}/login`);
   if (typeof user.user_metadata.lastMailboxSlug !== "string") return NextResponse.redirect(`${getBaseUrl()}/mailboxes`);
 
-  const mailbox = await getMailboxBySlug(user.user_metadata.lastMailboxSlug);
+  const mailbox = await getMailbox();
   if (!mailbox) return NextResponse.redirect(`${getBaseUrl()}/mailboxes`);
 
   const redirectUrl = new URL(`${getBaseUrl()}/mailboxes/${mailbox.slug}/settings`);

--- a/app/api/connect/slack/callback/route.ts
+++ b/app/api/connect/slack/callback/route.ts
@@ -4,7 +4,7 @@ import { NextResponse, type NextRequest } from "next/server";
 import { getBaseUrl } from "@/components/constants";
 import { db } from "@/db/client";
 import { mailboxes } from "@/db/schema";
-import { getMailboxBySlug } from "@/lib/data/mailbox";
+import { getMailbox } from "@/lib/data/mailbox";
 import { getSlackAccessToken } from "@/lib/slack/client";
 import { createClient } from "@/lib/supabase/server";
 
@@ -25,7 +25,7 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const mailbox = await getMailboxBySlug(state.mailbox_slug);
+    const mailbox = await getMailbox();
     if (!mailbox) {
       return NextResponse.redirect(`${redirectUrl}/integrations?slackConnectResult=error`);
     }

--- a/jobs/autoAssignConversation.ts
+++ b/jobs/autoAssignConversation.ts
@@ -5,7 +5,7 @@ import { conversations } from "@/db/schema/conversations";
 import { runAIObjectQuery } from "@/lib/ai";
 import { cacheFor } from "@/lib/cache";
 import { Conversation, updateConversation } from "@/lib/data/conversation";
-import { getMailboxById, Mailbox } from "@/lib/data/mailbox";
+import { getMailbox, Mailbox } from "@/lib/data/mailbox";
 import { getUsersWithMailboxAccess, UserRoles, type UserWithMailboxAccessData } from "@/lib/data/user";
 import { assertDefinedOrRaiseNonRetriableError } from "./utils";
 
@@ -174,7 +174,7 @@ export const autoAssignConversation = async ({ conversationId }: { conversationI
   if (conversation.assignedToId) return { message: "Skipped: already assigned" };
   if (conversation.mergedIntoId) return { message: "Skipped: conversation is merged" };
 
-  const mailbox = assertDefinedOrRaiseNonRetriableError(await getMailboxById(conversation.mailboxId));
+  const mailbox = assertDefinedOrRaiseNonRetriableError(await getMailbox());
   const teamMembers = assertDefinedOrRaiseNonRetriableError(await getUsersWithMailboxAccess(mailbox.id));
 
   const activeTeamMembers = teamMembers.filter(

--- a/jobs/bulkUpdateConversations.ts
+++ b/jobs/bulkUpdateConversations.ts
@@ -5,7 +5,7 @@ import { conversations } from "@/db/schema";
 import { updateConversation } from "@/lib/data/conversation";
 import { searchConversations } from "@/lib/data/conversation/search";
 import { searchSchema } from "@/lib/data/conversation/searchSchema";
-import { getMailboxById } from "@/lib/data/mailbox";
+import { getMailbox } from "@/lib/data/mailbox";
 import { assertDefinedOrRaiseNonRetriableError } from "./utils";
 
 export const bulkUpdateConversations = async ({
@@ -23,7 +23,7 @@ export const bulkUpdateConversations = async ({
   if (Array.isArray(conversationFilter)) {
     where = inArray(conversations.id, conversationFilter);
   } else {
-    const mailbox = assertDefinedOrRaiseNonRetriableError(await getMailboxById(mailboxId));
+    const mailbox = assertDefinedOrRaiseNonRetriableError(await getMailbox());
     const { where: searchWhere } = await searchConversations(mailbox, conversationFilter, "");
     where = and(...Object.values(searchWhere), ne(conversations.status, status));
   }

--- a/jobs/mergeSimilarConversations.ts
+++ b/jobs/mergeSimilarConversations.ts
@@ -4,7 +4,7 @@ import { db } from "@/db/client";
 import { conversationMessages } from "@/db/schema/conversationMessages";
 import { conversations } from "@/db/schema/conversations";
 import { runAIObjectQuery } from "@/lib/ai";
-import { getMailboxById } from "@/lib/data/mailbox";
+import { getMailbox } from "@/lib/data/mailbox";
 import { assertDefinedOrRaiseNonRetriableError } from "./utils";
 
 export const mergeSimilarConversations = async ({ messageId }: { messageId: number }) => {
@@ -37,7 +37,7 @@ export const mergeSimilarConversations = async ({ messageId }: { messageId: numb
     return { message: "Skipped: not the first message" };
   }
 
-  const mailbox = assertDefinedOrRaiseNonRetriableError(await getMailboxById(conversation.mailboxId));
+  const mailbox = assertDefinedOrRaiseNonRetriableError(await getMailbox());
 
   const otherConversations = await db.query.conversations.findMany({
     where: and(

--- a/jobs/updateSuggestedActions.ts
+++ b/jobs/updateSuggestedActions.ts
@@ -4,12 +4,12 @@ import { db } from "@/db/client";
 import { conversations, tools } from "@/db/schema";
 import { assertDefinedOrRaiseNonRetriableError } from "@/jobs/utils";
 import { getConversationById } from "@/lib/data/conversation";
-import { getMailboxById } from "@/lib/data/mailbox";
+import { getMailbox } from "@/lib/data/mailbox";
 import { generateSuggestedActions } from "@/lib/tools/apiTool";
 
 export const updateSuggestedActions = async ({ conversationId }: { conversationId: number }) => {
   const conversation = assertDefinedOrRaiseNonRetriableError(await getConversationById(conversationId));
-  const mailbox = assertDefinedOrRaiseNonRetriableError(await getMailboxById(conversation.mailboxId));
+  const mailbox = assertDefinedOrRaiseNonRetriableError(await getMailbox());
 
   const mailboxTools = await db.query.tools.findMany({
     where: and(eq(tools.mailboxId, mailbox.id), eq(tools.enabled, true)),

--- a/lib/data/conversation.ts
+++ b/lib/data/conversation.ts
@@ -17,7 +17,7 @@ import { emailKeywordsExtractor } from "../emailKeywordsExtractor";
 import { searchEmailsByKeywords } from "../emailSearchService/searchEmailsByKeywords";
 import { captureExceptionAndLog } from "../shared/sentry";
 import { getMessages } from "./conversationMessage";
-import { getMailboxById } from "./mailbox";
+import { getMailbox } from "./mailbox";
 import { determineVipStatus, getPlatformCustomer } from "./platformCustomer";
 
 type OptionalConversationAttributes = "slug" | "updatedAt" | "createdAt";
@@ -137,7 +137,7 @@ export const updateConversation = async (
   if (updatedConversation && !skipRealtimeEvents) {
     const publishEvents = async () => {
       try {
-        const mailbox = assertDefined(await getMailboxById(updatedConversation.mailboxId));
+        const mailbox = assertDefined(await getMailbox());
         const events = [
           publishToRealtime({
             channel: conversationChannelId(mailbox.slug, updatedConversation.slug),

--- a/lib/data/mailbox.ts
+++ b/lib/data/mailbox.ts
@@ -10,17 +10,8 @@ import { uninstallSlackApp } from "@/lib/slack/client";
 import { REQUIRED_SCOPES, SLACK_REDIRECT_URI } from "@/lib/slack/constants";
 import { captureExceptionAndLogIfDevelopment } from "../shared/sentry";
 
-export const getMailboxById = cache(async (id: number): Promise<Mailbox | null> => {
-  const result = await db.query.mailboxes.findFirst({
-    where: eq(mailboxes.id, id),
-  });
-  return result ?? null;
-});
-
-export const getMailboxBySlug = cache(async (slug: string): Promise<typeof mailboxes.$inferSelect | null> => {
-  const result = await db.query.mailboxes.findFirst({
-    where: eq(mailboxes.slug, slug),
-  });
+export const getMailbox = cache(async (): Promise<Mailbox | null> => {
+  const result = await db.query.mailboxes.findFirst({});
   return result ?? null;
 });
 

--- a/lib/data/mailboxMetadataApi.ts
+++ b/lib/data/mailboxMetadataApi.ts
@@ -4,7 +4,7 @@ import { db } from "@/db/client";
 import { mailboxes, mailboxesMetadataApi } from "@/db/schema";
 import { getMetadata, MetadataAPIError, timestamp } from "../metadataApiClient";
 import { DataError } from "./dataError";
-import { getMailboxBySlug } from "./mailbox";
+import { getMailbox } from "./mailbox";
 
 export const METADATA_API_HMAC_SECRET_PREFIX = "hlpr_";
 
@@ -22,8 +22,8 @@ export const getMetadataApiByMailbox = async (mailbox: typeof mailboxes.$inferSe
   return metadataApi[0] ?? null;
 };
 
-export const getMetadataApiByMailboxSlug = async (mailboxSlug: string) => {
-  const mailbox = await getMailboxBySlug(mailboxSlug);
+export const getMetadataApi = async () => {
+  const mailbox = await getMailbox();
   if (!mailbox) {
     throw new Error("Mailbox not found");
   }
@@ -31,7 +31,7 @@ export const getMetadataApiByMailboxSlug = async (mailboxSlug: string) => {
 };
 
 export const createMailboxMetadataApi = async (mailboxSlug: string, params: { url: string }): Promise<void> => {
-  const { mailbox, metadataApi } = await getMetadataApiByMailboxSlug(mailboxSlug);
+  const { mailbox, metadataApi } = await getMetadataApi();
   if (metadataApi) {
     throw new DataError("Mailbox already has a metadata endpoint");
   }
@@ -50,8 +50,8 @@ export const createMailboxMetadataApi = async (mailboxSlug: string, params: { ur
   });
 };
 
-export const deleteMailboxMetadataApiByMailboxSlug = async (mailboxSlug: string): Promise<void> => {
-  const { metadataApi } = await getMetadataApiByMailboxSlug(mailboxSlug);
+export const deleteMailboxMetadataApi = async (): Promise<void> => {
+  const { metadataApi } = await getMetadataApi();
   if (!metadataApi) {
     throw new DataError("Mailbox does not have a metadata endpoint");
   }
@@ -60,7 +60,7 @@ export const deleteMailboxMetadataApiByMailboxSlug = async (mailboxSlug: string)
 };
 
 export const testMailboxMetadataApiURL = async (mailboxSlug: string) => {
-  const { metadataApi } = await getMetadataApiByMailboxSlug(mailboxSlug);
+  const { metadataApi } = await getMetadataApi();
   if (!metadataApi) {
     throw new DataError("Mailbox does not have a metadata endpoint");
   }

--- a/lib/data/platformCustomer.ts
+++ b/lib/data/platformCustomer.ts
@@ -1,7 +1,7 @@
 import { and, eq } from "drizzle-orm";
 import { db } from "@/db/client";
 import { platformCustomers } from "@/db/schema";
-import { getMailboxById } from "./mailbox";
+import { getMailbox } from "./mailbox";
 
 type CustomerMetadata = {
   name?: string | null;
@@ -23,7 +23,7 @@ export const getPlatformCustomer = async (mailboxId: number, email: string): Pro
     db.query.platformCustomers.findFirst({
       where: and(eq(platformCustomers.email, email), eq(platformCustomers.mailboxId, mailboxId)),
     }),
-    getMailboxById(mailboxId),
+    getMailbox(),
   ]);
 
   if (!customer) return null;
@@ -81,7 +81,7 @@ export const findOrCreatePlatformCustomerByEmail = async (
         mailboxId,
       })
       .returning(),
-    getMailboxById(mailboxId),
+    getMailbox(),
   ]);
 
   const customer = result[0];

--- a/trpc/router/mailbox/procedure.ts
+++ b/trpc/router/mailbox/procedure.ts
@@ -1,13 +1,11 @@
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
-import { getMailboxBySlug } from "@/lib/data/mailbox";
+import { getMailbox } from "@/lib/data/mailbox";
 import { protectedProcedure } from "@/trpc/trpc";
 
-export const mailboxProcedure = protectedProcedure
-  .input(z.object({ mailboxSlug: z.string() }))
-  .use(async ({ ctx, input, next }) => {
-    const mailbox = await getMailboxBySlug(input.mailboxSlug);
-    if (!mailbox) throw new TRPCError({ code: "NOT_FOUND" });
+export const mailboxProcedure = protectedProcedure.use(async ({ ctx, next }) => {
+  const mailbox = await getMailbox();
+  if (!mailbox) throw new TRPCError({ code: "NOT_FOUND" });
 
-    return next({ ctx: { ...ctx, mailbox } });
-  });
+  return next({ ctx: { ...ctx, mailbox } });
+});


### PR DESCRIPTION
### Summary:

Replace getMailboxById and getMailboxBySlug with a getMailbox function that just returns the first mailbox

Fixes #489 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified mailbox retrieval throughout the app to use a single method, removing the need to specify mailbox IDs or slugs.
  * Updated related procedures and API endpoints to operate without requiring mailbox identifiers as input.
  * Streamlined mailbox metadata API management to work with a single mailbox context.
  * No changes to user-facing features or workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->