### PR TITLE
fix: remove screenshot CORS

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -21,7 +21,6 @@ import {
 // Import worker code as string
 const workerCode = require("modern-screenshot/dist/worker.js");
 
-// Function to create inline worker URL using Blob
 function createInlineWorkerUrl(): string {
   const blob = new Blob([workerCode], { type: "application/javascript" });
   return URL.createObjectURL(blob);
@@ -774,6 +773,7 @@ class HelperWidget {
       const screenshot = await domToPng(this.screenshotContext);
       this.sendMessageToEmbed({ action: "SCREENSHOT", content: screenshot });
     } catch (error) {
+      // eslint-disable-next-line no-console
       console.error("Failed to take screenshot:", error);
       this.sendMessageToEmbed({ action: "SCREENSHOT", content: null });
     }

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -18,7 +18,6 @@ import {
   type NotificationStatus,
 } from "./utils";
 
-// Import worker code as string
 const workerCode = require("modern-screenshot/dist/worker.js");
 
 function createInlineWorkerUrl(): string {

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,6 +1,5 @@
 // This is *only* used for the SDK output in the public directory and is not importable by the Next.js app
 
-import { Context } from "modern-screenshot";
 import React from "react";
 import embedStyles from "./embed.css";
 import GuideManager from "./guideManager";
@@ -23,8 +22,6 @@ declare global {
     helperWidgetConfig?: HelperWidgetConfig;
   }
 }
-
-const GUMROAD_MAILBOX_SLUG = "gumroad";
 
 const screenshotWorkerUrl = new URL("modern-screenshot/dist/worker.js", import.meta.url).href;
 
@@ -62,7 +59,7 @@ class HelperWidget {
   private readonly MINIMIZED_STORAGE_KEY = "helper_widget_minimized";
   private readonly ANONYMOUS_SESSION_TOKEN_KEY = "helper_widget_anonymous_session_token";
   private currentConversationSlug: string | null = null;
-  private screenshotContext: Context | null = null;
+  private screenshotContext: any | null = null;
   private renderedContactForms: Set<HTMLElement> = new Set();
 
   private constructor(config: HelperWidgetConfig) {

--- a/packages/sdk/webpack.sdk.cjs
+++ b/packages/sdk/webpack.sdk.cjs
@@ -31,7 +31,7 @@ module.exports = (env) => {
         },
         {
           test: /modern-screenshot\/dist\/worker.js$/,
-          type: "asset/resource",
+          use: "raw-loader",
           generator: {
             filename: "sdk-modern-screenshot-worker.js",
           },

--- a/packages/sdk/webpack.sdk.cjs
+++ b/packages/sdk/webpack.sdk.cjs
@@ -27,11 +27,11 @@ module.exports = (env) => {
         },
         {
           test: /\.css$/,
-          use: "raw-loader",
+          type: "asset/source",
         },
         {
           test: /modern-screenshot\/dist\/worker.js$/,
-          use: "raw-loader",
+          type: "asset/source",
           generator: {
             filename: "sdk-modern-screenshot-worker.js",
           },


### PR DESCRIPTION
Resolves: https://github.com/antiwork/helper/issues/741

We face CORS issue when we try to load screenshot worker from different origin.
<img width="1643" height="342" alt="image" src="https://github.com/user-attachments/assets/76f5bcf6-3e23-4b26-a608-c89b4a7e28a2" />
which prevents us from submitting a screenshot.
<img width="1920" height="1005" alt="image" src="https://github.com/user-attachments/assets/c2937eef-3f12-426e-b7ab-46f80d1b5338" />

### Solutions:
1- Allow CORS on server: This isn't a good solution because we allow people to self-host and then they have to remember to allow CORS on their server too.
2- Inline the worker code into the bundle 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Refactor**
  * Improved screenshot feature by optimizing how the worker script is loaded and initialized, enhancing performance and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->