### PR TITLE
Add `pointer-events: auto` in -wrapper and -icon

### DIFF
--- a/packages/sdk/src/embed.css
+++ b/packages/sdk/src/embed.css
@@ -29,6 +29,7 @@
   right: 20px;
   transform: translateX(0);
   opacity: 1;
+  pointer-events: auto;
 }
 
 .helper-widget-wrapper.temporarily-hidden {
@@ -240,6 +241,7 @@
   align-items: center;
   justify-content: center;
   z-index: 2147482998;
+  pointer-events: auto;
 }
 
 .helper-widget-icon:hover {


### PR DESCRIPTION
Fixes https://github.com/antiwork/helper/issues/763

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated styles to ensure interactive elements in the helper widget respond to mouse and pointer events when visible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->