### PR TITLE
feat: allow multiple images in chat by user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ test-results/
 tests/e2e/debug/*.png
 tests/e2e/screenshots/
 tests/e2e/.auth/
+CLAUDE.md

--- a/app/(dashboard)/settings/chat/chatWidgetSetting.tsx
+++ b/app/(dashboard)/settings/chat/chatWidgetSetting.tsx
@@ -134,6 +134,7 @@ const ChatWidgetSetting = ({ mailbox }: { mailbox: RouterOutputs["mailbox"]["get
   const handleSwitchChange = (checked: boolean) => {
     const newMode = checked ? "always" : "off";
     setMode(newMode);
+    setShowChatWidget(newMode !== "off");
   };
 
   const plainJSPrompt = `

--- a/app/api/chat/conversation/[slug]/route.ts
+++ b/app/api/chat/conversation/[slug]/route.ts
@@ -68,9 +68,19 @@ export const GET = withWidgetAuth<{ slug: string }>(async ({ context: { params }
       reactionType: message.reactionType,
       reactionFeedback: message.reactionFeedback,
       annotations: message.userId ? await getUserAnnotation(message.userId) : undefined,
-      experimental_attachments: (message.metadata as MessageMetadata)?.includesScreenshot
-        ? attachments.filter((a) => a.messageId === message.id)
-        : [],
+      experimental_attachments:
+        (message.metadata as MessageMetadata)?.hasAttachments ||
+        (message.metadata as MessageMetadata)?.includesScreenshot
+          ? await Promise.all(
+              attachments
+                .filter((a) => a.messageId === message.id)
+                .map(async (a) => ({
+                  name: a.name,
+                  url: await getFileUrl(a),
+                  contentType: a.contentType || "image/png",
+                })),
+            )
+          : [],
     })),
   );
 

--- a/app/api/chat/conversation/[slug]/route.ts
+++ b/app/api/chat/conversation/[slug]/route.ts
@@ -77,7 +77,7 @@ export const GET = withWidgetAuth<{ slug: string }>(async ({ context: { params }
                 .map(async (a) => ({
                   name: a.name,
                   url: await getFileUrl(a),
-                  contentType: a.contentType || "image/png",
+                  contentType: a.mimetype,
                 })),
             )
           : [],

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -79,7 +79,7 @@ export const POST = withWidgetAuth(async ({ request }, { session, mailbox }) => 
   const userMessage = await createUserMessage(
     conversation.id,
     userEmail,
-    message.content,
+    message.content || (attachmentData.length > 0 ? "[Image]" : ""),
     attachmentData.length > 0 ? attachmentData : undefined,
   );
 

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -58,17 +58,20 @@ export const POST = withWidgetAuth(async ({ request }, { session, mailbox }) => 
 
   // Validate attachments
   for (const attachment of attachments) {
-    if (!attachment.url.startsWith("data:image/")) {
-      return corsResponse({ error: "Only image attachments sent via data URL are supported" }, { status: 400 });
+    if (!attachment.url.startsWith("data:image/") || !attachment.url.includes(",")) {
+      return corsResponse({ error: "Only valid image data URLs are supported" }, { status: 400 });
     }
   }
 
   // Convert attachments to the format expected by createUserMessage
   const attachmentData = attachments.map((attachment) => {
     const [, base64Data] = attachment.url.split(",");
+    if (!base64Data) {
+      throw new Error("Invalid data URL format - missing base64 data");
+    }
     return {
-      name: attachment.name,
-      contentType: attachment.contentType,
+      name: attachment.name || "unknown.png",
+      contentType: attachment.contentType || "image/png",
       data: base64Data,
     };
   });

--- a/components/widget/ChatInput.tsx
+++ b/components/widget/ChatInput.tsx
@@ -1,4 +1,4 @@
-import { Camera, Mic, Paperclip } from "lucide-react";
+import { Camera, Mic, Paperclip, X } from "lucide-react";
 import * as motion from "motion/react-client";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useSpeechRecognition } from "@/components/hooks/useSpeechRecognition";
@@ -7,7 +7,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import ShadowHoverButton from "@/components/widget/ShadowHoverButton";
 import { useScreenshotStore } from "@/components/widget/widgetState";
-import { MAX_FILE_COUNT, validateClientAttachments } from "@/lib/shared/attachmentValidation";
+import { validateClientAttachments } from "@/lib/shared/attachmentValidation";
 import { captureExceptionAndLog } from "@/lib/shared/sentry";
 import { cn } from "@/lib/utils";
 import { closeWidget, sendScreenshot } from "@/lib/widget/messages";
@@ -392,16 +392,16 @@ export default function ChatInput({
               <TooltipProvider key={key} delayDuration={100}>
                 <Tooltip>
                   <TooltipTrigger asChild>
-                    <div className="relative bg-muted rounded-lg p-2 flex items-center gap-2">
-                      <img src={objectUrl} alt={file.name} className="w-8 h-8 object-cover rounded border" />
-                      <div className="text-sm text-muted-foreground truncate max-w-20">{file.name}</div>
+                    <div className="relative border border-black rounded flex items-center gap-2">
+                      <img src={objectUrl} alt={file.name} className="w-10 h-10 object-cover rounded-l" />
+                      <div className="text-sm truncate max-w-20 text-black">{file.name}</div>
                       <button
                         type="button"
+                        className="p-2 pl-0"
                         onClick={() => removeFile(index)}
-                        className="text-muted-foreground hover:text-foreground"
                         aria-label={`Remove ${file.name}`}
                       >
-                        ×
+                        <X className="w-3 h-3 text-black" />
                       </button>
                     </div>
                   </TooltipTrigger>

--- a/components/widget/ChatInput.tsx
+++ b/components/widget/ChatInput.tsx
@@ -289,7 +289,7 @@ export default function ChatInput({
             className="self-stretch max-w-md placeholder:text-muted-foreground text-foreground flex-1 resize-none border-none bg-white p-0 pr-3 outline-none focus:border-none focus:outline-none focus:ring-0 min-h-[24px] max-h-[200px]"
             disabled={isLoading}
           />
-          <div className="flex items-center gap-2">
+          <div className="flex items-center">
             <TooltipProvider delayDuration={100}>
               <Tooltip>
                 <TooltipTrigger asChild>

--- a/components/widget/ChatInput.tsx
+++ b/components/widget/ChatInput.tsx
@@ -132,7 +132,7 @@ export default function ChatInput({
     if (screenshot?.response) {
       // Get any pending attachments that were selected before screenshot
       const pendingAttachments = (window as any).pendingAttachments || [];
-      delete (window as any).pendingAttachments;
+      (window as any).pendingAttachments = undefined;
 
       handleSubmit(screenshot.response, pendingAttachments.length > 0 ? pendingAttachments : undefined);
       setScreenshot(null);

--- a/components/widget/Conversation.tsx
+++ b/components/widget/Conversation.tsx
@@ -242,7 +242,7 @@ export default function Conversation({
     }
   }, [isNewConversation, setMessages, setConversationSlug]);
 
-  const handleSubmit = async (screenshotData?: string) => {
+  const handleSubmit = async (screenshotData?: string, attachments?: File[]) => {
     if (!input.trim()) return;
 
     setData(undefined);
@@ -255,10 +255,37 @@ export default function Conversation({
 
       if (currentSlug) {
         setIsNewConversation(false);
+
+        const attachmentsToSend = [];
+
+        // Add screenshot if provided
+        if (screenshotData) {
+          attachmentsToSend.push({
+            name: "screenshot.png",
+            contentType: "image/png",
+            url: screenshotData,
+          });
+        }
+
+        // Add file attachments if provided
+        if (attachments && attachments.length > 0) {
+          for (const file of attachments) {
+            const reader = new FileReader();
+            const dataUrl = await new Promise<string>((resolve) => {
+              reader.onload = () => resolve(reader.result as string);
+              reader.readAsDataURL(file);
+            });
+
+            attachmentsToSend.push({
+              name: file.name,
+              contentType: file.type,
+              url: dataUrl,
+            });
+          }
+        }
+
         handleAISubmit(undefined, {
-          experimental_attachments: screenshotData
-            ? [{ name: "screenshot.png", contentType: "image/png", url: screenshotData }]
-            : [],
+          experimental_attachments: attachmentsToSend,
           body: { conversationSlug: currentSlug },
         });
       }

--- a/components/widget/Conversation.tsx
+++ b/components/widget/Conversation.tsx
@@ -270,17 +270,23 @@ export default function Conversation({
         // Add file attachments if provided
         if (attachments && attachments.length > 0) {
           for (const file of attachments) {
-            const reader = new FileReader();
-            const dataUrl = await new Promise<string>((resolve) => {
-              reader.onload = () => resolve(reader.result as string);
-              reader.readAsDataURL(file);
-            });
+            try {
+              const reader = new FileReader();
+              const dataUrl = await new Promise<string>((resolve, reject) => {
+                reader.onload = () => resolve(reader.result as string);
+                reader.onerror = () => reject(new Error(`Failed to read file: ${file.name}`));
+                reader.readAsDataURL(file);
+              });
 
-            attachmentsToSend.push({
-              name: file.name,
-              contentType: file.type,
-              url: dataUrl,
-            });
+              attachmentsToSend.push({
+                name: file.name,
+                contentType: file.type,
+                url: dataUrl,
+              });
+            } catch (error) {
+              captureExceptionAndLog(error);
+              // Continue with other files, skip the failed one
+            }
           }
         }
 

--- a/components/widget/Conversation.tsx
+++ b/components/widget/Conversation.tsx
@@ -243,7 +243,8 @@ export default function Conversation({
   }, [isNewConversation, setMessages, setConversationSlug]);
 
   const handleSubmit = async (screenshotData?: string, attachments?: File[]) => {
-    if (!input.trim()) return;
+    // Allow submission if there's text input OR attachments/screenshot
+    if (!input.trim() && !screenshotData && (!attachments || attachments.length === 0)) return;
 
     setData(undefined);
 

--- a/components/widget/Message.tsx
+++ b/components/widget/Message.tsx
@@ -117,8 +117,18 @@ export default function Message({
               type="button"
               className="w-full text-left rounded-lg focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
               onClick={() => {
-                // Open image directly in new tab with security parameters
-                window.open(attachment.url, "_blank", "noopener,noreferrer");
+                if (attachment.url.startsWith("data:")) {
+                  const link = document.createElement("a");
+                  link.href = attachment.url;
+                  link.target = "_blank";
+                  link.rel = "noopener noreferrer";
+                  link.download = attachment.name || "image";
+                  document.body.appendChild(link);
+                  link.click();
+                  document.body.removeChild(link);
+                } else {
+                  window.open(attachment.url, "_blank", "noopener,noreferrer");
+                }
               }}
               aria-label={`View image: ${attachment.name}`}
             >

--- a/components/widget/Message.tsx
+++ b/components/widget/Message.tsx
@@ -112,56 +112,22 @@ export default function Message({
           color={color}
         />
         {message.experimental_attachments?.map((attachment) => (
-          <div
-            key={attachment.url}
-            className="p-4 pt-0 cursor-pointer"
-            onClick={() => {
-              // Open image in new tab with proper handling
-              const newWindow = window.open();
-              if (newWindow) {
-                // Properly escape values to prevent XSS
-                const safeTitle = document.createElement('div');
-                safeTitle.textContent = attachment.name;
-                const escapedTitle = safeTitle.innerHTML;
-                
-                const safeUrl = document.createElement('div');
-                safeUrl.textContent = attachment.url;
-                const escapedUrl = safeUrl.innerHTML;
-                
-                newWindow.document.write(`
-                  <html>
-                    <head>
-                      <title>${escapedTitle}</title>
-                      <style>
-                        body {
-                          margin: 0;
-                          display: flex;
-                          justify-content: center;
-                          align-items: center;
-                          min-height: 100vh;
-                          background: #000;
-                        }
-                        img {
-                          max-width: 100%;
-                          max-height: 100vh;
-                          object-fit: contain;
-                        }
-                      </style>
-                    </head>
-                    <body>
-                      <img src="${escapedUrl}" alt="${escapedTitle}" />
-                    </body>
-                  </html>
-                `);
-                newWindow.document.close();
-              }
-            }}
-          >
-            <img
-              className="w-full rounded-lg hover:opacity-90 transition-opacity"
-              src={attachment.url}
-              alt={attachment.name}
-            />
+          <div key={attachment.url} className="p-4 pt-0">
+            <button
+              type="button"
+              className="w-full text-left rounded-lg focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
+              onClick={() => {
+                // Open image directly in new tab with security parameters
+                window.open(attachment.url, "_blank", "noopener,noreferrer");
+              }}
+              aria-label={`View image: ${attachment.name}`}
+            >
+              <img
+                className="w-full rounded-lg hover:opacity-90 transition-opacity"
+                src={attachment.url}
+                alt={attachment.name}
+              />
+            </button>
           </div>
         ))}
         {!message.experimental_attachments?.length && attachments.length > 0 && (

--- a/components/widget/Message.tsx
+++ b/components/widget/Message.tsx
@@ -119,10 +119,19 @@ export default function Message({
               // Open image in new tab with proper handling
               const newWindow = window.open();
               if (newWindow) {
+                // Properly escape values to prevent XSS
+                const safeTitle = document.createElement('div');
+                safeTitle.textContent = attachment.name;
+                const escapedTitle = safeTitle.innerHTML;
+                
+                const safeUrl = document.createElement('div');
+                safeUrl.textContent = attachment.url;
+                const escapedUrl = safeUrl.innerHTML;
+                
                 newWindow.document.write(`
                   <html>
                     <head>
-                      <title>${attachment.name}</title>
+                      <title>${escapedTitle}</title>
                       <style>
                         body {
                           margin: 0;
@@ -140,7 +149,7 @@ export default function Message({
                       </style>
                     </head>
                     <body>
-                      <img src="${attachment.url}" alt="${attachment.name}" />
+                      <img src="${escapedUrl}" alt="${escapedTitle}" />
                     </body>
                   </html>
                 `);

--- a/components/widget/Message.tsx
+++ b/components/widget/Message.tsx
@@ -112,15 +112,48 @@ export default function Message({
           color={color}
         />
         {message.experimental_attachments?.map((attachment) => (
-          <a
+          <div
             key={attachment.url}
-            href={attachment.url}
-            className="block p-4 pt-0"
-            target="_blank"
-            rel="noopener noreferrer"
+            className="p-4 pt-0 cursor-pointer"
+            onClick={() => {
+              // Open image in new tab with proper handling
+              const newWindow = window.open();
+              if (newWindow) {
+                newWindow.document.write(`
+                  <html>
+                    <head>
+                      <title>${attachment.name}</title>
+                      <style>
+                        body {
+                          margin: 0;
+                          display: flex;
+                          justify-content: center;
+                          align-items: center;
+                          min-height: 100vh;
+                          background: #000;
+                        }
+                        img {
+                          max-width: 100%;
+                          max-height: 100vh;
+                          object-fit: contain;
+                        }
+                      </style>
+                    </head>
+                    <body>
+                      <img src="${attachment.url}" alt="${attachment.name}" />
+                    </body>
+                  </html>
+                `);
+                newWindow.document.close();
+              }
+            }}
           >
-            <img className="w-full rounded-lg" src={attachment.url} alt={attachment.name} />
-          </a>
+            <img
+              className="w-full rounded-lg hover:opacity-90 transition-opacity"
+              src={attachment.url}
+              alt={attachment.name}
+            />
+          </div>
         ))}
         {!message.experimental_attachments?.length && attachments.length > 0 && (
           <div className="p-4 pt-0 flex flex-col gap-2">

--- a/components/widget/ShadowHoverButton.tsx
+++ b/components/widget/ShadowHoverButton.tsx
@@ -11,7 +11,7 @@ export default function ShadowHoverButton({
   const [isHovered, setIsHovered] = useState(false);
 
   return (
-    <div className="relative">
+    <div className="relative ml-2">
       <button
         type="submit"
         aria-label="Send message"

--- a/lib/ai/chat.ts
+++ b/lib/ai/chat.ts
@@ -465,6 +465,7 @@ export const createUserMessage = async (
   attachmentData?: { name: string; contentType: string; data: string }[],
 ) => {
   const hasAttachments = attachmentData && attachmentData.length > 0;
+  const includesScreenshot = attachmentData?.some(att => att.name === "screenshot.png") || false;
   const message = await createConversationMessage({
     conversationId,
     emailFrom: email,
@@ -474,7 +475,7 @@ export const createUserMessage = async (
     isPerfect: false,
     isPinned: false,
     isFlaggedAsBad: false,
-    metadata: { includesScreenshot: hasAttachments, hasAttachments },
+    metadata: { includesScreenshot, hasAttachments },
   });
 
   if (hasAttachments) {

--- a/lib/ai/chat.ts
+++ b/lib/ai/chat.ts
@@ -474,7 +474,7 @@ export const createUserMessage = async (
     isPerfect: false,
     isPinned: false,
     isFlaggedAsBad: false,
-    metadata: { includesScreenshot: hasAttachments },
+    metadata: { includesScreenshot: hasAttachments, hasAttachments },
   });
 
   if (hasAttachments) {

--- a/lib/ai/chat.ts
+++ b/lib/ai/chat.ts
@@ -462,8 +462,9 @@ export const createUserMessage = async (
   conversationId: number,
   email: string | null,
   query: string,
-  screenshotData?: string,
+  attachmentData?: { name: string; contentType: string; data: string }[],
 ) => {
+  const hasAttachments = attachmentData && attachmentData.length > 0;
   const message = await createConversationMessage({
     conversationId,
     emailFrom: email,
@@ -473,16 +474,18 @@ export const createUserMessage = async (
     isPerfect: false,
     isPinned: false,
     isFlaggedAsBad: false,
-    metadata: { includesScreenshot: !!screenshotData },
+    metadata: { includesScreenshot: hasAttachments },
   });
 
-  if (screenshotData) {
-    await createAndUploadFile({
-      data: Buffer.from(screenshotData, "base64"),
-      fileName: `screenshot-${Date.now()}.png`,
-      prefix: `screenshots/${conversationId}`,
-      messageId: message.id,
-    });
+  if (hasAttachments) {
+    for (const attachment of attachmentData) {
+      await createAndUploadFile({
+        data: Buffer.from(attachment.data, "base64"),
+        fileName: attachment.name,
+        prefix: `attachments/${conversationId}`,
+        messageId: message.id,
+      });
+    }
   }
 
   return message;

--- a/lib/ai/chat.ts
+++ b/lib/ai/chat.ts
@@ -462,7 +462,7 @@ export const createUserMessage = async (
   conversationId: number,
   email: string | null,
   query: string,
-  attachmentData?: { name: string; contentType: string; data: string }[],
+  attachmentData: { name: string; contentType: string; data: string }[],
 ) => {
   const hasAttachments = attachmentData?.length > 0;
   const message = await createConversationMessage({

--- a/lib/shared/attachmentValidation.ts
+++ b/lib/shared/attachmentValidation.ts
@@ -1,0 +1,147 @@
+export const MAX_FILE_SIZE = 25 * 1024 * 1024; // 25MB
+export const MAX_TOTAL_SIZE = 50 * 1024 * 1024; // 50MB
+export const MAX_FILE_COUNT = 5;
+export const SUPPORTED_MIME_TYPES = ["image/png", "image/jpeg", "image/gif", "image/webp"];
+
+export interface AttachmentValidationResult {
+  isValid: boolean;
+  errors: string[];
+  fileSize?: number;
+  totalSize?: number;
+}
+
+export interface AttachmentData {
+  name: string;
+  size?: number;
+  type?: string;
+  url: string; // Required for server-side validation
+}
+
+export interface ClientAttachmentData {
+  name: string;
+  size?: number;
+  type?: string;
+  url?: string; // Optional for client-side file validation
+}
+
+export function validateAttachment(attachment: AttachmentData): AttachmentValidationResult {
+  const errors: string[] = [];
+
+  // Validate URL is present
+  if (!attachment.url) {
+    errors.push(`${attachment.name}: Missing URL`);
+    return { isValid: false, errors };
+  }
+
+  // Validate file type
+  if (attachment.type && !SUPPORTED_MIME_TYPES.includes(attachment.type)) {
+    errors.push(`${attachment.name}: Only image files are supported`);
+  }
+
+  // Validate data URL format
+  if (!/^data:image\/(png|jpeg|gif|webp);base64,.+/.test(attachment.url)) {
+    errors.push(`${attachment.name}: Invalid data URL format`);
+  }
+
+  // Calculate file size
+  let fileSize = attachment.size || 0;
+  if (attachment.url.startsWith("data:")) {
+    const [, base64Data] = attachment.url.split(",");
+    if (base64Data) {
+      fileSize = Math.ceil((base64Data.length * 3) / 4);
+    }
+  }
+
+  // Validate file size
+  if (fileSize > MAX_FILE_SIZE) {
+    errors.push(`${attachment.name}: File size (${Math.round(fileSize / 1024 / 1024)}MB) exceeds limit (25MB)`);
+  }
+
+  return {
+    isValid: errors.length === 0,
+    errors,
+    fileSize,
+  };
+}
+
+export function validateClientAttachments(
+  attachments: ClientAttachmentData[],
+  currentFiles: ClientAttachmentData[] = [],
+): AttachmentValidationResult {
+  const errors: string[] = [];
+  let totalSize = 0;
+
+  // Check file count limit
+  if (currentFiles.length + attachments.length > MAX_FILE_COUNT) {
+    errors.push(`Cannot upload more than ${MAX_FILE_COUNT} files total`);
+  }
+
+  // Calculate current total size
+  for (const file of currentFiles) {
+    totalSize += file.size || 0;
+  }
+
+  // Validate each attachment (skip URL validation for client files)
+  for (const attachment of attachments) {
+    if (attachment.type && !SUPPORTED_MIME_TYPES.includes(attachment.type)) {
+      errors.push(`${attachment.name}: Only image files are supported`);
+    }
+
+    const fileSize = attachment.size || 0;
+    if (fileSize > MAX_FILE_SIZE) {
+      errors.push(`${attachment.name}: File size (${Math.round(fileSize / 1024 / 1024)}MB) exceeds limit (25MB)`);
+    }
+
+    totalSize += fileSize;
+  }
+
+  // Check total size limit
+  if (totalSize > MAX_TOTAL_SIZE) {
+    errors.push(`Total file size (${Math.round(totalSize / 1024 / 1024)}MB) exceeds limit (50MB)`);
+  }
+
+  return {
+    isValid: errors.length === 0,
+    errors,
+    totalSize,
+  };
+}
+
+export function validateAttachments(
+  attachments: AttachmentData[],
+  currentFiles: AttachmentData[] = [],
+): AttachmentValidationResult {
+  const errors: string[] = [];
+  let totalSize = 0;
+
+  // Check file count limit
+  if (currentFiles.length + attachments.length > MAX_FILE_COUNT) {
+    errors.push(`Cannot upload more than ${MAX_FILE_COUNT} files total`);
+  }
+
+  // Calculate current total size
+  for (const file of currentFiles) {
+    totalSize += file.size || 0;
+  }
+
+  // Validate each attachment
+  for (const attachment of attachments) {
+    const result = validateAttachment(attachment);
+    errors.push(...result.errors);
+
+    if (result.fileSize) {
+      totalSize += result.fileSize;
+    }
+  }
+
+  // Check total size limit
+  if (totalSize > MAX_TOTAL_SIZE) {
+    errors.push(`Total file size (${Math.round(totalSize / 1024 / 1024)}MB) exceeds limit (50MB)`);
+  }
+
+  return {
+    isValid: errors.length === 0,
+    errors,
+    totalSize,
+  };
+}

--- a/lib/shared/attachmentValidation.ts
+++ b/lib/shared/attachmentValidation.ts
@@ -1,7 +1,7 @@
-export const MAX_FILE_SIZE = 25 * 1024 * 1024; // 25MB
-export const MAX_TOTAL_SIZE = 50 * 1024 * 1024; // 50MB
-export const MAX_FILE_COUNT = 5;
-export const SUPPORTED_MIME_TYPES = ["image/png", "image/jpeg", "image/gif", "image/webp"];
+const MAX_FILE_SIZE = 25 * 1024 * 1024; // 25MB
+const MAX_TOTAL_SIZE = 50 * 1024 * 1024; // 50MB
+const MAX_FILE_COUNT = 5;
+const SUPPORTED_MIME_TYPES = ["image/png", "image/jpeg", "image/gif", "image/webp"];
 
 export interface AttachmentValidationResult {
   isValid: boolean;

--- a/tests/e2e/image-attachments/image-attachments.spec.ts
+++ b/tests/e2e/image-attachments/image-attachments.spec.ts
@@ -1,0 +1,139 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Image Attachments E2E", () => {
+  
+  test("should upload and attach images in chat widget", async ({ page }) => {
+    // Navigate to the chat widget settings page
+    await page.goto('/mailboxes/gumroad/settings/chat');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(3000);
+    
+    // First, ensure the chat widget is enabled by checking the switch
+    const chatVisibilitySection = page.locator('text="Chat Icon Visibility"').locator('..');
+    const chatSwitch = chatVisibilitySection.locator('button[role="switch"]');
+    
+    // Check if the switch is already enabled, if not, click it
+    const switchState = await chatSwitch.getAttribute('data-state');
+    if (switchState === 'unchecked') {
+      await chatSwitch.click();
+      await page.waitForTimeout(2000);
+    }
+    
+    // Now look for the widget icon that should appear after enabling
+    const widgetIcon = page.locator('.helper-widget-icon');
+    await expect(widgetIcon).toBeVisible({ timeout: 15000 });
+    
+    // Click to open the widget
+    await widgetIcon.click();
+    await page.waitForTimeout(2000);
+    
+    // Now find the chat input - it should be visible after opening the widget
+    const chatInput = page.locator('textarea[aria-label="Ask a question"]');
+    await expect(chatInput).toBeVisible({ timeout: 15000 });
+    
+    // Find the attachment button (paperclip icon)
+    const attachButton = page.locator('label[aria-label="Attach images"]');
+    await expect(attachButton).toBeVisible();
+    
+    // Create a small test image file
+    const imageBuffer = Buffer.from(
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==',
+      'base64'
+    );
+    
+    // Upload the image file via the hidden file input
+    const fileInput = page.locator('input[type="file"][accept="image/*"]');
+    await fileInput.setInputFiles({
+      name: 'test-image.png',
+      mimeType: 'image/png',
+      buffer: imageBuffer
+    });
+    
+    // Wait a moment for the file to be processed
+    await page.waitForTimeout(1000);
+    
+    // Verify the attachment appears in the preview
+    // Look for the filename in the attachment preview
+    await expect(page.getByText('test-image.png')).toBeVisible({ timeout: 5000 });
+    
+    // Type a message
+    await chatInput.fill('Here is an image attachment for testing');
+    
+    // Submit the message
+    const submitButton = page.locator('button[type="submit"]');
+    await submitButton.click();
+    
+    // Verify the message was sent - look for the message content in the conversation
+    await expect(page.getByText('Here is an image attachment for testing')).toBeVisible({ timeout: 15000 });
+    
+    console.log('✅ Image attachment uploaded and message sent successfully');
+  });
+
+  test("should support multiple image formats", async ({ page }) => {
+    // Navigate to the chat widget settings page
+    await page.goto('/mailboxes/gumroad/settings/chat');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(3000);
+    
+    // First, ensure the chat widget is enabled by checking the switch
+    const chatVisibilitySection = page.locator('text="Chat Icon Visibility"').locator('..');
+    const chatSwitch = chatVisibilitySection.locator('button[role="switch"]');
+    
+    // Check if the switch is already enabled, if not, click it
+    const switchState = await chatSwitch.getAttribute('data-state');
+    if (switchState === 'unchecked') {
+      await chatSwitch.click();
+      await page.waitForTimeout(2000);
+    }
+    
+    // Now look for the widget icon that should appear after enabling
+    const widgetIcon = page.locator('.helper-widget-icon');
+    await expect(widgetIcon).toBeVisible({ timeout: 15000 });
+    
+    // Click to open the widget
+    await widgetIcon.click();
+    await page.waitForTimeout(2000);
+    
+    const chatInput = page.locator('textarea[aria-label="Ask a question"]');
+    await expect(chatInput).toBeVisible({ timeout: 15000 });
+    
+    // Test PNG format
+    const pngBuffer = Buffer.from(
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==',
+      'base64'
+    );
+    
+    const fileInput = page.locator('input[type="file"][accept="image/*"]');
+    await fileInput.setInputFiles({
+      name: 'test.png',
+      mimeType: 'image/png',
+      buffer: pngBuffer
+    });
+    
+    // Verify PNG appears
+    await expect(page.getByText('test.png')).toBeVisible({ timeout: 5000 });
+    
+    // Test JPEG format
+    const jpegBuffer = Buffer.from(
+      '/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAABAAEDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAv/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFQEBAQAAAAAAAAAAAAAAAAAAAAX/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIRAxEAPwCdABmX/9k=',
+      'base64'
+    );
+    
+    await fileInput.setInputFiles({
+      name: 'test.jpg',
+      mimeType: 'image/jpeg', 
+      buffer: jpegBuffer
+    });
+    
+    // Verify JPEG appears
+    await expect(page.getByText('test.jpg')).toBeVisible({ timeout: 5000 });
+    
+    // Send message with multiple formats
+    await chatInput.fill('Testing multiple image formats');
+    await page.locator('button[type="submit"]').click();
+    
+    await expect(page.getByText('Testing multiple image formats')).toBeVisible({ timeout: 15000 });
+    
+    console.log('✅ Multiple image formats supported');
+  });
+});

--- a/tests/e2e/image-attachments/image-attachments.spec.ts
+++ b/tests/e2e/image-attachments/image-attachments.spec.ts
@@ -15,16 +15,16 @@ test.describe("Image Attachments E2E", () => {
 
     // Click to open the widget
     await widgetIcon.click();
-    
+
     // Wait for the widget to open - it might be in an iframe or shadow DOM
     await page.waitForTimeout(2000);
-    
+
     // Try to find the chat widget container first
     const widgetContainer = page.locator('[class*="helper-widget"]').first();
     await expect(widgetContainer).toBeVisible({ timeout: 10000 });
 
     // Wait for the widget iframe to load and grab its frame locator
-    const widgetFrame = page.frameLocator('iframe.helper-widget-iframe');
+    const widgetFrame = page.frameLocator("iframe.helper-widget-iframe");
 
     // Now find the chat input - it should be visible inside the iframe
     const chatInput = widgetFrame.locator('textarea[aria-label="Ask a question"]');
@@ -79,16 +79,16 @@ test.describe("Image Attachments E2E", () => {
 
     // Click to open the widget
     await widgetIcon.click();
-    
+
     // Wait for the widget to open
     await page.waitForTimeout(2000);
-    
+
     // Try to find the chat widget container first
     const widgetContainer = page.locator('[class*="helper-widget"]').first();
     await expect(widgetContainer).toBeVisible({ timeout: 10000 });
 
     // Wait for the widget iframe to load and grab its frame locator
-    const widgetFrame = page.frameLocator('iframe.helper-widget-iframe');
+    const widgetFrame = page.frameLocator("iframe.helper-widget-iframe");
     const chatInput = widgetFrame.locator('textarea[aria-label="Ask a question"]');
     await expect(chatInput).toBeVisible({ timeout: 15000 });
 

--- a/tests/e2e/image-attachments/image-attachments.spec.ts
+++ b/tests/e2e/image-attachments/image-attachments.spec.ts
@@ -1,139 +1,138 @@
-import { test, expect } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
 test.describe("Image Attachments E2E", () => {
-  
   test("should upload and attach images in chat widget", async ({ page }) => {
     // Navigate to the chat widget settings page
-    await page.goto('/mailboxes/gumroad/settings/chat');
-    await page.waitForLoadState('networkidle');
+    await page.goto("/mailboxes/gumroad/settings/chat");
+    await page.waitForLoadState("networkidle");
     await page.waitForTimeout(3000);
-    
+
     // First, ensure the chat widget is enabled by checking the switch
-    const chatVisibilitySection = page.locator('text="Chat Icon Visibility"').locator('..');
+    const chatVisibilitySection = page.locator('text="Chat Icon Visibility"').locator("..");
     const chatSwitch = chatVisibilitySection.locator('button[role="switch"]');
-    
+
     // Check if the switch is already enabled, if not, click it
-    const switchState = await chatSwitch.getAttribute('data-state');
-    if (switchState === 'unchecked') {
+    const switchState = await chatSwitch.getAttribute("data-state");
+    if (switchState === "unchecked") {
       await chatSwitch.click();
       await page.waitForTimeout(2000);
     }
-    
+
     // Now look for the widget icon that should appear after enabling
-    const widgetIcon = page.locator('.helper-widget-icon');
+    const widgetIcon = page.locator(".helper-widget-icon");
     await expect(widgetIcon).toBeVisible({ timeout: 15000 });
-    
+
     // Click to open the widget
     await widgetIcon.click();
     await page.waitForTimeout(2000);
-    
+
     // Now find the chat input - it should be visible after opening the widget
     const chatInput = page.locator('textarea[aria-label="Ask a question"]');
     await expect(chatInput).toBeVisible({ timeout: 15000 });
-    
+
     // Find the attachment button (paperclip icon)
     const attachButton = page.locator('label[aria-label="Attach images"]');
     await expect(attachButton).toBeVisible();
-    
+
     // Create a small test image file
     const imageBuffer = Buffer.from(
-      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==',
-      'base64'
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==",
+      "base64",
     );
-    
+
     // Upload the image file via the hidden file input
     const fileInput = page.locator('input[type="file"][accept="image/*"]');
     await fileInput.setInputFiles({
-      name: 'test-image.png',
-      mimeType: 'image/png',
-      buffer: imageBuffer
+      name: "test-image.png",
+      mimeType: "image/png",
+      buffer: imageBuffer,
     });
-    
+
     // Wait a moment for the file to be processed
     await page.waitForTimeout(1000);
-    
+
     // Verify the attachment appears in the preview
     // Look for the filename in the attachment preview
-    await expect(page.getByText('test-image.png')).toBeVisible({ timeout: 5000 });
-    
+    await expect(page.getByText("test-image.png")).toBeVisible({ timeout: 5000 });
+
     // Type a message
-    await chatInput.fill('Here is an image attachment for testing');
-    
+    await chatInput.fill("Here is an image attachment for testing");
+
     // Submit the message
     const submitButton = page.locator('button[type="submit"]');
     await submitButton.click();
-    
+
     // Verify the message was sent - look for the message content in the conversation
-    await expect(page.getByText('Here is an image attachment for testing')).toBeVisible({ timeout: 15000 });
-    
-    console.log('✅ Image attachment uploaded and message sent successfully');
+    await expect(page.getByText("Here is an image attachment for testing")).toBeVisible({ timeout: 15000 });
+
+    console.log("✅ Image attachment uploaded and message sent successfully");
   });
 
   test("should support multiple image formats", async ({ page }) => {
     // Navigate to the chat widget settings page
-    await page.goto('/mailboxes/gumroad/settings/chat');
-    await page.waitForLoadState('networkidle');
+    await page.goto("/mailboxes/gumroad/settings/chat");
+    await page.waitForLoadState("networkidle");
     await page.waitForTimeout(3000);
-    
+
     // First, ensure the chat widget is enabled by checking the switch
-    const chatVisibilitySection = page.locator('text="Chat Icon Visibility"').locator('..');
+    const chatVisibilitySection = page.locator('text="Chat Icon Visibility"').locator("..");
     const chatSwitch = chatVisibilitySection.locator('button[role="switch"]');
-    
+
     // Check if the switch is already enabled, if not, click it
-    const switchState = await chatSwitch.getAttribute('data-state');
-    if (switchState === 'unchecked') {
+    const switchState = await chatSwitch.getAttribute("data-state");
+    if (switchState === "unchecked") {
       await chatSwitch.click();
       await page.waitForTimeout(2000);
     }
-    
+
     // Now look for the widget icon that should appear after enabling
-    const widgetIcon = page.locator('.helper-widget-icon');
+    const widgetIcon = page.locator(".helper-widget-icon");
     await expect(widgetIcon).toBeVisible({ timeout: 15000 });
-    
+
     // Click to open the widget
     await widgetIcon.click();
     await page.waitForTimeout(2000);
-    
+
     const chatInput = page.locator('textarea[aria-label="Ask a question"]');
     await expect(chatInput).toBeVisible({ timeout: 15000 });
-    
+
     // Test PNG format
     const pngBuffer = Buffer.from(
-      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==',
-      'base64'
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==",
+      "base64",
     );
-    
+
     const fileInput = page.locator('input[type="file"][accept="image/*"]');
     await fileInput.setInputFiles({
-      name: 'test.png',
-      mimeType: 'image/png',
-      buffer: pngBuffer
+      name: "test.png",
+      mimeType: "image/png",
+      buffer: pngBuffer,
     });
-    
+
     // Verify PNG appears
-    await expect(page.getByText('test.png')).toBeVisible({ timeout: 5000 });
-    
+    await expect(page.getByText("test.png")).toBeVisible({ timeout: 5000 });
+
     // Test JPEG format
     const jpegBuffer = Buffer.from(
-      '/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAABAAEDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAv/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFQEBAQAAAAAAAAAAAAAAAAAAAAX/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIRAxEAPwCdABmX/9k=',
-      'base64'
+      "/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAABAAEDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAv/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFQEBAQAAAAAAAAAAAAAAAAAAAAX/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIRAxEAPwCdABmX/9k=",
+      "base64",
     );
-    
+
     await fileInput.setInputFiles({
-      name: 'test.jpg',
-      mimeType: 'image/jpeg', 
-      buffer: jpegBuffer
+      name: "test.jpg",
+      mimeType: "image/jpeg",
+      buffer: jpegBuffer,
     });
-    
+
     // Verify JPEG appears
-    await expect(page.getByText('test.jpg')).toBeVisible({ timeout: 5000 });
-    
+    await expect(page.getByText("test.jpg")).toBeVisible({ timeout: 5000 });
+
     // Send message with multiple formats
-    await chatInput.fill('Testing multiple image formats');
+    await chatInput.fill("Testing multiple image formats");
     await page.locator('button[type="submit"]').click();
-    
-    await expect(page.getByText('Testing multiple image formats')).toBeVisible({ timeout: 15000 });
-    
-    console.log('✅ Multiple image formats supported');
+
+    await expect(page.getByText("Testing multiple image formats")).toBeVisible({ timeout: 15000 });
+
+    console.log("✅ Multiple image formats supported");
   });
 });

--- a/tests/e2e/image-attachments/image-attachments.spec.ts
+++ b/tests/e2e/image-attachments/image-attachments.spec.ts
@@ -1,37 +1,37 @@
 import { expect, test } from "@playwright/test";
 
+// Use the working authentication
+test.use({ storageState: "tests/e2e/.auth/user.json" });
+
 test.describe("Image Attachments E2E", () => {
   test("should upload and attach images in chat widget", async ({ page }) => {
-    // Navigate to the chat widget settings page
-    await page.goto("/mailboxes/gumroad/settings/chat");
+    // Navigate to the in-app chat settings page where the widget is available
+    await page.goto("/settings/in-app-chat");
     await page.waitForLoadState("networkidle");
-    await page.waitForTimeout(3000);
 
-    // First, ensure the chat widget is enabled by checking the switch
-    const chatVisibilitySection = page.locator('text="Chat Icon Visibility"').locator("..");
-    const chatSwitch = chatVisibilitySection.locator('button[role="switch"]');
-
-    // Check if the switch is already enabled, if not, click it
-    const switchState = await chatSwitch.getAttribute("data-state");
-    if (switchState === "unchecked") {
-      await chatSwitch.click();
-      await page.waitForTimeout(2000);
-    }
-
-    // Now look for the widget icon that should appear after enabling
+    // Look for the widget icon
     const widgetIcon = page.locator(".helper-widget-icon");
     await expect(widgetIcon).toBeVisible({ timeout: 15000 });
 
     // Click to open the widget
     await widgetIcon.click();
+    
+    // Wait for the widget to open - it might be in an iframe or shadow DOM
     await page.waitForTimeout(2000);
+    
+    // Try to find the chat widget container first
+    const widgetContainer = page.locator('[class*="helper-widget"]').first();
+    await expect(widgetContainer).toBeVisible({ timeout: 10000 });
 
-    // Now find the chat input - it should be visible after opening the widget
-    const chatInput = page.locator('textarea[aria-label="Ask a question"]');
+    // Wait for the widget iframe to load and grab its frame locator
+    const widgetFrame = page.frameLocator('iframe.helper-widget-iframe');
+
+    // Now find the chat input - it should be visible inside the iframe
+    const chatInput = widgetFrame.locator('textarea[aria-label="Ask a question"]');
     await expect(chatInput).toBeVisible({ timeout: 15000 });
 
     // Find the attachment button (paperclip icon)
-    const attachButton = page.locator('label[aria-label="Attach images"]');
+    const attachButton = widgetFrame.locator('label[aria-label="Attach images"]');
     await expect(attachButton).toBeVisible();
 
     // Create a small test image file
@@ -41,7 +41,7 @@ test.describe("Image Attachments E2E", () => {
     );
 
     // Upload the image file via the hidden file input
-    const fileInput = page.locator('input[type="file"][accept="image/*"]');
+    const fileInput = widgetFrame.locator('input[type="file"][accept="image/*"]');
     await fileInput.setInputFiles({
       name: "test-image.png",
       mimeType: "image/png",
@@ -53,47 +53,43 @@ test.describe("Image Attachments E2E", () => {
 
     // Verify the attachment appears in the preview
     // Look for the filename in the attachment preview
-    await expect(page.getByText("test-image.png")).toBeVisible({ timeout: 5000 });
+    await expect(widgetFrame.getByText("test-image.png")).toBeVisible({ timeout: 5000 });
 
     // Type a message
     await chatInput.fill("Here is an image attachment for testing");
 
     // Submit the message
-    const submitButton = page.locator('button[type="submit"]');
+    const submitButton = widgetFrame.locator('button[type="submit"]');
     await submitButton.click();
 
     // Verify the message was sent - look for the message content in the conversation
-    await expect(page.getByText("Here is an image attachment for testing")).toBeVisible({ timeout: 15000 });
+    await expect(widgetFrame.getByText("Here is an image attachment for testing")).toBeVisible({ timeout: 15000 });
 
     console.log("✅ Image attachment uploaded and message sent successfully");
   });
 
   test("should support multiple image formats", async ({ page }) => {
-    // Navigate to the chat widget settings page
-    await page.goto("/mailboxes/gumroad/settings/chat");
+    // Navigate to the in-app chat settings page where the widget is available
+    await page.goto("/settings/in-app-chat");
     await page.waitForLoadState("networkidle");
-    await page.waitForTimeout(3000);
 
-    // First, ensure the chat widget is enabled by checking the switch
-    const chatVisibilitySection = page.locator('text="Chat Icon Visibility"').locator("..");
-    const chatSwitch = chatVisibilitySection.locator('button[role="switch"]');
-
-    // Check if the switch is already enabled, if not, click it
-    const switchState = await chatSwitch.getAttribute("data-state");
-    if (switchState === "unchecked") {
-      await chatSwitch.click();
-      await page.waitForTimeout(2000);
-    }
-
-    // Now look for the widget icon that should appear after enabling
+    // Look for the widget icon
     const widgetIcon = page.locator(".helper-widget-icon");
     await expect(widgetIcon).toBeVisible({ timeout: 15000 });
 
     // Click to open the widget
     await widgetIcon.click();
+    
+    // Wait for the widget to open
     await page.waitForTimeout(2000);
+    
+    // Try to find the chat widget container first
+    const widgetContainer = page.locator('[class*="helper-widget"]').first();
+    await expect(widgetContainer).toBeVisible({ timeout: 10000 });
 
-    const chatInput = page.locator('textarea[aria-label="Ask a question"]');
+    // Wait for the widget iframe to load and grab its frame locator
+    const widgetFrame = page.frameLocator('iframe.helper-widget-iframe');
+    const chatInput = widgetFrame.locator('textarea[aria-label="Ask a question"]');
     await expect(chatInput).toBeVisible({ timeout: 15000 });
 
     // Test PNG format
@@ -102,7 +98,7 @@ test.describe("Image Attachments E2E", () => {
       "base64",
     );
 
-    const fileInput = page.locator('input[type="file"][accept="image/*"]');
+    const fileInput = widgetFrame.locator('input[type="file"][accept="image/*"]');
     await fileInput.setInputFiles({
       name: "test.png",
       mimeType: "image/png",
@@ -110,7 +106,7 @@ test.describe("Image Attachments E2E", () => {
     });
 
     // Verify PNG appears
-    await expect(page.getByText("test.png")).toBeVisible({ timeout: 5000 });
+    await expect(widgetFrame.getByText("test.png")).toBeVisible({ timeout: 5000 });
 
     // Test JPEG format
     const jpegBuffer = Buffer.from(
@@ -125,13 +121,13 @@ test.describe("Image Attachments E2E", () => {
     });
 
     // Verify JPEG appears
-    await expect(page.getByText("test.jpg")).toBeVisible({ timeout: 5000 });
+    await expect(widgetFrame.getByText("test.jpg")).toBeVisible({ timeout: 5000 });
 
     // Send message with multiple formats
     await chatInput.fill("Testing multiple image formats");
-    await page.locator('button[type="submit"]').click();
+    await widgetFrame.locator('button[type="submit"]').click();
 
-    await expect(page.getByText("Testing multiple image formats")).toBeVisible({ timeout: 15000 });
+    await expect(widgetFrame.getByText("Testing multiple image formats")).toBeVisible({ timeout: 15000 });
 
     console.log("✅ Multiple image formats supported");
   });


### PR DESCRIPTION
## Summary
Implements the feature request from [issue #736](https://github.com/antiwork/helper/issues/736) to allow users to upload multiple images through the chat widget before escalation to human support.

## What's Changed
- Added attachment button (📎) to chat input alongside existing microphone button
- Enabled multiple image file selection via file dialog
- Added drag-and-drop functionality for image uploads
- Implemented file preview with individual removal options
- Extended backend API to process multiple image attachments
- Maintained backward compatibility with existing screenshot functionality

## Architecture Overview

```
┌─────────────────┐    ┌──────────────────┐    ┌─────────────────┐
│   Chat Widget   │───▶│   Chat API       │───▶│  File Storage   │
│                 │    │                  │    │                 │
│ • File Input    │    │ • Multi-image    │    │ • Supabase      │
│ • Drag & Drop   │    │   validation     │    │ • File URLs     │
│ • File Preview  │    │ • Base64 convert │    │ • Attachments   │
│ • Screenshot    │    │ • createUserMsg  │    │                 │
└─────────────────┘    └──────────────────┘    └─────────────────┘
```

## User Experience
- Users can now click the paperclip icon to select multiple images
- Drag and drop images directly onto the chat input area
- See selected files as removable pills before sending
- Existing screenshot suggestions still work for troubleshooting keywords
- All images are properly attached to the conversation for human escalation

## Demo Video Recordings Needed

**📹 Recording 1: Basic File Upload Flow**

https://github.com/user-attachments/assets/e7a56d73-e0e9-4b44-9b48-d4080dd34faa


**📹 Recording 2: Drag & Drop Functionality** 

https://github.com/user-attachments/assets/1c624fad-d544-440a-a929-2bc5d4a48da8

---

## Testing
- ✅ Lint and type checking passed
- ✅ Build process successful
- ✅ Backward compatibility maintained
- ✅ e2e tests also added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added support for attaching multiple image files (PNG, JPEG, GIF, WEBP) to chat messages via file picker or drag-and-drop in the chat input.
  * Attached images are displayed below the chat input with options to remove individual files before sending.

* **Enhancements**
  * All image attachments, including screenshots and uploads, are now sent and processed together in chat messages.
  * Attachment display updated to open images via accessible buttons that open images in new tabs or trigger downloads with improved styling.
  * Chat widget visibility updates immediately when toggled in settings.
  * Improved attachment validation with detailed error messages and enforced limits on file count and size.

* **Bug Fixes**
  * Enforced validation to allow only valid image files and size limits for attachments.

* **Chores**
  * Updated `.gitignore` to exclude `CLAUDE.md` from version control.

* **Tests**
  * Added end-to-end tests verifying image upload functionality and multiple image format support in the chat widget.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->