### PR TITLE
Remove mailbox switcher dropdown and mailboxes.list procedure

### DIFF
--- a/app/(dashboard)/mailboxes/[mailbox_slug]/appSidebar.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/appSidebar.tsx
@@ -3,8 +3,6 @@
 import {
   BarChart,
   BookOpen,
-  CheckCircle,
-  ChevronDown,
   ChevronLeft,
   Inbox,
   Link as LinkIcon,
@@ -21,13 +19,6 @@ import { usePathname, useRouter } from "next/navigation";
 import { useRef } from "react";
 import { AccountDropdown } from "@/app/(dashboard)/mailboxes/[mailbox_slug]/accountDropdown";
 import { Avatar } from "@/components/ui/avatar";
-import { Button } from "@/components/ui/button";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
 import {
   Sidebar,
   SidebarContent,
@@ -61,9 +52,8 @@ export function AppSidebar({ mailboxSlug }: { mailboxSlug: string }) {
   const pathname = usePathname();
   const router = useRouter();
   const previousAppUrlRef = useRef<string | null>(null);
-  const { data: mailboxes } = api.mailbox.list.useQuery();
   const { data: openCounts } = api.mailbox.openCount.useQuery({ mailboxSlug });
-  const currentMailbox = mailboxes?.find((m) => m.slug === mailboxSlug);
+  const { data: mailbox } = api.mailbox.get.useQuery({ mailboxSlug });
   const isSettingsPage = pathname.startsWith(`/mailboxes/${mailboxSlug}/settings`);
   const { isMobile, setOpenMobile } = useSidebar();
 
@@ -100,38 +90,10 @@ export function AppSidebar({ mailboxSlug }: { mailboxSlug: string }) {
             </SidebarMenuItem>
           </SidebarMenu>
         ) : (
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant="sidebar"
-                size="sm"
-                className="flex items-center gap-2 w-full h-10 px-2 rounded-lg transition-colors hover:bg-sidebar-accent/80 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0"
-              >
-                <Avatar src={undefined} fallback={currentMailbox?.name || ""} size="sm" />
-                <span className="truncate text-base group-data-[collapsible=icon]:hidden">{currentMailbox?.name}</span>
-                <ChevronDown className="ml-auto h-4 w-4 group-data-[collapsible=icon]:hidden" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent side="bottom" align="start" className="min-w-[180px]">
-              {mailboxes?.map((mailbox) => (
-                <DropdownMenuItem
-                  key={mailbox.slug}
-                  onClick={() => {
-                    const currentView = /\/mailboxes\/[^/]+\/([^/]+)/.exec(pathname)?.[1] || "conversations";
-                    router.push(`/mailboxes/${mailbox.slug}/${currentView}`);
-                    handleItemClick();
-                  }}
-                  className="flex items-center gap-2 cursor-pointer"
-                >
-                  <Avatar src={undefined} fallback={mailbox.name} size="sm" />
-                  <span className="truncate text-base">{mailbox.name}</span>
-                  <span className="ml-auto">
-                    {mailbox.slug === currentMailbox?.slug && <CheckCircle className="text-foreground w-4 h-4" />}
-                  </span>
-                </DropdownMenuItem>
-              ))}
-            </DropdownMenuContent>
-          </DropdownMenu>
+          <div className="flex items-center gap-2 w-full h-10 px-2 rounded-lg">
+            <Avatar src={undefined} fallback={mailbox?.name || "G"} size="sm" />
+            <span className="truncate text-base group-data-[collapsible=icon]:hidden">{mailbox?.name}</span>
+          </div>
         )}
       </SidebarHeader>
 

--- a/app/(dashboard)/mailboxes/[mailbox_slug]/dashboard/page.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/dashboard/page.tsx
@@ -8,10 +8,10 @@ type PageProps = {
 
 const DashboardPage = async (props: { params: Promise<PageProps> }) => {
   const params = await props.params;
-  const mailboxes = await api.mailbox.list();
-  const currentMailbox = mailboxes.find((m) => m.slug === params.mailbox_slug);
 
-  if (!currentMailbox) {
+  try {
+    await api.mailbox.get({ mailboxSlug: params.mailbox_slug });
+  } catch (_) {
     return redirect("/mailboxes");
   }
 

--- a/app/(dashboard)/mailboxes/[mailbox_slug]/settings/preferences/mailboxNameSetting.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/settings/preferences/mailboxNameSetting.tsx
@@ -19,7 +19,6 @@ const MailboxNameSetting = ({ mailbox }: { mailbox: RouterOutputs["mailbox"]["ge
   const { mutate: update } = api.mailbox.update.useMutation({
     onSuccess: () => {
       utils.mailbox.get.invalidate({ mailboxSlug: mailbox.slug });
-      utils.mailbox.list.invalidate();
       savingIndicator.setState("saved");
     },
     onError: (error) => {

--- a/app/(dashboard)/mailboxes/page.tsx
+++ b/app/(dashboard)/mailboxes/page.tsx
@@ -1,7 +1,7 @@
 import { redirect } from "next/navigation";
+import { getAllMailboxes } from "@/lib/data/mailbox";
 import { captureExceptionAndLog } from "@/lib/shared/sentry";
 import { createClient } from "@/lib/supabase/server";
-import { api } from "@/trpc/server";
 
 const Page = async () => {
   const supabase = await createClient();
@@ -12,21 +12,9 @@ const Page = async () => {
   if (error) captureExceptionAndLog(error);
   if (!user) return redirect("/login");
 
-  const lastMailboxSlug = user.user_metadata.lastMailboxSlug;
-  if (lastMailboxSlug) {
-    try {
-      await api.mailbox.get({ mailboxSlug: lastMailboxSlug });
-      return redirect(`/mailboxes/${lastMailboxSlug}/mine`);
-    } catch (error) {
-      captureExceptionAndLog(error);
-    }
-  }
-
-  try {
-    await api.mailbox.get({ mailboxSlug: "helper" });
-    return redirect(`/mailboxes/helper/mine`);
-  } catch (error) {
-    captureExceptionAndLog(error);
+  const mailboxes = await getAllMailboxes();
+  if (mailboxes.length > 0) {
+    return redirect(`/mailboxes/${mailboxes[0]?.slug}/mine`);
   }
 
   return redirect("/login");

--- a/app/(dashboard)/mailboxes/page.tsx
+++ b/app/(dashboard)/mailboxes/page.tsx
@@ -12,10 +12,23 @@ const Page = async () => {
   if (error) captureExceptionAndLog(error);
   if (!user) return redirect("/login");
 
-  const mailboxes = await api.mailbox.list();
-  if (mailboxes.find(({ slug }) => slug === user.user_metadata.lastMailboxSlug))
-    return redirect(`/mailboxes/${user.user_metadata.lastMailboxSlug}/mine`);
-  else if (mailboxes[0]) return redirect(`/mailboxes/${mailboxes[0].slug}/mine`);
+  const lastMailboxSlug = user.user_metadata.lastMailboxSlug;
+  if (lastMailboxSlug) {
+    try {
+      await api.mailbox.get({ mailboxSlug: lastMailboxSlug });
+      return redirect(`/mailboxes/${lastMailboxSlug}/mine`);
+    } catch (error) {
+      captureExceptionAndLog(error);
+    }
+  }
+
+  try {
+    await api.mailbox.get({ mailboxSlug: "helper" });
+    return redirect(`/mailboxes/helper/mine`);
+  } catch (error) {
+    captureExceptionAndLog(error);
+  }
+
   return redirect("/login");
 };
 

--- a/lib/data/mailbox.ts
+++ b/lib/data/mailbox.ts
@@ -1,5 +1,5 @@
 import "server-only";
-import { and, eq, isNull } from "drizzle-orm";
+import { and, eq, isNull, sql } from "drizzle-orm";
 import { cache } from "react";
 import { assertDefined } from "@/components/utils/assert";
 import { db, Transaction } from "@/db/client";
@@ -136,6 +136,8 @@ export const updateGitHubRepo = async (mailboxId: number, repoOwner: string, rep
     .where(eq(mailboxes.id, mailboxId));
 };
 
-export const getAllMailboxes = async () => {
-  return db.query.mailboxes.findMany();
-};
+export const getAllMailboxes = cache(async (): Promise<Mailbox[]> => {
+  return await db.query.mailboxes.findMany({
+    where: isNull(sql`${mailboxes.preferences}->>'disabled'`),
+  });
+});

--- a/lib/data/mailbox.ts
+++ b/lib/data/mailbox.ts
@@ -135,3 +135,7 @@ export const updateGitHubRepo = async (mailboxId: number, repoOwner: string, rep
     })
     .where(eq(mailboxes.id, mailboxId));
 };
+
+export const getAllMailboxes = async () => {
+  return db.query.mailboxes.findMany();
+};

--- a/tests/trpc/router/mailbox.test.ts
+++ b/tests/trpc/router/mailbox.test.ts
@@ -1,5 +1,4 @@
 import { conversationFactory } from "@tests/support/factories/conversations";
-import { mailboxFactory } from "@tests/support/factories/mailboxes";
 import { userFactory } from "@tests/support/factories/users";
 import { createTestTRPCContext } from "@tests/support/trpcUtils";
 import { eq } from "drizzle-orm";

--- a/tests/trpc/router/mailbox.test.ts
+++ b/tests/trpc/router/mailbox.test.ts
@@ -22,31 +22,6 @@ vi.mock("@/lib/data/user", () => ({
 }));
 
 describe("mailboxRouter", () => {
-  describe("list", () => {
-    it("returns a list of mailboxes for the user's organization", async () => {
-      const { user, mailbox } = await userFactory.createRootUser();
-      const { mailbox: mailbox2 } = await mailboxFactory.create();
-
-      const caller = createCaller(createTestTRPCContext(user));
-
-      const result = await caller.mailbox.list();
-
-      expect(result).toHaveLength(2);
-      expect(result).toEqual([
-        {
-          id: mailbox.id,
-          name: mailbox.name,
-          slug: mailbox.slug,
-        },
-        {
-          id: mailbox2.id,
-          name: mailbox2.name,
-          slug: mailbox2.slug,
-        },
-      ]);
-    });
-  });
-
   describe("update", () => {
     it("updates slack settings", async () => {
       const { user, mailbox } = await userFactory.createRootUser();

--- a/trpc/router/mailbox/index.ts
+++ b/trpc/router/mailbox/index.ts
@@ -1,5 +1,5 @@
 import { TRPCError, type TRPCRouterRecord } from "@trpc/server";
-import { and, count, eq, isNotNull, isNull, sql, SQL } from "drizzle-orm";
+import { and, count, eq, isNotNull, isNull, SQL } from "drizzle-orm";
 import { z } from "zod";
 import { db } from "@/db/client";
 import { conversations, mailboxes } from "@/db/schema";
@@ -7,7 +7,6 @@ import { triggerEvent } from "@/jobs/trigger";
 import { getLatestEvents } from "@/lib/data/dashboardEvent";
 import { getGuideSessionsForMailbox } from "@/lib/data/guide";
 import { getMailboxInfo } from "@/lib/data/mailbox";
-import { protectedProcedure } from "@/trpc/trpc";
 import { conversationsRouter } from "./conversations/index";
 import { customersRouter } from "./customers";
 import { faqsRouter } from "./faqs";
@@ -23,17 +22,6 @@ import { websitesRouter } from "./websites";
 export { mailboxProcedure };
 
 export const mailboxRouter = {
-  list: protectedProcedure.query(async () => {
-    const allMailboxes = await db.query.mailboxes.findMany({
-      where: isNull(sql`${mailboxes.preferences}->>'disabled'`),
-      columns: {
-        id: true,
-        name: true,
-        slug: true,
-      },
-    });
-    return allMailboxes;
-  }),
   openCount: mailboxProcedure.query(async ({ ctx }) => {
     const countOpenStatus = async (where?: SQL) => {
       const result = await db


### PR DESCRIPTION


- Removed the mailbox switcher dropdown from the sidebar UI
- Deleted the mailboxes.list TRPC procedure and all its usages
- Updated default/fallback mailbox logic to use the "helper" slug
- Cleaned up related tests and code

This is part of the second sub-part of this issue: Ref: #489 

before:
![image](https://github.com/user-attachments/assets/6cb1100b-4ed6-4868-b275-7f8b95bf70e8)


after:

![image](https://github.com/user-attachments/assets/ad0a4456-2181-49b9-8719-c9fd0f9d702f)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified mailbox data fetching by removing the mailbox list query and dropdown menu for switching mailboxes in the sidebar.
  * Updated dashboard and mailbox page logic to fetch only the relevant mailbox directly, improving error handling and redirection.
  * Adjusted cache invalidation to target only the current mailbox after updates.
  * Modified mailbox page redirection to always use the first mailbox if available, or redirect to login if none exist.
  * Introduced a new method to retrieve all mailboxes for streamlined data access.

* **Tests**
  * Removed tests related to listing all mailboxes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->