### PR TITLE
feat: add spam tab actions with confirmation dialogs

### DIFF
--- a/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/list/conversationList.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/list/conversationList.tsx
@@ -232,7 +232,7 @@ export const List = () => {
                   </Tooltip>
                 </TooltipProvider>
                 <div className="flex items-center gap-2">
-                  {searchParams.status === "closed" ? (
+                  {(searchParams.status === "closed" || searchParams.status === "spam") && (
                     <ConfirmationDialog
                       message={`Are you sure you want to reopen ${selectedCount} conversation${
                         selectedCount === 1 ? "" : "s"
@@ -245,7 +245,8 @@ export const List = () => {
                         Reopen
                       </Button>
                     </ConfirmationDialog>
-                  ) : (
+                  )}
+                  {searchParams.status !== "closed" && searchParams.status !== "spam" && (
                     <ConfirmationDialog
                       message={`Are you sure you want to close ${selectedCount} conversation${
                         selectedCount === 1 ? "" : "s"

--- a/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/list/conversationList.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/list/conversationList.tsx
@@ -232,7 +232,7 @@ export const List = () => {
                   </Tooltip>
                 </TooltipProvider>
                 <div className="flex items-center gap-2">
-                  {(searchParams.status === "closed" || searchParams.status === "spam") && (
+                  {searchParams.status !== "open" && (
                     <ConfirmationDialog
                       message={`Are you sure you want to reopen ${selectedCount} conversation${
                         selectedCount === 1 ? "" : "s"

--- a/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/list/conversationList.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/list/conversationList.tsx
@@ -246,7 +246,7 @@ export const List = () => {
                       </Button>
                     </ConfirmationDialog>
                   )}
-                  {searchParams.status !== "closed" && searchParams.status !== "spam" && (
+                  {searchParams.status !== "closed" && (
                     <ConfirmationDialog
                       message={`Are you sure you want to close ${selectedCount} conversation${
                         selectedCount === 1 ? "" : "s"


### PR DESCRIPTION
## Gmail-style Select All
- Add always-visible checkbox and label in bulk actions row
- Prevents layout shifts when selection state changes
- Dynamic label: "Select all" → "X selected" → "All conversations selected"
- Remove old select all button from search bar that caused layout shifts

## Spam Tab Actions
- Add both Reopen and Close action buttons when viewing spam conversations
- Gives users flexibility to move spam conversations to either open or closed status
- Previously only Close action was available implicitly through other tabs

## Testing
- Includes comprehensive e2e tests for both features
- All tests pass successfully


## Before Video: 

https://github.com/user-attachments/assets/ce2b3a70-52d9-4bdf-895e-61557d7b8c52




## After Video:
https://github.com/user-attachments/assets/baec9981-b647-41e7-a509-65fe74bc10b8





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the display logic for bulk action confirmation dialogs in conversation lists, ensuring dialogs for "Reopen" and "Close" actions appear more accurately based on conversation status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->