### PR TITLE
fix (conversations): select all not bulk updating all items

### DIFF
--- a/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/list/conversationList.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/list/conversationList.tsx
@@ -82,8 +82,7 @@ export const List = () => {
   const handleBulkUpdate = (status: "open" | "closed" | "spam") => {
     setIsBulkUpdating(true);
     try {
-      const conversationFilter = allConversationsSelected ? conversations.map((c) => c.id) : selectedConversations;
-      const selectedCount = allConversationsSelected ? conversations.length : selectedConversations.length;
+      const conversationFilter = allConversationsSelected ? input : selectedConversations;
 
       bulkUpdate(
         {
@@ -99,9 +98,14 @@ export const List = () => {
             void utils.mailbox.conversations.count.invalidate();
 
             if (updatedImmediately) {
+              const ticketsText = allConversationsSelected
+                ? "All matching tickets"
+                : `${selectedConversations.length} ticket${selectedConversations.length === 1 ? "" : "s"}`;
+
               const actionText = status === "open" ? "reopened" : status === "closed" ? "closed" : "marked as spam";
+
               toast({
-                title: `${selectedCount} ticket${selectedCount === 1 ? "" : "s"} ${actionText}`,
+                title: `${ticketsText} ${actionText}`,
               });
             } else {
               toast({ title: "Starting update, refresh to see status." });
@@ -202,7 +206,9 @@ export const List = () => {
     });
   });
 
-  const selectedCount = allConversationsSelected ? conversations.length : selectedConversations.length;
+  const conversationsText = allConversationsSelected
+    ? "all matching conversations"
+    : `${selectedConversations.length} conversation${selectedConversations.length === 1 ? "" : "s"}`;
 
   return (
     <div className="flex flex-col w-full h-full">
@@ -234,9 +240,7 @@ export const List = () => {
                 <div className="flex items-center gap-2">
                   {searchParams.status === "closed" ? (
                     <ConfirmationDialog
-                      message={`Are you sure you want to reopen ${selectedCount} conversation${
-                        selectedCount === 1 ? "" : "s"
-                      }?`}
+                      message={`Are you sure you want to reopen ${conversationsText}?`}
                       onConfirm={() => handleBulkUpdate("open")}
                       confirmLabel="Yes, reopen"
                       confirmVariant="bright"
@@ -247,9 +251,7 @@ export const List = () => {
                     </ConfirmationDialog>
                   ) : (
                     <ConfirmationDialog
-                      message={`Are you sure you want to close ${selectedCount} conversation${
-                        selectedCount === 1 ? "" : "s"
-                      }?`}
+                      message={`Are you sure you want to close ${conversationsText}?`}
                       onConfirm={() => handleBulkUpdate("closed")}
                       confirmLabel="Yes, close"
                       confirmVariant="bright"
@@ -261,9 +263,7 @@ export const List = () => {
                   )}
                   {searchParams.status !== "spam" && (
                     <ConfirmationDialog
-                      message={`Are you sure you want to mark ${selectedCount} conversation${
-                        selectedCount === 1 ? "" : "s"
-                      } as spam?`}
+                      message={`Are you sure you want to mark ${conversationsText} as spam?`}
                       onConfirm={() => handleBulkUpdate("spam")}
                       confirmLabel="Yes, mark as spam"
                       confirmVariant="bright"


### PR DESCRIPTION
This PR fixes an issue where clicking "Select all" and performing a bulk update only sends the currently loaded items to the backend which causes incomplete updates.

The fix was inspired by @binary-koan's [comment](https://github.com/antiwork/helper/pull/627#discussion_r2179514057) in a separate discussion, noting that the endpoint is expected to support bulk actions using both filters and ID lists when "Select all" is used.

Before:

https://github.com/user-attachments/assets/98b7c7d5-302e-4082-9026-494990fc9a32

After:

https://github.com/user-attachments/assets/b064b924-6b15-49ef-96d8-d1ecd8553414
