### PR TITLE
fix: remove layout shift on marketing page

### DIFF
--- a/packages/marketing/app/page.tsx
+++ b/packages/marketing/app/page.tsx
@@ -123,20 +123,28 @@ export default function Home() {
       <div className="flex-grow">
         <section className="flex items-center justify-center h-dvh pt-20">
           <div className="container mx-auto px-4">
-            <h1 className="text-5xl sm:text-6xl font-bold mb-24 text-center text-secondary dark:text-foreground">
+            <h1 className="text-5xl sm:text-6xl font-bold mb-12 sm:mb-24 text-center text-secondary dark:text-foreground">
               Helper helps customers help themselves.
             </h1>
 
             <div className="max-w-lg mx-auto">
               {showCustomerMessage && (
                 <motion.div
-                  className="flex justify-end mb-8"
-                  initial={{ opacity: 0, y: 20 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  transition={{ duration: 0.5 }}
+                  className="flex justify-end mb-4 sm:mb-8"
+                  initial={{ opacity: 0, y: 20, height: 0 }}
+                  animate={{ opacity: 1, y: 0, height: "auto" }}
+                  transition={{ duration: 0.5, height: { duration: 0.6, ease: "easeOut" } }}
+                  style={{ overflow: "hidden" }}
+                  layout
                 >
                   <div className="max-w-md w-full">
-                    <div className="bg-[rgba(99,72,71,0.3)] rounded-t-2xl rounded-bl-2xl p-6 shadow-md min-h-[80px] flex items-center">
+                    <motion.div
+                      className="bg-[rgba(99,72,71,0.3)] rounded-t-2xl rounded-bl-2xl p-6 shadow-md min-h-[80px] flex items-center"
+                      initial={{ height: 0 }}
+                      animate={{ height: "auto" }}
+                      transition={{ duration: 0.6, ease: "easeOut" }}
+                      style={{ overflow: "hidden" }}
+                    >
                       {customerQuestions[currentQuestionIndex] && (
                         <AnimatedTyping
                           text={customerQuestions[currentQuestionIndex]}
@@ -144,7 +152,7 @@ export default function Home() {
                           onComplete={handleCustomerTypingComplete}
                         />
                       )}
-                    </div>
+                    </motion.div>
                     <div className="flex justify-end mt-2"></div>
                   </div>
                 </motion.div>
@@ -153,14 +161,20 @@ export default function Home() {
               {showHelperMessage && (
                 <motion.div
                   className="flex mb-8"
-                  initial={{ opacity: 0, y: 20 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  transition={{ duration: 0.5 }}
+                  initial={{ opacity: 0, y: 20, height: 0 }}
+                  animate={{ opacity: 1, y: 0, height: "auto" }}
+                  transition={{ duration: 0.5, height: { duration: 0.6, ease: "easeOut" } }}
+                  style={{ overflow: "hidden" }}
+                  layout
                 >
                   <div className="w-96">
-                    <div
+                    <motion.div
                       ref={helperMessageRef}
                       className="bg-[rgba(99,72,71,0.3)] rounded-t-2xl rounded-br-2xl p-6 shadow-md"
+                      initial={{ height: 0 }}
+                      animate={{ height: "auto" }}
+                      transition={{ duration: 0.6, ease: "easeOut" }}
+                      style={{ overflow: "hidden" }}
                     >
                       <AnimatedTyping
                         text="Let me show you how I can help..."
@@ -170,9 +184,10 @@ export default function Home() {
                       {showHelperButton && (
                         <motion.div
                           className="mt-4"
-                          initial={{ opacity: 0, y: 10 }}
-                          animate={{ opacity: 1, y: 0 }}
-                          transition={{ duration: 0.3, delay: 0.2 }}
+                          initial={{ opacity: 0, y: 10, height: 0 }}
+                          animate={{ opacity: 1, y: 0, height: "auto" }}
+                          transition={{ duration: 0.3, delay: 0.2, height: { duration: 0.4, ease: "easeOut" } }}
+                          style={{ overflow: "hidden" }}
                         >
                           <Button
                             ref={showMeButtonRef}
@@ -183,12 +198,18 @@ export default function Home() {
                           </Button>
                         </motion.div>
                       )}
-                    </div>
-                    <div className="flex justify-start mt-2">
+                    </motion.div>
+                    <motion.div
+                      className="flex justify-start mt-2"
+                      initial={{ opacity: 0, height: 0 }}
+                      animate={{ opacity: 1, height: "auto" }}
+                      transition={{ duration: 0.4, delay: 0.3, height: { duration: 0.4, ease: "easeOut" } }}
+                      style={{ overflow: "hidden" }}
+                    >
                       <div className="w-8 h-8">
                         <LogoIconAmber />
                       </div>
-                    </div>
+                    </motion.div>
                   </div>
                 </motion.div>
               )}


### PR DESCRIPTION
before:

https://github.com/user-attachments/assets/135005f9-c1f9-497d-911c-ffca23f4d7b0

after:

https://github.com/user-attachments/assets/6d0586eb-394f-4d24-88da-077cdd696ac5








<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved vertical spacing and sizing in the hero section of the marketing page for better visual balance across different screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->