### PR TITLE
fix:added spam and closed count and removed reopen when status is open

### DIFF
--- a/app/(dashboard)/[category]/conversation/conversationContext.tsx
+++ b/app/(dashboard)/[category]/conversation/conversationContext.tsx
@@ -76,7 +76,7 @@ export const ConversationContextProvider = ({ children }: { children: React.Reac
       utils.mailbox.conversations.get.invalidate({
         conversationSlug: variables.conversationSlug,
       });
-      utils.mailbox.openCount.invalidate();
+      utils.mailbox.getCount.invalidate();
     },
   });
 

--- a/app/(dashboard)/[category]/conversation/conversationContext.tsx
+++ b/app/(dashboard)/[category]/conversation/conversationContext.tsx
@@ -76,6 +76,7 @@ export const ConversationContextProvider = ({ children }: { children: React.Reac
       utils.mailbox.conversations.get.invalidate({
         conversationSlug: variables.conversationSlug,
       });
+      utils.mailbox.openCount.invalidate();
     },
   });
 

--- a/app/(dashboard)/[category]/list/conversationList.tsx
+++ b/app/(dashboard)/[category]/list/conversationList.tsx
@@ -102,7 +102,7 @@ export const List = () => {
             clearSelectedConversations();
             void utils.mailbox.conversations.list.invalidate();
             void utils.mailbox.conversations.count.invalidate();
-            void utils.mailbox.openCount.invalidate();
+            void utils.mailbox.getCount.invalidate();
 
             if (updatedImmediately) {
               const ticketsText = allConversationsSelected

--- a/app/(dashboard)/[category]/list/conversationList.tsx
+++ b/app/(dashboard)/[category]/list/conversationList.tsx
@@ -102,6 +102,7 @@ export const List = () => {
             clearSelectedConversations();
             void utils.mailbox.conversations.list.invalidate();
             void utils.mailbox.conversations.count.invalidate();
+            void utils.mailbox.openCount.invalidate();
 
             if (updatedImmediately) {
               const ticketsText = allConversationsSelected
@@ -241,7 +242,7 @@ export const List = () => {
                   </Tooltip>
                 </TooltipProvider>
                 <div className="flex items-center gap-2">
-                  {searchParams.status !== "open" && (
+                  {searchParams.status && searchParams.status !== "open" && (
                     <ConfirmationDialog
                       message={`Are you sure you want to reopen ${conversationsText}?`}
                       onConfirm={() => handleBulkUpdate("open")}

--- a/app/(dashboard)/[category]/list/conversationListContext.tsx
+++ b/app/(dashboard)/[category]/list/conversationListContext.tsx
@@ -86,7 +86,7 @@ export const ConversationListContextProvider = ({
   const debouncedInvalidate = useDebouncedCallback(() => {
     router.refresh();
     utils.mailbox.conversations.list.invalidate();
-    utils.mailbox.openCount.invalidate();
+    utils.mailbox.getCount.invalidate();
   }, 1000);
 
   const removeConversationFromList = (condition: (conversation: ConversationListItem) => boolean) => {
@@ -101,7 +101,7 @@ export const ConversationListContextProvider = ({
       };
     });
     if (!input.status || input.status[0] === "open") {
-      utils.mailbox.openCount.setData(undefined, (data) => {
+      utils.mailbox.getCount.setData(undefined, (data) => {
         if (!data) return data;
         return {
           ...data,

--- a/app/(dashboard)/[category]/list/conversationListContext.tsx
+++ b/app/(dashboard)/[category]/list/conversationListContext.tsx
@@ -105,7 +105,7 @@ export const ConversationListContextProvider = ({
         if (!data) return data;
         return {
           ...data,
-          [input.category]: data[input.category] - 1,
+          [input.category]: data.open[input.category] - 1,
         };
       });
     }

--- a/app/(dashboard)/[category]/list/conversationSearchBar.tsx
+++ b/app/(dashboard)/[category]/list/conversationSearchBar.tsx
@@ -38,13 +38,13 @@ export const ConversationSearchBar = ({
   const searchInputRef = useRef<HTMLInputElement>(null);
   const [search, setSearch] = useState(searchParams.search || "");
 
-  const { data: openCount } = api.mailbox.openCount.useQuery();
+  const { data: count } = api.mailbox.openCount.useQuery();
 
-  const status = openCount
+  const status = count
     ? [
-        { status: "open", count: openCount[input.category] },
-        { status: "closed", count: 0 },
-        { status: "spam", count: 0 },
+        { status: "open", count: count.open[input.category] },
+        { status: "closed", count: count.closed[input.category] },
+        { status: "spam", count: count.spam[input.category] },
       ]
     : [];
 

--- a/app/(dashboard)/[category]/list/conversationSearchBar.tsx
+++ b/app/(dashboard)/[category]/list/conversationSearchBar.tsx
@@ -38,13 +38,13 @@ export const ConversationSearchBar = ({
   const searchInputRef = useRef<HTMLInputElement>(null);
   const [search, setSearch] = useState(searchParams.search || "");
 
-  const { data: count } = api.mailbox.openCount.useQuery();
+  const { data: counts } = api.mailbox.getCount.useQuery();
 
-  const status = count
+  const status = counts
     ? [
-        { status: "open", count: count.open[input.category] },
-        { status: "closed", count: count.closed[input.category] },
-        { status: "spam", count: count.spam[input.category] },
+        { status: "open", count: counts.open[input.category] },
+        { status: "closed", count: counts.closed[input.category] },
+        { status: "spam", count: counts.spam[input.category] },
       ]
     : [];
 

--- a/app/(dashboard)/appSidebar.tsx
+++ b/app/(dashboard)/appSidebar.tsx
@@ -52,7 +52,7 @@ export function AppSidebar() {
   const pathname = usePathname();
   const router = useRouter();
   const previousAppUrlRef = useRef<string | null>(null);
-  const { data: openCounts } = api.mailbox.openCount.useQuery();
+  const { data: counts } = api.mailbox.getCount.useQuery();
   const { data: mailbox } = api.mailbox.get.useQuery();
   const isSettingsPage = pathname.startsWith(`/settings`);
   const { isMobile, setOpenMobile } = useSidebar();
@@ -127,7 +127,7 @@ export function AppSidebar() {
                         <span className="group-data-[collapsible=icon]:hidden">Mine</span>
                       </Link>
                     </SidebarMenuButton>
-                    {openCounts && openCounts.open.mine > 0 && <SidebarMenuBadge>{openCounts.open.mine}</SidebarMenuBadge>}
+                    {counts && counts.open.mine > 0 && <SidebarMenuBadge>{counts.open.mine}</SidebarMenuBadge>}
                   </SidebarMenuItem>
                   <SidebarMenuItem>
                     <SidebarMenuButton asChild isActive={pathname === `/assigned`} tooltip="Assigned">
@@ -136,8 +136,8 @@ export function AppSidebar() {
                         <span className="group-data-[collapsible=icon]:hidden">Assigned</span>
                       </Link>
                     </SidebarMenuButton>
-                    {openCounts && openCounts.open.assigned > 0 && (
-                      <SidebarMenuBadge>{openCounts.open.assigned}</SidebarMenuBadge>
+                    {counts && counts.open.assigned > 0 && (
+                      <SidebarMenuBadge>{counts.open.assigned}</SidebarMenuBadge>
                     )}
                   </SidebarMenuItem>
                   <SidebarMenuItem>
@@ -147,8 +147,8 @@ export function AppSidebar() {
                         <span className="group-data-[collapsible=icon]:hidden">Up for grabs</span>
                       </Link>
                     </SidebarMenuButton>
-                    {openCounts && openCounts.open.unassigned > 0 && (
-                      <SidebarMenuBadge>{openCounts.open.unassigned}</SidebarMenuBadge>
+                    {counts && counts.open.unassigned > 0 && (
+                      <SidebarMenuBadge>{counts.open.unassigned}</SidebarMenuBadge>
                     )}
                   </SidebarMenuItem>
                   <SidebarMenuItem>
@@ -158,8 +158,8 @@ export function AppSidebar() {
                         <span className="group-data-[collapsible=icon]:hidden">All</span>
                       </Link>
                     </SidebarMenuButton>
-                    {openCounts && openCounts.open.conversations > 0 && (
-                      <SidebarMenuBadge>{openCounts.open.conversations}</SidebarMenuBadge>
+                    {counts && counts.open.conversations > 0 && (
+                      <SidebarMenuBadge>{counts.open.conversations}</SidebarMenuBadge>
                     )}
                   </SidebarMenuItem>
                 </SidebarMenu>

--- a/app/(dashboard)/appSidebar.tsx
+++ b/app/(dashboard)/appSidebar.tsx
@@ -127,7 +127,7 @@ export function AppSidebar() {
                         <span className="group-data-[collapsible=icon]:hidden">Mine</span>
                       </Link>
                     </SidebarMenuButton>
-                    {openCounts && openCounts.mine > 0 && <SidebarMenuBadge>{openCounts.mine}</SidebarMenuBadge>}
+                    {openCounts && openCounts.open.mine > 0 && <SidebarMenuBadge>{openCounts.open.mine}</SidebarMenuBadge>}
                   </SidebarMenuItem>
                   <SidebarMenuItem>
                     <SidebarMenuButton asChild isActive={pathname === `/assigned`} tooltip="Assigned">
@@ -136,8 +136,8 @@ export function AppSidebar() {
                         <span className="group-data-[collapsible=icon]:hidden">Assigned</span>
                       </Link>
                     </SidebarMenuButton>
-                    {openCounts && openCounts.assigned > 0 && (
-                      <SidebarMenuBadge>{openCounts.assigned}</SidebarMenuBadge>
+                    {openCounts && openCounts.open.assigned > 0 && (
+                      <SidebarMenuBadge>{openCounts.open.assigned}</SidebarMenuBadge>
                     )}
                   </SidebarMenuItem>
                   <SidebarMenuItem>
@@ -147,8 +147,8 @@ export function AppSidebar() {
                         <span className="group-data-[collapsible=icon]:hidden">Up for grabs</span>
                       </Link>
                     </SidebarMenuButton>
-                    {openCounts && openCounts.unassigned > 0 && (
-                      <SidebarMenuBadge>{openCounts.unassigned}</SidebarMenuBadge>
+                    {openCounts && openCounts.open.unassigned > 0 && (
+                      <SidebarMenuBadge>{openCounts.open.unassigned}</SidebarMenuBadge>
                     )}
                   </SidebarMenuItem>
                   <SidebarMenuItem>
@@ -158,8 +158,8 @@ export function AppSidebar() {
                         <span className="group-data-[collapsible=icon]:hidden">All</span>
                       </Link>
                     </SidebarMenuButton>
-                    {openCounts && openCounts.conversations > 0 && (
-                      <SidebarMenuBadge>{openCounts.conversations}</SidebarMenuBadge>
+                    {openCounts && openCounts.open.conversations > 0 && (
+                      <SidebarMenuBadge>{openCounts.open.conversations}</SidebarMenuBadge>
                     )}
                   </SidebarMenuItem>
                 </SidebarMenu>

--- a/app/(dashboard)/appSidebar.tsx
+++ b/app/(dashboard)/appSidebar.tsx
@@ -136,9 +136,7 @@ export function AppSidebar() {
                         <span className="group-data-[collapsible=icon]:hidden">Assigned</span>
                       </Link>
                     </SidebarMenuButton>
-                    {counts && counts.open.assigned > 0 && (
-                      <SidebarMenuBadge>{counts.open.assigned}</SidebarMenuBadge>
-                    )}
+                    {counts && counts.open.assigned > 0 && <SidebarMenuBadge>{counts.open.assigned}</SidebarMenuBadge>}
                   </SidebarMenuItem>
                   <SidebarMenuItem>
                     <SidebarMenuButton asChild isActive={pathname === `/unassigned`} tooltip="Up for grabs">

--- a/trpc/router/mailbox/index.ts
+++ b/trpc/router/mailbox/index.ts
@@ -22,7 +22,7 @@ import { websitesRouter } from "./websites";
 export { mailboxProcedure };
 
 export const mailboxRouter = {
-  openCount: mailboxProcedure.query(async ({ ctx }) => {
+  getCount: mailboxProcedure.query(async ({ ctx }) => {
     const countByStatus = async (status: "open" | "closed" | "spam", extraCondition?: SQL) => {
       const result = await db
         .select({ count: count() })

--- a/trpc/router/mailbox/index.ts
+++ b/trpc/router/mailbox/index.ts
@@ -27,9 +27,7 @@ export const mailboxRouter = {
       const result = await db
         .select({ count: count() })
         .from(conversations)
-        .where(
-          and(eq(conversations.status, status), isNull(conversations.mergedIntoId), extraCondition),
-        );
+        .where(and(eq(conversations.status, status), isNull(conversations.mergedIntoId), extraCondition));
       return result[0]?.count ?? 0;
     };
 


### PR DESCRIPTION

https://github.com/user-attachments/assets/09db21b5-d495-4a36-803e-a804df984b8f



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mailbox now displays dynamic counts for "open", "closed", and "spam" conversations across all relevant dashboard views and sidebar badges.

* **Bug Fixes**
  * Sidebar and search bar now accurately reflect conversation counts for all statuses, not just "open".
  * Bulk status updates and conversation actions immediately refresh all relevant count displays.

* **Refactor**
  * Improved how conversation status counts are fetched and displayed for consistency across the dashboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->