### PR TITLE
fix: make the saved reply form scrollable

### DIFF
--- a/app/(dashboard)/mailboxes/[mailbox_slug]/saved-replies/savedReplyForm.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/saved-replies/savedReplyForm.tsx
@@ -167,7 +167,7 @@ export function SavedReplyForm({ savedReply, mailboxSlug, onSuccess, onCancel, o
               <FormControl>
                 <TipTapEditor
                   ref={editorRef}
-                  className="min-h-48"
+                  className="min-h-48 max-h-96"
                   ariaLabel="Saved reply content editor"
                   placeholder="Enter your saved reply content here..."
                   defaultContent={initialContentObject}


### PR DESCRIPTION
This PR fixes an issue where the textarea in the saved reply form (both create and update) would overflow when too many lines were entered, by making it scrollable instead.

Before:

<img width="1512" alt="before" src="https://github.com/user-attachments/assets/a431aadd-4403-4829-984f-e7b1199d2020" />

After:

<img width="1510" alt="after" src="https://github.com/user-attachments/assets/d62f511d-2a92-45a6-a5ea-61270d69f554" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added a maximum height limit to the editor to prevent it from expanding too much while keeping a minimum height.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->