### PR TITLE
refactor: replace getMailboxById/getMailboxBySlug with getMailbox

### DIFF
--- a/app/api/connect/github/callback/route.ts
+++ b/app/api/connect/github/callback/route.ts
@@ -3,7 +3,7 @@ import { NextResponse, type NextRequest } from "next/server";
 import { getBaseUrl } from "@/components/constants";
 import { db } from "@/db/client";
 import { mailboxes } from "@/db/schema";
-import { getMailboxBySlug } from "@/lib/data/mailbox";
+import { getMailbox } from "@/lib/data/mailbox";
 import { listRepositories } from "@/lib/github/client";
 import { captureExceptionAndThrowIfDevelopment } from "@/lib/shared/sentry";
 import { createClient } from "@/lib/supabase/server";
@@ -16,9 +16,8 @@ export async function GET(request: NextRequest) {
     data: { user },
   } = await supabase.auth.getUser();
   if (!user) return NextResponse.redirect(`${getBaseUrl()}/login`);
-  if (typeof user.user_metadata.lastMailboxSlug !== "string") return NextResponse.redirect(`${getBaseUrl()}/mailboxes`);
 
-  const mailbox = await getMailboxBySlug(user.user_metadata.lastMailboxSlug);
+  const mailbox = await getMailbox();
   if (!mailbox) return NextResponse.redirect(`${getBaseUrl()}/mailboxes`);
 
   const redirectUrl = new URL(`${getBaseUrl()}/mailboxes/${mailbox.slug}/settings`);

--- a/app/api/connect/slack/callback/route.ts
+++ b/app/api/connect/slack/callback/route.ts
@@ -5,9 +5,7 @@ import { getBaseUrl } from "@/components/constants";
 import { db } from "@/db/client";
 import { mailboxes } from "@/db/schema";
 import { getMailbox } from "@/lib/data/mailbox";
-import { captureExceptionAndLog } from "@/lib/shared/sentry";
 import { getSlackAccessToken } from "@/lib/slack/client";
-import { SLACK_REDIRECT_URI } from "@/lib/slack/constants";
 import { createClient } from "@/lib/supabase/server";
 
 export async function GET(request: NextRequest) {

--- a/app/api/connect/slack/callback/route.ts
+++ b/app/api/connect/slack/callback/route.ts
@@ -4,31 +4,36 @@ import { NextResponse, type NextRequest } from "next/server";
 import { getBaseUrl } from "@/components/constants";
 import { db } from "@/db/client";
 import { mailboxes } from "@/db/schema";
-import { getMailboxBySlug } from "@/lib/data/mailbox";
+import { getMailbox } from "@/lib/data/mailbox";
+import { captureExceptionAndLog } from "@/lib/shared/sentry";
 import { getSlackAccessToken } from "@/lib/slack/client";
+import { SLACK_REDIRECT_URI } from "@/lib/slack/constants";
 import { createClient } from "@/lib/supabase/server";
 
 export async function GET(request: NextRequest) {
-  const state = JSON.parse(request.nextUrl.searchParams.get("state") || "{}");
-  const code = request.nextUrl.searchParams.get("code");
-  const redirectUrl = new URL(`${getBaseUrl()}/mailboxes/${state.mailbox_slug}/settings`);
-
-  if (!code) {
-    return NextResponse.redirect(`${redirectUrl}/integrations?slackConnectResult=error`);
-  }
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) {
-    return NextResponse.redirect(`${redirectUrl}/integrations?slackConnectResult=error`);
-  }
-
   try {
-    const mailbox = await getMailboxBySlug(state.mailbox_slug);
-    if (!mailbox) {
-      return NextResponse.redirect(`${redirectUrl}/integrations?slackConnectResult=error`);
+    const supabase = await createClient();
+    const {
+      data: { user },
+      error,
+    } = await supabase.auth.getUser();
+    if (error) throw error;
+    if (!user) return NextResponse.redirect(new URL("/login", request.url));
+
+    const searchParams = request.nextUrl.searchParams;
+    const code = searchParams.get("code");
+
+    if (!code) {
+      return NextResponse.redirect(new URL("/mailboxes", request.url));
     }
+
+    const mailbox = await getMailbox();
+    if (!mailbox) {
+      return NextResponse.redirect(new URL("/mailboxes", request.url));
+    }
+
+    const redirectUrl = new URL(`${getBaseUrl()}/mailboxes/${mailbox.slug}/settings`);
+
     const { teamId, botUserId, accessToken } = await getSlackAccessToken(code);
 
     if (!teamId) throw new Error("Slack team ID not found in response");
@@ -45,6 +50,6 @@ export async function GET(request: NextRequest) {
     return NextResponse.redirect(`${redirectUrl}/integrations?slackConnectResult=success`);
   } catch (error) {
     Sentry.captureException(error);
-    return NextResponse.redirect(`${redirectUrl}/integrations?slackConnectResult=error`);
+    return NextResponse.redirect(`${getBaseUrl()}/mailboxes?slackConnectResult=error`);
   }
 }

--- a/jobs/autoAssignConversation.ts
+++ b/jobs/autoAssignConversation.ts
@@ -157,7 +157,17 @@ const getNextTeamMember = async (
 
 export const autoAssignConversation = async ({ conversationId }: { conversationId: number }) => {
   const conversation = assertDefinedOrRaiseNonRetriableError(
-    await db.query.conversations.findFirst({ where: eq(conversations.id, conversationId), with: { messages: true } }),
+    await db.query.conversations.findFirst({
+      where: eq(conversations.id, conversationId),
+      with: {
+        messages: {
+          columns: {
+            role: true,
+            cleanedUpText: true,
+          },
+        },
+      },
+    }),
   );
 
   if (conversation.assignedToId) {

--- a/jobs/autoAssignConversation.ts
+++ b/jobs/autoAssignConversation.ts
@@ -1,11 +1,11 @@
-import { eq } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 import { z } from "zod";
 import { db } from "@/db/client";
 import { conversations } from "@/db/schema/conversations";
 import { runAIObjectQuery } from "@/lib/ai";
 import { cacheFor } from "@/lib/cache";
 import { Conversation, updateConversation } from "@/lib/data/conversation";
-import { getMailboxById, Mailbox } from "@/lib/data/mailbox";
+import { getMailbox, Mailbox } from "@/lib/data/mailbox";
 import { getUsersWithMailboxAccess, UserRoles, type UserWithMailboxAccessData } from "@/lib/data/user";
 import { assertDefinedOrRaiseNonRetriableError } from "./utils";
 
@@ -157,24 +157,14 @@ const getNextTeamMember = async (
 
 export const autoAssignConversation = async ({ conversationId }: { conversationId: number }) => {
   const conversation = assertDefinedOrRaiseNonRetriableError(
-    await db.query.conversations.findFirst({
-      where: eq(conversations.id, conversationId),
-      with: {
-        messages: {
-          columns: {
-            id: true,
-            role: true,
-            cleanedUpText: true,
-          },
-        },
-      },
-    }),
+    await db.query.conversations.findFirst({ where: eq(conversations.id, conversationId) }),
   );
 
-  if (conversation.assignedToId) return { message: "Skipped: already assigned" };
-  if (conversation.mergedIntoId) return { message: "Skipped: conversation is merged" };
+  if (conversation.assignedToId) {
+    return { message: "Conversation is already assigned" };
+  }
 
-  const mailbox = assertDefinedOrRaiseNonRetriableError(await getMailboxById(conversation.mailboxId));
+  const mailbox = assertDefinedOrRaiseNonRetriableError(await getMailbox());
   const teamMembers = assertDefinedOrRaiseNonRetriableError(await getUsersWithMailboxAccess(mailbox.id));
 
   const activeTeamMembers = teamMembers.filter(

--- a/jobs/autoAssignConversation.ts
+++ b/jobs/autoAssignConversation.ts
@@ -1,4 +1,4 @@
-import { and, eq, isNull } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { z } from "zod";
 import { db } from "@/db/client";
 import { conversations } from "@/db/schema/conversations";
@@ -157,7 +157,7 @@ const getNextTeamMember = async (
 
 export const autoAssignConversation = async ({ conversationId }: { conversationId: number }) => {
   const conversation = assertDefinedOrRaiseNonRetriableError(
-    await db.query.conversations.findFirst({ where: eq(conversations.id, conversationId) }),
+    await db.query.conversations.findFirst({ where: eq(conversations.id, conversationId), with: { messages: true } }),
   );
 
   if (conversation.assignedToId) {

--- a/jobs/bulkUpdateConversations.ts
+++ b/jobs/bulkUpdateConversations.ts
@@ -5,7 +5,7 @@ import { conversations } from "@/db/schema";
 import { updateConversation } from "@/lib/data/conversation";
 import { searchConversations } from "@/lib/data/conversation/search";
 import { searchSchema } from "@/lib/data/conversation/searchSchema";
-import { getMailboxById } from "@/lib/data/mailbox";
+import { getMailbox } from "@/lib/data/mailbox";
 import { assertDefinedOrRaiseNonRetriableError } from "./utils";
 
 export const bulkUpdateConversations = async ({
@@ -19,11 +19,12 @@ export const bulkUpdateConversations = async ({
   userId: string;
   mailboxId: number;
 }) => {
+  const mailbox = assertDefinedOrRaiseNonRetriableError(await getMailbox());
+
   let where;
   if (Array.isArray(conversationFilter)) {
     where = inArray(conversations.id, conversationFilter);
   } else {
-    const mailbox = assertDefinedOrRaiseNonRetriableError(await getMailboxById(mailboxId));
     const { where: searchWhere } = await searchConversations(mailbox, conversationFilter, "");
     where = and(...Object.values(searchWhere), ne(conversations.status, status));
   }

--- a/jobs/bulkUpdateConversations.ts
+++ b/jobs/bulkUpdateConversations.ts
@@ -12,12 +12,10 @@ export const bulkUpdateConversations = async ({
   conversationFilter,
   status,
   userId,
-  mailboxId,
 }: {
   conversationFilter: number[] | z.infer<typeof searchSchema>;
   status: "open" | "closed" | "spam";
   userId: string;
-  mailboxId: number;
 }) => {
   const mailbox = assertDefinedOrRaiseNonRetriableError(await getMailbox());
 

--- a/jobs/mergeSimilarConversations.ts
+++ b/jobs/mergeSimilarConversations.ts
@@ -4,7 +4,7 @@ import { db } from "@/db/client";
 import { conversationMessages } from "@/db/schema/conversationMessages";
 import { conversations } from "@/db/schema/conversations";
 import { runAIObjectQuery } from "@/lib/ai";
-import { getMailboxById } from "@/lib/data/mailbox";
+import { getMailbox } from "@/lib/data/mailbox";
 import { assertDefinedOrRaiseNonRetriableError } from "./utils";
 
 export const mergeSimilarConversations = async ({ messageId }: { messageId: number }) => {
@@ -37,7 +37,7 @@ export const mergeSimilarConversations = async ({ messageId }: { messageId: numb
     return { message: "Skipped: not the first message" };
   }
 
-  const mailbox = assertDefinedOrRaiseNonRetriableError(await getMailboxById(conversation.mailboxId));
+  const mailbox = assertDefinedOrRaiseNonRetriableError(await getMailbox());
 
   const otherConversations = await db.query.conversations.findMany({
     where: and(

--- a/jobs/updateSuggestedActions.ts
+++ b/jobs/updateSuggestedActions.ts
@@ -4,12 +4,12 @@ import { db } from "@/db/client";
 import { conversations, tools } from "@/db/schema";
 import { assertDefinedOrRaiseNonRetriableError } from "@/jobs/utils";
 import { getConversationById } from "@/lib/data/conversation";
-import { getMailboxById } from "@/lib/data/mailbox";
+import { getMailbox } from "@/lib/data/mailbox";
 import { generateSuggestedActions } from "@/lib/tools/apiTool";
 
 export const updateSuggestedActions = async ({ conversationId }: { conversationId: number }) => {
   const conversation = assertDefinedOrRaiseNonRetriableError(await getConversationById(conversationId));
-  const mailbox = assertDefinedOrRaiseNonRetriableError(await getMailboxById(conversation.mailboxId));
+  const mailbox = assertDefinedOrRaiseNonRetriableError(await getMailbox());
 
   const mailboxTools = await db.query.tools.findMany({
     where: and(eq(tools.mailboxId, mailbox.id), eq(tools.enabled, true)),

--- a/lib/data/conversation.ts
+++ b/lib/data/conversation.ts
@@ -17,7 +17,7 @@ import { emailKeywordsExtractor } from "../emailKeywordsExtractor";
 import { searchEmailsByKeywords } from "../emailSearchService/searchEmailsByKeywords";
 import { captureExceptionAndLog } from "../shared/sentry";
 import { getMessages } from "./conversationMessage";
-import { getMailboxById } from "./mailbox";
+import { getMailbox } from "./mailbox";
 import { determineVipStatus, getPlatformCustomer } from "./platformCustomer";
 
 type OptionalConversationAttributes = "slug" | "updatedAt" | "createdAt";
@@ -137,7 +137,7 @@ export const updateConversation = async (
   if (updatedConversation && !skipRealtimeEvents) {
     const publishEvents = async () => {
       try {
-        const mailbox = assertDefined(await getMailboxById(updatedConversation.mailboxId));
+        const mailbox = assertDefined(await getMailbox());
         const events = [
           publishToRealtime({
             channel: conversationChannelId(mailbox.slug, updatedConversation.slug),

--- a/lib/data/mailbox.ts
+++ b/lib/data/mailbox.ts
@@ -10,16 +10,9 @@ import { uninstallSlackApp } from "@/lib/slack/client";
 import { REQUIRED_SCOPES, SLACK_REDIRECT_URI } from "@/lib/slack/constants";
 import { captureExceptionAndLogIfDevelopment } from "../shared/sentry";
 
-export const getMailboxById = cache(async (id: number): Promise<Mailbox | null> => {
+export const getMailbox = cache(async (): Promise<typeof mailboxes.$inferSelect | null> => {
   const result = await db.query.mailboxes.findFirst({
-    where: eq(mailboxes.id, id),
-  });
-  return result ?? null;
-});
-
-export const getMailboxBySlug = cache(async (slug: string): Promise<typeof mailboxes.$inferSelect | null> => {
-  const result = await db.query.mailboxes.findFirst({
-    where: eq(mailboxes.slug, slug),
+    where: isNull(sql`${mailboxes.preferences}->>'disabled'`),
   });
   return result ?? null;
 });

--- a/lib/data/mailboxMetadataApi.ts
+++ b/lib/data/mailboxMetadataApi.ts
@@ -30,7 +30,7 @@ export const getMetadataApi = async () => {
   return { mailbox, metadataApi: await getMetadataApiByMailbox(mailbox) };
 };
 
-export const createMailboxMetadataApi = async (mailboxSlug: string, params: { url: string }): Promise<void> => {
+export const createMailboxMetadataApi = async (params: { url: string }): Promise<void> => {
   const { mailbox, metadataApi } = await getMetadataApi();
   if (metadataApi) {
     throw new DataError("Mailbox already has a metadata endpoint");
@@ -50,7 +50,7 @@ export const createMailboxMetadataApi = async (mailboxSlug: string, params: { ur
   });
 };
 
-export const deleteMailboxMetadataApiByMailboxSlug = async (mailboxSlug: string): Promise<void> => {
+export const deleteMailboxMetadataApi = async (): Promise<void> => {
   const { metadataApi } = await getMetadataApi();
   if (!metadataApi) {
     throw new DataError("Mailbox does not have a metadata endpoint");
@@ -59,7 +59,7 @@ export const deleteMailboxMetadataApiByMailboxSlug = async (mailboxSlug: string)
   await db.delete(mailboxesMetadataApi).where(eq(mailboxesMetadataApi.id, metadataApi.id));
 };
 
-export const testMailboxMetadataApiURL = async (mailboxSlug: string) => {
+export const testMailboxMetadataApiURL = async () => {
   const { metadataApi } = await getMetadataApi();
   if (!metadataApi) {
     throw new DataError("Mailbox does not have a metadata endpoint");

--- a/lib/data/mailboxMetadataApi.ts
+++ b/lib/data/mailboxMetadataApi.ts
@@ -4,7 +4,7 @@ import { db } from "@/db/client";
 import { mailboxes, mailboxesMetadataApi } from "@/db/schema";
 import { getMetadata, MetadataAPIError, timestamp } from "../metadataApiClient";
 import { DataError } from "./dataError";
-import { getMailboxBySlug } from "./mailbox";
+import { getMailbox } from "./mailbox";
 
 export const METADATA_API_HMAC_SECRET_PREFIX = "hlpr_";
 
@@ -23,7 +23,7 @@ export const getMetadataApiByMailbox = async (mailbox: typeof mailboxes.$inferSe
 };
 
 export const getMetadataApiByMailboxSlug = async (mailboxSlug: string) => {
-  const mailbox = await getMailboxBySlug(mailboxSlug);
+  const mailbox = await getMailbox();
   if (!mailbox) {
     throw new Error("Mailbox not found");
   }

--- a/lib/data/mailboxMetadataApi.ts
+++ b/lib/data/mailboxMetadataApi.ts
@@ -22,7 +22,7 @@ export const getMetadataApiByMailbox = async (mailbox: typeof mailboxes.$inferSe
   return metadataApi[0] ?? null;
 };
 
-export const getMetadataApiByMailboxSlug = async (mailboxSlug: string) => {
+export const getMetadataApi = async () => {
   const mailbox = await getMailbox();
   if (!mailbox) {
     throw new Error("Mailbox not found");
@@ -31,7 +31,7 @@ export const getMetadataApiByMailboxSlug = async (mailboxSlug: string) => {
 };
 
 export const createMailboxMetadataApi = async (mailboxSlug: string, params: { url: string }): Promise<void> => {
-  const { mailbox, metadataApi } = await getMetadataApiByMailboxSlug(mailboxSlug);
+  const { mailbox, metadataApi } = await getMetadataApi();
   if (metadataApi) {
     throw new DataError("Mailbox already has a metadata endpoint");
   }
@@ -51,7 +51,7 @@ export const createMailboxMetadataApi = async (mailboxSlug: string, params: { ur
 };
 
 export const deleteMailboxMetadataApiByMailboxSlug = async (mailboxSlug: string): Promise<void> => {
-  const { metadataApi } = await getMetadataApiByMailboxSlug(mailboxSlug);
+  const { metadataApi } = await getMetadataApi();
   if (!metadataApi) {
     throw new DataError("Mailbox does not have a metadata endpoint");
   }
@@ -60,7 +60,7 @@ export const deleteMailboxMetadataApiByMailboxSlug = async (mailboxSlug: string)
 };
 
 export const testMailboxMetadataApiURL = async (mailboxSlug: string) => {
-  const { metadataApi } = await getMetadataApiByMailboxSlug(mailboxSlug);
+  const { metadataApi } = await getMetadataApi();
   if (!metadataApi) {
     throw new DataError("Mailbox does not have a metadata endpoint");
   }

--- a/lib/data/platformCustomer.ts
+++ b/lib/data/platformCustomer.ts
@@ -1,7 +1,7 @@
 import { and, eq } from "drizzle-orm";
 import { db } from "@/db/client";
 import { platformCustomers } from "@/db/schema";
-import { getMailboxById } from "./mailbox";
+import { getMailbox } from "./mailbox";
 
 type CustomerMetadata = {
   name?: string | null;
@@ -23,7 +23,7 @@ export const getPlatformCustomer = async (mailboxId: number, email: string): Pro
     db.query.platformCustomers.findFirst({
       where: and(eq(platformCustomers.email, email), eq(platformCustomers.mailboxId, mailboxId)),
     }),
-    getMailboxById(mailboxId),
+    getMailbox(),
   ]);
 
   if (!customer) return null;
@@ -81,7 +81,7 @@ export const findOrCreatePlatformCustomerByEmail = async (
         mailboxId,
       })
       .returning(),
-    getMailboxById(mailboxId),
+    getMailbox(),
   ]);
 
   const customer = result[0];

--- a/lib/data/retrieval.ts
+++ b/lib/data/retrieval.ts
@@ -9,7 +9,7 @@ import { Mailbox } from "@/lib/data/mailbox";
 import { cleanUpTextForAI } from "../ai/core";
 import { getMetadata, timestamp } from "../metadataApiClient";
 import { captureExceptionAndLogIfDevelopment } from "../shared/sentry";
-import { getMetadataApiByMailboxSlug } from "./mailboxMetadataApi";
+import { getMetadataApi } from "./mailboxMetadataApi";
 
 const SIMILARITY_THRESHOLD = 0.4;
 const MAX_SIMILAR_CONVERSATIONS = 3;
@@ -148,7 +148,7 @@ export const fetchPromptRetrievalData = async (
 };
 
 export const fetchMetadata = async (email: string, mailboxSlug: string) => {
-  const { metadataApi } = await getMetadataApiByMailboxSlug(mailboxSlug);
+  const { metadataApi } = await getMetadataApi();
   if (!metadataApi) return null;
 
   try {

--- a/lib/data/retrieval.ts
+++ b/lib/data/retrieval.ts
@@ -147,7 +147,7 @@ export const fetchPromptRetrievalData = async (
   };
 };
 
-export const fetchMetadata = async (email: string, mailboxSlug: string) => {
+export const fetchMetadata = async (email: string) => {
   const { metadataApi } = await getMetadataApi();
   if (!metadataApi) return null;
 

--- a/trpc/router/mailbox/metadataEndpoint.ts
+++ b/trpc/router/mailbox/metadataEndpoint.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { DataError } from "@/lib/data/dataError";
 import {
   createMailboxMetadataApi,
-  deleteMailboxMetadataApiByMailboxSlug,
+  deleteMailboxMetadataApi,
   testMailboxMetadataApiURL,
 } from "@/lib/data/mailboxMetadataApi";
 import { mailboxProcedure } from "./procedure";
@@ -16,25 +16,25 @@ export const metadataEndpointRouter = {
         url: z.string().url(),
       }),
     )
-    .mutation(async ({ ctx, input: { url } }) => {
+    .mutation(async ({ input: { url } }) => {
       try {
-        await createMailboxMetadataApi(ctx.mailbox.slug, { url });
+        await createMailboxMetadataApi({ url });
         return { success: true, error: undefined };
       } catch (e) {
         return { success: false, error: e instanceof DataError ? e.message : "Error adding metadata endpoint" };
       }
     }),
-  delete: mailboxProcedure.input(z.object({ mailboxSlug: z.string().optional() })).mutation(async ({ ctx }) => {
+  delete: mailboxProcedure.mutation(async () => {
     try {
-      await deleteMailboxMetadataApiByMailboxSlug(ctx.mailbox.slug);
+      await deleteMailboxMetadataApi();
       return { success: true, error: undefined };
     } catch (e) {
       return { success: false, error: e instanceof DataError ? e.message : "Error deleting metadata endpoint" };
     }
   }),
-  test: mailboxProcedure.input(z.object({ mailboxSlug: z.string().optional() })).query(async ({ ctx }) => {
+  test: mailboxProcedure.query(async () => {
     try {
-      await testMailboxMetadataApiURL(ctx.mailbox.slug);
+      await testMailboxMetadataApiURL();
       return { success: true, error: undefined };
     } catch (e) {
       return { success: false, error: e instanceof DataError ? e.message : "Error testing metadata endpoint" };

--- a/trpc/router/mailbox/procedure.ts
+++ b/trpc/router/mailbox/procedure.ts
@@ -1,12 +1,12 @@
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
-import { getMailboxBySlug } from "@/lib/data/mailbox";
+import { getMailbox } from "@/lib/data/mailbox";
 import { protectedProcedure } from "@/trpc/trpc";
 
 export const mailboxProcedure = protectedProcedure
   .input(z.object({ mailboxSlug: z.string() }))
   .use(async ({ ctx, input, next }) => {
-    const mailbox = await getMailboxBySlug(input.mailboxSlug);
+    const mailbox = await getMailbox();
     if (!mailbox) throw new TRPCError({ code: "NOT_FOUND" });
 
     return next({ ctx: { ...ctx, mailbox } });

--- a/trpc/router/mailbox/procedure.ts
+++ b/trpc/router/mailbox/procedure.ts
@@ -5,7 +5,7 @@ import { protectedProcedure } from "@/trpc/trpc";
 
 export const mailboxProcedure = protectedProcedure
   .input(z.object({ mailboxSlug: z.string() }))
-  .use(async ({ ctx, input, next }) => {
+  .use(async ({ ctx, next }) => {
     const mailbox = await getMailbox();
     if (!mailbox) throw new TRPCError({ code: "NOT_FOUND" });
 


### PR DESCRIPTION
### Summary:
- Replace getMailboxById and getMailboxBySlug with a getMailbox function that just returns the first mailbox

- [x] all test passed.
- This is part of the third sub-part of this issue: Ref: #489


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized mailbox retrieval across the application by replacing various mailbox fetch methods with a single, streamlined approach.
  * Improved error handling and authentication checks in integration callback flows for GitHub and Slack.
  * Simplified and unified mailbox context usage in conversation assignment, merging, and update processes.
  * Enhanced maintainability by removing redundant code and consolidating mailbox-related logic.
  * Updated metadata API handling to remove mailbox slug dependencies, simplifying API interactions.
* **Tests**
  * Refined test setup for conversation routing to use shared user and mailbox instances, improving consistency and reducing redundancy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->