### PR TITLE
fix, chore: set missing document titles, standardize with a hook

### DIFF
--- a/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/inbox.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/[category]/inbox.tsx
@@ -16,6 +16,7 @@ import { useSaveLatestMailboxSlug } from "@/app/(dashboard)/mailboxes/[mailbox_s
 import { FileUploadProvider } from "@/components/fileUploadContext";
 import { useIsMobile } from "@/components/hooks/use-mobile";
 import { PageHeader } from "@/components/pageHeader";
+import { useDocumentTitle } from "@/components/useDocumentTitle";
 import useKeyboardShortcut from "@/components/useKeyboardShortcut";
 import { cn } from "@/lib/utils";
 import { api } from "@/trpc/react";
@@ -51,11 +52,7 @@ const Inbox = () => {
     ? `${currentConversation.subject} - ${currentConversation.emailFrom}`
     : CATEGORY_LABELS[params.category];
 
-  useEffect(() => {
-    if (pageTitle) {
-      document.title = pageTitle;
-    }
-  }, [pageTitle]);
+  useDocumentTitle(pageTitle);
 
   const currentConversationIndex =
     conversationListData?.conversations.findIndex((c) => c.slug === currentConversationSlug) ?? -1;

--- a/app/(dashboard)/mailboxes/[mailbox_slug]/dashboard/dashboardContent.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/dashboard/dashboardContent.tsx
@@ -8,6 +8,7 @@ import { ReactionsChart } from "@/app/(dashboard)/mailboxes/[mailbox_slug]/dashb
 import { useIsMobile } from "@/components/hooks/use-mobile";
 import { PageHeader } from "@/components/pageHeader";
 import { Panel } from "@/components/panel";
+import { useDocumentTitle } from "@/components/useDocumentTitle";
 import { DashboardAlerts } from "./dashboardAlerts";
 import { StatusByTypeChart } from "./statusByTypeChart";
 import { TimeRangeSelector } from "./timeRangeSelector";
@@ -24,6 +25,8 @@ export function DashboardContent({ mailboxSlug }: Props) {
   const [timeRange, setTimeRange] = useState<TimeRange>("7d");
   const [customDate, setCustomDate] = useState<DateRange>();
   const isMobile = useIsMobile();
+
+  useDocumentTitle("Dashboard");
 
   return (
     <div className="flex flex-col h-full">

--- a/app/(dashboard)/mailboxes/[mailbox_slug]/saved-replies/page.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/saved-replies/page.tsx
@@ -10,6 +10,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
+import { useDocumentTitle } from "@/components/useDocumentTitle";
 import { stripHtmlTags } from "@/components/utils/html";
 import { captureExceptionAndLog } from "@/lib/shared/sentry";
 import { showErrorToast, showSuccessToast } from "@/lib/utils/toast";
@@ -27,6 +28,8 @@ export default function SavedRepliesPage() {
   const [debouncedSearchTerm, setDebouncedSearchTerm] = useState("");
   const [showCreateDialog, setShowCreateDialog] = useState(false);
   const [editingSavedReply, setEditingSavedReply] = useState<SavedReply | null>(null);
+
+  useDocumentTitle("Saved replies");
 
   // Debounce search term to avoid losing focus on every keystroke
   useEffect(() => {

--- a/app/(dashboard)/mailboxes/[mailbox_slug]/settings/[tab]/page.tsx
+++ b/app/(dashboard)/mailboxes/[mailbox_slug]/settings/[tab]/page.tsx
@@ -6,6 +6,7 @@ import Loading from "@/app/(dashboard)/loading";
 import { FileUploadProvider } from "@/components/fileUploadContext";
 import { PageHeader } from "@/components/pageHeader";
 import { Alert } from "@/components/ui/alert";
+import { useDocumentTitle } from "@/components/useDocumentTitle";
 import { api } from "@/trpc/react";
 import ChatWidgetSetting from "../chat/chatWidgetSetting";
 import AutoCloseSetting from "../customers/autoCloseSetting";
@@ -22,6 +23,8 @@ import ToolSetting from "../tools/toolSetting";
 export default function TabsPage() {
   const params = useParams<{ mailbox_slug: string; tab: string }>();
   const { data: mailbox, error } = api.mailbox.get.useQuery({ mailboxSlug: params.mailbox_slug });
+  useDocumentTitle("Settings");
+
   if (error) return <Alert variant="destructive">Error loading mailbox: {error.message}</Alert>;
   if (!mailbox) return <Loading />;
 

--- a/components/useDocumentTitle.ts
+++ b/components/useDocumentTitle.ts
@@ -1,0 +1,17 @@
+import { useEffect, useRef } from "react";
+
+export function useDocumentTitle(title: string, retainOnUnmount = false) {
+  const defaultTitle = useRef(document.title);
+
+  useEffect(() => {
+    document.title = title;
+  }, [title]);
+
+  useEffect(() => {
+    return () => {
+      if (!retainOnUnmount) {
+        document.title = defaultTitle.current;
+      }
+    };
+  }, []);
+}


### PR DESCRIPTION
This PR is similar to #607, except that it adds missing document titles for the rest of the pages to be consistent, and it also standardizes it with a new `useDocumentTitle` hook.

Preview:

https://github.com/user-attachments/assets/52aa64be-b17d-455c-bc6a-87936866090c
