### PR TITLE
fix (conversations): prevent closed conv from appearing in open status filter

### DIFF
--- a/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/shared/queries.ts
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/shared/queries.ts
@@ -23,7 +23,7 @@ export const useConversationsListInput = () => {
 
   const input = {
     mailboxSlug: params.mailbox_slug,
-    status: searchParams.status ? [searchParams.status] : null,
+    status: searchParams.status ? [searchParams.status] : ["open"],
     sort: searchParams.sort,
     category: params.category,
     search: searchParams.search ?? null,


### PR DESCRIPTION
Closed conversations were appearing in the conversation list when the status filter was set to "open". This PR ensures that only conversations matching the selected status are displayed.

This fix was originally part of a feature PR #628 which wasn't merged, but the bug is important enough to address separately IMO.

Before:

https://github.com/user-attachments/assets/7cf53f66-f115-4a10-aca0-d002202c7fc6

After:

https://github.com/user-attachments/assets/a968045e-6da2-4ce7-9f6c-a59ed83be3e6


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default status filter for conversations to show only "open" conversations when no specific status is selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->