### PR TITLE
Make isMinimized a widget config param

### DIFF
--- a/app/widget/embed/page.tsx
+++ b/app/widget/embed/page.tsx
@@ -5,7 +5,7 @@ import cx from "classnames";
 import { jwtDecode } from "jwt-decode";
 import { domAnimation, LazyMotion, m } from "motion/react";
 import { useCallback, useEffect, useState } from "react";
-import { HelperWidgetConfig, MESSAGE_TYPE, RESUME_GUIDE } from "@helperai/sdk";
+import { MESSAGE_TYPE, RESUME_GUIDE } from "@helperai/sdk";
 import Conversation from "@/components/widget/Conversation";
 import { eventBus, messageQueue } from "@/components/widget/eventBus";
 import Header, { WidgetHeaderConfig } from "@/components/widget/Header";
@@ -29,7 +29,7 @@ const queryClient = new QueryClient();
 
 export default function Page() {
   const [token, setToken] = useState<string | null>(null);
-  const [config, setConfig] = useState<HelperWidgetConfig | null>(null);
+  const [config, setConfig] = useState<WidgetHeaderConfig | null>(null);
   const [defaultTitle, setDefaultTitle] = useState<string | null>(null);
   const [currentURL, setCurrentURL] = useState<string | null>(null);
   const [selectedConversationSlug, setSelectedConversationSlug] = useState<string | null>(null);
@@ -145,7 +145,7 @@ export default function Page() {
         })}
       >
         <Header
-          config={config as WidgetHeaderConfig}
+          config={config}
           onShowPreviousConversations={onShowPreviousConversations}
           onNewConversation={memoizedHandleNewConversation}
           title={headerTitle}

--- a/app/widget/embed/page.tsx
+++ b/app/widget/embed/page.tsx
@@ -8,7 +8,7 @@ import { useCallback, useEffect, useState } from "react";
 import { HelperWidgetConfig, MESSAGE_TYPE, RESUME_GUIDE } from "@helperai/sdk";
 import Conversation from "@/components/widget/Conversation";
 import { eventBus, messageQueue } from "@/components/widget/eventBus";
-import Header from "@/components/widget/Header";
+import Header, { WidgetHeaderConfig } from "@/components/widget/Header";
 import { useReadPageTool } from "@/components/widget/hooks/useReadPageTool";
 import PreviousConversations from "@/components/widget/PreviousConversations";
 import PromptDetailsModal from "@/components/widget/PromptDetailsModal";
@@ -145,7 +145,7 @@ export default function Page() {
         })}
       >
         <Header
-          config={config}
+          config={config as WidgetHeaderConfig}
           onShowPreviousConversations={onShowPreviousConversations}
           onNewConversation={memoizedHandleNewConversation}
           title={headerTitle}

--- a/components/widget/Header.tsx
+++ b/components/widget/Header.tsx
@@ -4,8 +4,12 @@ import { HelperWidgetConfig } from "@helperai/sdk";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { closeWidget, toggleWidgetHeight } from "@/lib/widget/messages";
 
+export type WidgetHeaderConfig = HelperWidgetConfig & {
+  isMinimized?: boolean;
+};
+
 type Props = {
-  config: HelperWidgetConfig;
+  config: WidgetHeaderConfig;
   onShowPreviousConversations: () => void;
   onNewConversation: () => void;
   title: string;

--- a/components/widget/Header.tsx
+++ b/components/widget/Header.tsx
@@ -19,13 +19,17 @@ const NewChatIcon = React.memo(() => (
 ));
 
 const Header = React.memo(function Header({ config, onShowPreviousConversations, onNewConversation, title }: Props) {
-  const [isMaximized, setIsMaximized] = React.useState(() => {
-    return localStorage.getItem("helper_widget_minimized") !== "true";
+  const [isMinimized, setIsMinimized] = React.useState(() => {
+    return config.isMinimized === true;
   });
 
+  React.useEffect(() => {
+    setIsMinimized(config.isMinimized === true);
+  }, [config.isMinimized]);
+
   const handleToggleHeight = () => {
-    const newState = !isMaximized;
-    setIsMaximized(newState);
+    const newState = !isMinimized;
+    setIsMinimized(newState);
     toggleWidgetHeight();
   };
 
@@ -70,12 +74,12 @@ const Header = React.memo(function Header({ config, onShowPreviousConversations,
                 <button
                   className="text-primary hover:text-muted-foreground p-1 rounded-full hover:bg-muted"
                   onClick={handleToggleHeight}
-                  aria-label={isMaximized ? "Minimize widget" : "Maximize widget"}
+                  aria-label={isMinimized ? "Maximize widget" : "Minimize widget"}
                 >
-                  {isMaximized ? <Minimize2 className="h-5 w-5" /> : <Maximize2 className="h-5 w-5" />}
+                  {isMinimized ? <Maximize2 className="h-5 w-5" /> : <Minimize2 className="h-5 w-5" />}
                 </button>
               </TooltipTrigger>
-              <TooltipContent>{isMaximized ? "Minimize" : "Maximize"}</TooltipContent>
+              <TooltipContent>{isMinimized ? "Maximize" : "Minimize"}</TooltipContent>
             </Tooltip>
           )}
           <Tooltip>

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -304,7 +304,7 @@ class HelperWidget {
         this.sendMessageToEmbed({
           action: "CONFIG",
           content: {
-            config: { ...this.config, viewportWidth: window.innerWidth },
+            config: { ...this.config, viewportWidth: window.innerWidth, isMinimized: this.isMinimized },
             sessionToken: this.sessionToken,
             pageHTML: document.documentElement.outerHTML,
             currentURL: window.location.href,
@@ -450,7 +450,7 @@ class HelperWidget {
     this.sendMessageToEmbed({
       action: "CONFIG",
       content: {
-        config: { ...this.config, viewportWidth: window.innerWidth },
+        config: { ...this.config, viewportWidth: window.innerWidth, isMinimized: this.isMinimized },
         sessionToken: this.sessionToken,
         pageHTML: document.documentElement.outerHTML,
         currentURL: window.location.href,
@@ -657,6 +657,7 @@ class HelperWidget {
       if (this.toggleButton) {
         this.toggleButton.classList.add("with-minimized-widget");
       }
+      this.initFrameConfig();
     }
   }
 
@@ -672,6 +673,7 @@ class HelperWidget {
       if (this.toggleButton) {
         this.toggleButton.classList.remove("with-minimized-widget");
       }
+      this.initFrameConfig();
     }
   }
 

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -23,7 +23,6 @@ export type HelperWidgetConfig = {
     accent: string;
   };
   viewportWidth?: number;
-  isMinimized?: boolean;
 };
 
 export type ReadPageToolConfig = {

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -23,6 +23,7 @@ export type HelperWidgetConfig = {
     accent: string;
   };
   viewportWidth?: number;
+  isMinimized?: boolean;
 };
 
 export type ReadPageToolConfig = {


### PR DESCRIPTION
Solves #746 

## Problem
The widget (in [Header.tsx](./components/widget/Header.tsx)) is deriving the `isMaximized` state from the localStorage, similarly as the SDK does. However, the SDK and the widget are running in different contexts:
- `index.ts` runs in the parent page's context and can access the parent's localStorage
- `Header.tsx` runs inside an iframe and has its own isolated localStorage, so it can't access keys stored by the SDK.

## Solution
Instead of relying on localStorage to fetch the maximized/minimized state, pass it as a new config param.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The widget header now supports a minimized state, allowing users to minimize or maximize the widget as needed.
  * The minimized state is synchronized between the host page and the embedded widget for a consistent experience.

* **Accessibility & UI Improvements**
  * Updated aria-labels, icons, and tooltips to accurately reflect the minimized/maximized state for improved accessibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->