### PR TITLE
fix: correct bulk assign count when Select All is used

### DIFF
--- a/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/list/conversationListItem.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/list/conversationListItem.tsx
@@ -1,11 +1,17 @@
 import { escape } from "lodash-es";
-import { Bot, User } from "lucide-react";
-import { useEffect, useRef } from "react";
+import { Archive, Bot, CornerUpLeft, ShieldAlert, User, UserPlus } from "lucide-react";
+import { useParams } from "next/navigation";
+import { useEffect, useRef, useState } from "react";
 import scrollIntoView from "scroll-into-view-if-needed";
 import { ConversationListItem as ConversationListItemType } from "@/app/types/global";
+import { AssigneeOption, AssignSelect } from "@/components/assignSelect";
+import { useToast } from "@/components/hooks/use-toast";
 import HumanizedTime from "@/components/humanizedTime";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { ToastAction } from "@/components/ui/toast";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { formatCurrency } from "@/components/utils/currency";
 import { cn } from "@/lib/utils";
@@ -33,8 +39,16 @@ export const ConversationListItem = ({
 }: ConversationListItemProps) => {
   const listItemRef = useRef<HTMLAnchorElement>(null);
   const { mailboxSlug } = useConversationListContext();
+  const { category } = useParams<{ category: string }>();
   const { searchParams } = useConversationsListInput();
   const searchTerms = searchParams.search ? searchParams.search.split(/\s+/).filter(Boolean) : [];
+  const { toast } = useToast();
+  const utils = api.useUtils();
+  const [showAssignPopover, setShowAssignPopover] = useState(false);
+  const [assignedTo, setAssignedTo] = useState<AssigneeOption | null>(null);
+
+  const { mutate: updateStatus, isPending: isUpdating } = api.mailbox.conversations.update.useMutation();
+  const { mutate: updateAssignment, isPending: isAssigning } = api.mailbox.conversations.update.useMutation();
 
   useEffect(() => {
     if (isActive && listItemRef.current) {
@@ -46,6 +60,111 @@ export const ConversationListItem = ({
     }
   }, [conversation, isActive]);
 
+  const handleUpdateStatus = (e: React.MouseEvent, newStatus: "open" | "closed" | "spam") => {
+    e.stopPropagation();
+    const previousStatus = conversation.status;
+    
+    updateStatus(
+      {
+        mailboxSlug,
+        conversationSlug: conversation.slug,
+        status: newStatus,
+      },
+      {
+        onSuccess: (data, variables) => {
+          void utils.mailbox.conversations.list.invalidate();
+          void utils.mailbox.conversations.count.invalidate();
+
+          const { status } = variables;
+
+          if (status === "spam") {
+            toast({
+              title: "Marked as spam",
+              action: (
+                <ToastAction
+                  altText="Undo"
+                  onClick={() => {
+                    updateStatus(
+                      {
+                        mailboxSlug,
+                        conversationSlug: conversation.slug,
+                        status: previousStatus,
+                      },
+                      {
+                        onSuccess: () => {
+                          void utils.mailbox.conversations.list.invalidate();
+                          void utils.mailbox.conversations.count.invalidate();
+                          toast({
+                            title: "No longer marked as spam",
+                          });
+                        },
+                        onError: () => {
+                          toast({ title: "Failed to undo spam", variant: "destructive" });
+                        }
+                      },
+                    );
+                  }}
+                >
+                  Undo
+                </ToastAction>
+              ),
+            });
+          } else if (status === "closed") {
+            toast({
+              title: "Conversation closed",
+              variant: "success",
+            });
+          } else if (status === "open") {
+            toast({
+              title: "Conversation reopened",
+              variant: "success",
+            });
+          }
+        },
+        onError: () => {
+          const actionText = newStatus === "open" ? "reopen" : newStatus === "closed" ? "close" : "mark as spam";
+          toast({ title: `Failed to ${actionText} conversation`, variant: "destructive" });
+        }
+      }
+    );
+  };
+
+  const handleAssign = () => {
+    if (!assignedTo) return;
+    
+    const assignedToId = "id" in assignedTo ? assignedTo.id : null;
+    const assignedToAI = "ai" in assignedTo;
+
+    updateAssignment(
+      {
+        mailboxSlug,
+        conversationSlug: conversation.slug,
+        assignedToId,
+        assignedToAI,
+      },
+      {
+        onSuccess: () => {
+          void utils.mailbox.conversations.list.invalidate();
+          setShowAssignPopover(false);
+          setAssignedTo(null);
+          const displayName = assignedTo && "displayName" in assignedTo ? assignedTo.displayName : null;
+          const assignText = assignedToAI 
+            ? "assigned to Helper agent" 
+            : assignedToId 
+              ? `assigned to ${displayName || "user"}`
+              : "unassigned";
+          toast({
+            title: `Conversation ${assignText}`,
+            variant: "success",
+          });
+        },
+        onError: () => {
+          toast({ title: "Failed to assign conversation", variant: "destructive" });
+        }
+      }
+    );
+  };
+
   let highlightedSubject = escape(conversation.subject);
   let highlightedBody = escape(conversation.matchedMessageText ?? conversation.recentMessageText ?? "");
   if (searchTerms.length > 0) {
@@ -55,17 +174,126 @@ export const ConversationListItem = ({
     }
   }
 
+  const quickActions: Record<string, React.ReactNode[]> = {
+    open: [
+      <TooltipProvider key="close" delayDuration={0}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button 
+              onClick={(e) => handleUpdateStatus(e, "closed")} 
+              disabled={isUpdating}
+              className="rounded-md p-1 hover:bg-muted"
+            >
+              <Archive className="h-4 w-4" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="top" className="text-xs">
+            <p>Close</p>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>,
+      <TooltipProvider key="spam" delayDuration={0}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button 
+              onClick={(e) => handleUpdateStatus(e, "spam")} 
+              disabled={isUpdating}
+              className="rounded-md p-1 hover:bg-muted"
+            >
+              <ShieldAlert className="h-4 w-4" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="top" className="text-xs">
+            <p>Mark as spam</p>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>,
+    ],
+    closed: [
+      <TooltipProvider key="reopen" delayDuration={0}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button 
+              onClick={(e) => handleUpdateStatus(e, "open")} 
+              disabled={isUpdating}
+              className="rounded-md p-1 hover:bg-muted"
+            >
+              <CornerUpLeft className="h-4 w-4" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="top" className="text-xs">
+            <p>Reopen</p>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>,
+    ],
+    spam: [
+      <TooltipProvider key="reopen" delayDuration={0}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button 
+              onClick={(e) => handleUpdateStatus(e, "open")} 
+              disabled={isUpdating}
+              className="rounded-md p-1 hover:bg-muted"
+            >
+              <CornerUpLeft className="h-4 w-4" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="top" className="text-xs">
+            <p>Reopen</p>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>,
+    ],
+  };
+
+  // Add assign action to all statuses
+  Object.keys(quickActions).forEach((status) => {
+    quickActions[status]!.push(
+      <Popover key="assign" open={showAssignPopover} onOpenChange={setShowAssignPopover}>
+        <PopoverTrigger asChild>
+          <button
+            onClick={(e) => e.stopPropagation()}
+            disabled={isAssigning}
+            className="rounded-md p-1 hover:bg-muted"
+          >
+            <UserPlus className="h-4 w-4" />
+          </button>
+        </PopoverTrigger>
+        <PopoverContent className="w-80 p-4" side="top">
+          <div className="flex flex-col space-y-4">
+            <h4 className="font-medium">Assign conversation</h4>
+            <AssignSelect
+              selectedUserId={assignedTo && "id" in assignedTo ? assignedTo.id : null}
+              onChange={setAssignedTo}
+              aiOption
+              aiOptionSelected={!!(assignedTo && "ai" in assignedTo)}
+            />
+            <Button 
+              className="w-full" 
+              onClick={handleAssign}
+              disabled={!assignedTo || isAssigning}
+              size="sm"
+            >
+              Assign
+            </Button>
+          </div>
+        </PopoverContent>
+      </Popover>
+    );
+  });
+
   return (
     <div className="px-1 md:px-2">
       <div
         className={cn(
-          "flex w-full cursor-pointer flex-col  transition-colors border-b border-border py-3 md:py-4",
+          "group flex w-full cursor-pointer flex-col  transition-colors border-b border-border py-3 md:py-4",
           isActive
             ? "bg-amber-50 dark:bg-white/5 border-l-4 border-l-amber-400"
             : "hover:bg-gray-50 dark:hover:bg-white/[0.02]",
         )}
       >
-        <div className="flex items-start gap-4 px-2 md:px-4">
+        <div className="flex items-start gap-4 px-2 md:px-4 relative">
           <div className="w-5 flex items-center">
             <Checkbox
               checked={isSelected}
@@ -146,6 +374,9 @@ export const ConversationListItem = ({
               </div>
             </div>
           </a>
+          <div className="absolute bottom-2 right-2 flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+            {quickActions[conversation.status]?.map((action) => action)}
+          </div>
         </div>
       </div>
     </div>

--- a/jobs/trigger.ts
+++ b/jobs/trigger.ts
@@ -45,6 +45,16 @@ const events = {
     }),
     jobs: ["bulkUpdateConversations"],
   },
+  "conversations/bulk-assign": {
+    data: z.object({
+      mailboxId: z.number(),
+      userId: z.string(),
+      conversationFilter: z.union([z.array(z.number()), searchSchema]),
+      assignedToId: z.string().nullable(),
+      assignedToAI: z.boolean().optional(),
+    }),
+    jobs: ["bulkAssignConversations"],
+  },
   "conversations/update-suggested-actions": {
     data: z.object({
       conversationId: z.number(),

--- a/trpc/router/mailbox/conversations/index.ts
+++ b/trpc/router/mailbox/conversations/index.ts
@@ -190,6 +190,44 @@ export const conversationsRouter = {
       });
       return { updatedImmediately: false };
     }),
+  bulkAssign: mailboxProcedure
+    .input(
+      z.object({
+        conversationFilter: z.union([z.array(z.number()), searchSchema]),
+        assignedToId: z.string().nullable(),
+        assignedToAI: z.boolean().optional(),
+        mailboxSlug: z.string(),
+      }),
+    )
+    .mutation(async ({ input, ctx }) => {
+      const { conversationFilter, assignedToId, assignedToAI } = input;
+
+      if (assignedToId) {
+        const assignee = await db.query.authUsers.findFirst({
+          where: eq(authUsers.id, assignedToId),
+        });
+        if (!assignee) throw new TRPCError({ code: "BAD_REQUEST", message: "Assignee not found" });
+      }
+
+      if (Array.isArray(conversationFilter) && conversationFilter.length < 25) {
+        for (const conversationId of conversationFilter) {
+          await updateConversation(conversationId, { 
+            set: { assignedToId, assignedToAI }, 
+            byUserId: ctx.user.id 
+          });
+        }
+        return { updatedImmediately: true };
+      }
+
+      await triggerEvent("conversations/bulk-assign", {
+        mailboxId: ctx.mailbox.id,
+        userId: ctx.user.id,
+        conversationFilter: input.conversationFilter,
+        assignedToId: input.assignedToId,
+        assignedToAI: input.assignedToAI,
+      });
+      return { updatedImmediately: false };
+    }),
   generateDraft: conversationProcedure.mutation(async ({ ctx }) => {
     const newDraft = await generateDraftResponse(ctx.conversation.id, ctx.mailbox);
     return serializeResponseAiDraft(newDraft, ctx.mailbox);


### PR DESCRIPTION
Video:

https://github.com/user-attachments/assets/151c57ab-995e-4f1c-96e3-c184842fc51b


Assign Functionality Video:

https://github.com/user-attachments/assets/8aaf82e7-3bcf-4e63-9a05-5bdc50952121

## Summary

Add quick action buttons to conversation list items for improved productivity:
- Close conversation
- Reopen conversation  
- Mark as spam

## Features

### Quick Actions
- **Desktop**: Actions appear on hover in the bottom-right corner of each conversation item
- **Mobile**: Actions are always visible below each conversation for easy access
- **Icons**: Archive (close), CornerUpLeft (reopen), ShieldAlert (spam)

### User Feedback
- Toast notifications for all status changes
- Success messages: "Conversation closed", "Conversation reopened", "Marked as spam"
- Undo functionality for marking as spam with one-click restore

### Smart Display Logic
- Shows reopen button only for closed/spam conversations
- Shows close button only for non-closed conversations
- Shows spam button only for non-spam conversations
- Disabled state during updates to prevent double-clicks

## Implementation Details

- Uses existing `api.mailbox.conversations.update` mutation
- Invalidates conversation list and count caches on success
- Prevents event bubbling to avoid triggering conversation navigation
- Responsive design with different layouts for mobile/desktop

## Benefits

- Faster workflow - no need to open conversations to change status
- Better UX with immediate feedback and undo capabilities
- Consistent with existing UI patterns and styling
- Reduces clicks needed for common actions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to assign multiple conversations at once using bulk actions in the conversation list.
  * Introduced a popover UI for selecting an assignee and confirming bulk assignment.
  * Enabled quick assignment and status updates (open, closed, spam) directly from each conversation list item, with immediate feedback and undo options.
* **Bug Fixes**
  * Improved selection handling to ensure accurate bulk actions when filters or selections change.
* **Chores**
  * Added support for a new bulk assignment event and job to handle large-scale conversation assignments efficiently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->