### PR TITLE
feat: revamp the settings pages

### DIFF
--- a/app/(dashboard)/settings/knowledge/knowledgeBankSetting.tsx
+++ b/app/(dashboard)/settings/knowledge/knowledgeBankSetting.tsx
@@ -7,37 +7,36 @@ import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { api } from "@/trpc/react";
-import SectionWrapper from "../sectionWrapper";
 import KnowledgeBankItem, { KnowledgeEditForm } from "./knowledgeBankItem";
 import SuggestedKnowledgeBankItem from "./suggestedKnowledgeBankItem";
 
-const KnowledgeBankSetting = () => {
+export default function KnowledgeBankSetting() {
   const [newFaqContent, setNewFaqContent] = useState<string>("");
   const [showNewFaqForm, setShowNewFaqForm] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
   const utils = api.useUtils();
 
   const { data: faqs = [], isLoading } = api.mailbox.faqs.list.useQuery();
-
   const filteredFaqs = faqs.filter((faq) => faq.content.toLowerCase().includes(searchQuery.toLowerCase()));
-
   const suggestedFaqs = filteredFaqs.filter((faq) => faq.suggested && faq.suggestedReplacementForId === null);
   const withSuggestedReplacement = filteredFaqs.flatMap((faq) => {
     const suggestedReplacement = faqs.find((f) => f.suggestedReplacementForId === faq.id);
     return suggestedReplacement ? [{ ...faq, suggestedReplacement }] : [];
   });
   const otherEntries = filteredFaqs.filter(
-    (faq) => !faq.suggested && !withSuggestedReplacement.some((f) => f.id === faq.id),
+    (faq) => !faq.suggested && !withSuggestedReplacement.some((f) => f.id === faq.id)
   );
 
   const createMutation = api.mailbox.faqs.create.useMutation({
     onSuccess: (data) => {
       utils.mailbox.faqs.list.setData(undefined, (old) =>
-        old ? [...old, data].sort((a, b) => a.content.localeCompare(b.content)) : [data],
+        old ? [...old, data].sort((a, b) => a.content.localeCompare(b.content)) : [data]
       );
       setShowNewFaqForm(false);
       setNewFaqContent("");
+      toast.success("Knowledge added successfully");
     },
     onError: (error) => {
       toast.error("Error creating knowledge", { description: error.message });
@@ -46,120 +45,138 @@ const KnowledgeBankSetting = () => {
 
   const deleteMutation = api.mailbox.faqs.delete.useMutation({
     onSuccess: () => {
-      toast.success("Knowledge deleted!");
       utils.mailbox.faqs.list.invalidate();
+      toast.success("Knowledge deleted successfully");
     },
     onError: (error) => {
       toast.error("Error deleting knowledge", { description: error.message });
     },
   });
 
-  const handleUpsertFaq = async () => {
-    if (!newFaqContent) return;
-    await createMutation.mutateAsync({
-      content: newFaqContent,
-    });
-  };
-
-  const handleDeleteFaq = async (id: number) => {
-    await deleteMutation.mutateAsync({ id });
-  };
-
   return (
-    <SectionWrapper
-      title="Knowledge Bank"
-      description={
-        <>
-          <div className="mb-2">
-            Record information that you frequently share with customers. Helper will use this to provide consistent,
-            accurate, and relevant responses to inquiries.
-          </div>
-          Helper will suggest improvements to your knowledge bank to ensure it's up to date.
-        </>
-      }
-    >
-      <Input
-        type="text"
-        placeholder="Search knowledge bank..."
-        value={searchQuery}
-        onChange={(e) => setSearchQuery(e.target.value)}
-        className="mb-4"
-      />
-      {suggestedFaqs.length > 0 && (
-        <Accordion type="single" collapsible>
-          <AccordionItem value="suggested">
-            <AccordionTrigger className="hover:no-underline">
-              <Badge variant="bright">
-                {suggestedFaqs.length} suggested {suggestedFaqs.length === 1 ? "entry" : "entries"}
-              </Badge>
-            </AccordionTrigger>
-            <AccordionContent>
-              <div className="space-y-2">
-                {suggestedFaqs.map((faq) => (
-                  <SuggestedKnowledgeBankItem key={faq.id} faq={faq} />
-                ))}
+    <div className="space-y-6 mt-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>Knowledge Bank</CardTitle>
+          <CardDescription>
+            Record information that you frequently share with customers. Helper uses this to provide consistent and accurate responses.
+            <p className="mt-2">
+              Helper will suggest improvements to your knowledge bank to ensure it's up to date.
+            </p>
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="flex flex-col gap-6">
+            <div className="flex flex-col sm:flex-row items-start sm:items-center gap-4">
+              <div className="relative flex-1">
+                <Input
+                  type="text"
+                  placeholder="Search knowledge bank..."
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                  className="w-full max-w-md pr-4"
+                />
               </div>
-            </AccordionContent>
-          </AccordionItem>
-        </Accordion>
-      )}
-      <div className="mb-4 divide-y divide-border">
-        {isLoading ? (
-          <>
-            {Array.from({ length: 2 }).map((_, i) => (
-              <div key={i} className="flex items-center gap-3 py-4">
-                <div className="grow space-y-2">
-                  <div className="h-4 w-32 rounded bg-secondary animate-skeleton" />
-                  <div className="h-4 w-48 rounded bg-secondary animate-skeleton" />
-                </div>
-                <div className="h-6 w-16 rounded bg-secondary animate-skeleton" />
-              </div>
-            ))}
-          </>
-        ) : (
-          <>
-            {withSuggestedReplacement.map((faq) => (
-              <KnowledgeBankItem
-                key={faq.id}
-                faq={faq}
-                suggestedReplacement={faq.suggestedReplacement}
-                onDelete={() => handleDeleteFaq(faq.id)}
-              />
-            ))}
-            {otherEntries.map((faq) => (
-              <KnowledgeBankItem key={faq.id} faq={faq} onDelete={() => handleDeleteFaq(faq.id)} />
-            ))}
-          </>
-        )}
-      </div>
-      {showNewFaqForm ? (
-        <div className="mb-4">
-          <KnowledgeEditForm
-            content={newFaqContent}
-            onChange={setNewFaqContent}
-            onSubmit={handleUpsertFaq}
-            onCancel={() => {
-              setShowNewFaqForm(false);
-              setNewFaqContent("");
-            }}
-            isLoading={createMutation.isPending}
-          />
-        </div>
-      ) : (
-        <Button
-          variant="subtle"
-          onClick={(e) => {
-            e.preventDefault();
-            setNewFaqContent("");
-            setShowNewFaqForm(true);
-          }}
-        >
-          <PlusCircle className="mr-2 h-4 w-4" />
-          Add Knowledge
-        </Button>
-      )}
-    </SectionWrapper>
-  );
-};
+              {!showNewFaqForm && (
+                <Button
+                  onClick={() => {
+                    setNewFaqContent("");
+                    setShowNewFaqForm(true);
+                  }}
+                  className="w-full sm:w-auto"
+                >
+                  <PlusCircle className="mr-2 h-4 w-4" />
+                  Add Knowledge
+                </Button>
+              )}
+            </div>
 
-export default KnowledgeBankSetting;
+            {showNewFaqForm && (
+              <Card>
+                <CardContent className="pt-6">
+                  <KnowledgeEditForm
+                    content={newFaqContent}
+                    onChange={setNewFaqContent}
+                    onSubmit={async () => {
+                      if (!newFaqContent) return;
+                      await createMutation.mutateAsync({ content: newFaqContent });
+                    }}
+                    onCancel={() => {
+                      setShowNewFaqForm(false);
+                      setNewFaqContent("");
+                    }}
+                    isLoading={createMutation.isPending}
+                  />
+                </CardContent>
+              </Card>
+            )}
+
+            {suggestedFaqs.length > 0 && (
+              <Card className="border-dashed">
+                <Accordion type="single" collapsible className="w-full">
+                  <AccordionItem value="suggested" className="border-none">
+                    <AccordionTrigger className="px-6 py-4 hover:no-underline">
+                      <Badge variant="bright" className="py-1.5 px-3">
+                        {suggestedFaqs.length} suggested {suggestedFaqs.length === 1 ? "entry" : "entries"}
+                      </Badge>
+                    </AccordionTrigger>
+                    <AccordionContent className="px-6 pb-6">
+                      <div className="space-y-4">
+                        {suggestedFaqs.map((faq) => (
+                          <SuggestedKnowledgeBankItem key={faq.id} faq={faq} />
+                        ))}
+                      </div>
+                    </AccordionContent>
+                  </AccordionItem>
+                </Accordion>
+              </Card>
+            )}
+
+            <Card>
+              <CardContent className="p-0">
+                {isLoading ? (
+                  <div className="divide-y">
+                    {Array.from({ length: 3 }).map((_, i) => (
+                      <div key={i} className="flex items-center gap-4 p-6">
+                        <div className="flex-1 space-y-2">
+                          <div className="h-4 w-2/3 rounded bg-muted" />
+                          <div className="h-4 w-1/2 rounded bg-muted" />
+                        </div>
+                        <div className="h-8 w-20 rounded bg-muted" />
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <div className="divide-y">
+                    {withSuggestedReplacement.map((faq) => (
+                      <div key={faq.id} className="p-6 transition-colors hover:bg-muted/50">
+                        <KnowledgeBankItem
+                          faq={faq}
+                          suggestedReplacement={faq.suggestedReplacement}
+                          onDelete={() => deleteMutation.mutate({ id: faq.id })}
+                        />
+                      </div>
+                    ))}
+                    {otherEntries.map((faq) => (
+                      <div key={faq.id} className="p-6 transition-colors hover:bg-muted/50">
+                        <KnowledgeBankItem 
+                          faq={faq} 
+                          onDelete={() => deleteMutation.mutate({ id: faq.id })} 
+                        />
+                      </div>
+                    ))}
+                    {!withSuggestedReplacement.length && !otherEntries.length && (
+                      <div className="flex flex-col items-center justify-center gap-2 p-12 text-center">
+                        <p className="text-sm text-muted-foreground">No knowledge entries found</p>
+                      </div>
+                    )}
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/(dashboard)/settings/sectionWrapper.tsx
+++ b/app/(dashboard)/settings/sectionWrapper.tsx
@@ -16,15 +16,21 @@ type SectionWrapperProps = {
 
 const SectionWrapper = ({ title, description, fullWidth, className, action, children }: SectionWrapperProps) => {
   return (
-    <section className="flex flex-col gap-4 border-b py-8 first:pt-4 lg:flex-row">
-      <div className="flex w-full flex-col gap-3 lg:max-w-xs">
-        <div className="flex w-full flex-col gap-1">
-          <h2 className="text-base flex items-center gap-2">{title}</h2>
-          <div className="w-full text-sm text-muted-foreground">{description}</div>
+    <section className="flex flex-col gap-8 border-b py-8 first:pt-4">
+      <div className="flex flex-col gap-6">
+        <div className="flex flex-col gap-3">
+          <div className="flex items-center justify-between gap-4">
+            <h2 className="text-xl font-semibold flex items-center gap-2">{title}</h2>
+            {action && <div className="flex-shrink-0">{action}</div>}
+          </div>
+          {description && (
+            <div className="text-sm text-muted-foreground">{description}</div>
+          )}
         </div>
-        {action}
       </div>
-      <div className={cn("grow", !fullWidth && "max-w-xl", className)}>{children}</div>
+      <div className={cn("w-full", !fullWidth && "max-w-3xl", className)}>
+        {children}
+      </div>
     </section>
   );
 };
@@ -52,23 +58,30 @@ const SwitchSectionWrapper = ({
 
   const handleSwitchChange = (checked: boolean) => {
     setIsSwitchChecked(checked);
-    if (onSwitchChange) {
-      onSwitchChange(checked);
-    }
+    onSwitchChange?.(checked);
   };
 
   return (
     <SectionWrapper
       title={
-        <>
-          {title}
-          <Badge variant={isSwitchChecked ? "dark" : "default"}>{isSwitchChecked ? "On" : "Off"}</Badge>
-        </>
+        <div className="flex items-center gap-3">
+          <span>{title}</span>
+          <Badge variant={isSwitchChecked ? "dark" : "default"} className="h-6">
+            {isSwitchChecked ? "On" : "Off"}
+          </Badge>
+        </div>
       }
       description={description}
       fullWidth={fullWidth}
       className={className}
-      action={<Switch aria-label={`${title} Switch`} checked={isSwitchChecked} onCheckedChange={handleSwitchChange} />}
+      action={
+        <Switch 
+          aria-label={`${title} Switch`} 
+          checked={isSwitchChecked} 
+          onCheckedChange={handleSwitchChange}
+          className="scale-110"
+        />
+      }
     >
       {children}
     </SectionWrapper>

--- a/app/(dashboard)/settings/team/teamMemberRow.tsx
+++ b/app/(dashboard)/settings/team/teamMemberRow.tsx
@@ -228,7 +228,7 @@ const TeamMemberRow = ({ member, isAdmin }: TeamMemberRowProps) => {
           <span className="truncate">{member.email || "No email"}</span>
         </div>
       </TableCell>
-      <TableCell className="w-[150px">
+      <TableCell className="w-[150px]">
         {isAdmin || member.id === currentUser?.id ? (
           <Input
             value={displayNameInput}

--- a/app/(dashboard)/settings/team/teamMemberRow.tsx
+++ b/app/(dashboard)/settings/team/teamMemberRow.tsx
@@ -228,13 +228,13 @@ const TeamMemberRow = ({ member, isAdmin }: TeamMemberRowProps) => {
           <span className="truncate">{member.email || "No email"}</span>
         </div>
       </TableCell>
-      <TableCell>
+      <TableCell className="w-[150px">
         {isAdmin || member.id === currentUser?.id ? (
           <Input
             value={displayNameInput}
             onChange={(e) => handleDisplayNameChange(e.target.value)}
             placeholder="Enter display name"
-            className="w-full max-w-lg"
+            className="w-full max-w-sm"
           />
         ) : (
           <span>{member.displayName || "No display name"}</span>
@@ -258,7 +258,7 @@ const TeamMemberRow = ({ member, isAdmin }: TeamMemberRowProps) => {
       <TableCell>
         {isAdmin ? (
           <Select value={role} onValueChange={(value: UserRole) => handleRoleChange(value)}>
-            <SelectTrigger className="w-[100px]">
+            <SelectTrigger className="w-[120px]">
               <SelectValue placeholder="Role" />
             </SelectTrigger>
             <SelectContent>

--- a/app/(dashboard)/settings/team/teamSetting.tsx
+++ b/app/(dashboard)/settings/team/teamSetting.tsx
@@ -5,10 +5,10 @@ import { useState } from "react";
 import { Input } from "@/components/ui/input";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { useSession } from "@/components/useSession";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { api } from "@/trpc/react";
-import SectionWrapper from "../sectionWrapper";
 import { AddMember } from "./addMember";
-import TeamMemberRow, { ROLE_DISPLAY_NAMES } from "./teamMemberRow";
+import TeamMemberRow from "./teamMemberRow";
 import { TeamSettingLoadingSkeleton } from "./teamSettingLoadingSkeleton";
 
 const TeamSetting = () => {
@@ -27,67 +27,92 @@ const TeamSetting = () => {
   });
 
   return (
-    <SectionWrapper
-      title="Manage Team Members"
-      description="Add and organize team members for efficient ticket assignment"
-      fullWidth
-    >
-      <div className="w-full space-y-6">
-        {user?.permissions === "admin" && <AddMember teamMembers={teamMembers} />}
+    <div className="space-y-6 mt-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>Team Management</CardTitle>
+          <CardDescription>Add and organize team members for efficient ticket assignment</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          {user?.permissions === "admin" && <AddMember teamMembers={teamMembers} />}
+          <div className="space-y-4">
+            {teamMembers.length > 0 && (
+              <div className="relative">
+                <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                <Input
+                  placeholder="Search team members..."
+                  value={searchTerm}
+                  onChange={(e) => setSearchTerm(e.target.value)}
+                />
+              </div>
+            )}
 
-        {(teamMembers.length > 0 || isLoading) && (
-          <Input
-            placeholder="Search..."
-            value={searchTerm}
-            onChange={(e) => setSearchTerm(e.target.value)}
-            iconsPrefix={<Search className="h-4 w-4 text-muted-foreground" />}
-          />
-        )}
-
-        <div className="rounded-md border">
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Email</TableHead>
-                <TableHead className="min-w-[140px]">Name</TableHead>
-                <TableHead className="w-[100px]">Permissions</TableHead>
-                <TableHead className="w-[100px]">Support role</TableHead>
-                <TableHead className="min-w-[180px]">Auto-assign keywords</TableHead>
-                <TableHead>Actions</TableHead>
-                <TableHead className="w-[120px]">Status</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {isLoading ? (
-                <TeamSettingLoadingSkeleton />
-              ) : filteredTeamMembers.length === 0 ? (
-                <TableRow>
-                  <TableCell colSpan={7} className="text-center py-6 text-muted-foreground">
-                    {searchTerm
-                      ? `No team members found matching "${searchTerm}"`
-                      : "No team members in your organization yet. Use the form above to invite new members."}
-                  </TableCell>
-                </TableRow>
-              ) : (
-                filteredTeamMembers.map((member) => (
-                  <TeamMemberRow key={member.id} member={member} isAdmin={user?.permissions === "admin"} />
-                ))
-              )}
-            </TableBody>
-          </Table>
-        </div>
-
-        <div className="text-sm text-muted-foreground space-y-1">
-          <p>Note:</p>
-          <ul className="list-disc list-inside space-y-1">
-            <li>{ROLE_DISPLAY_NAMES.core} members are assigned tickets in a round-robin style.</li>
-            <li>{ROLE_DISPLAY_NAMES.nonCore} members are only assigned if the ticket tags match their keywords.</li>
-            <li>{ROLE_DISPLAY_NAMES.afk} members do not receive any ticket assignments.</li>
-            <li>Only {ROLE_DISPLAY_NAMES.core} support team members will be mentioned explicitly in weekly reports.</li>
-          </ul>
-        </div>
-      </div>
-    </SectionWrapper>
+            <div className="rounded-md border">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Email</TableHead>
+                    <TableHead className="min-w-[150px]">Name</TableHead>
+                    <TableHead className="w-[120px]">Permissions</TableHead>
+                    <TableHead className="w-[120px]">Support role</TableHead>
+                    <TableHead className="min-w-[200px]">Auto-assign keywords</TableHead>
+                    <TableHead>Actions</TableHead>
+                    <TableHead className="w-[120px]">Status</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {isLoading ? (
+                    <TeamSettingLoadingSkeleton />
+                  ) : filteredTeamMembers.length === 0 ? (
+                    <TableRow>
+                      <TableCell colSpan={7} className="h-32">
+                        <div className="flex flex-col items-center justify-center gap-2 text-center">
+                          <p className="text-sm text-muted-foreground">
+                            {searchTerm
+                              ? `No team members found matching "${searchTerm}"`
+                              : "No team members in your organization yet"}
+                          </p>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  ) : (
+                    filteredTeamMembers.map((member) => (
+                      <TeamMemberRow key={member.id} member={member} isAdmin={user?.permissions === "admin"} />
+                    ))
+                  )}
+                </TableBody>
+              </Table>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+      <Card>
+      <CardHeader>
+        <CardTitle>Support Team Assignment Rules</CardTitle>
+        <CardDescription>Understanding how tickets are assigned to team members</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <ul className="space-y-2 text-sm text-muted-foreground">
+          <li className="flex items-start gap-2">
+            <span className="font-medium text-foreground">Core Members:</span>
+            Assigned tickets in a round-robin style
+          </li>
+          <li className="flex items-start gap-2">
+            <span className="font-medium text-foreground">Non-core Members:</span>
+            Only assigned tickets when tags match their keywords
+          </li>
+          <li className="flex items-start gap-2">
+            <span className="font-medium text-foreground">Away Members:</span>
+            Do not receive any ticket assignments
+          </li>
+          <li className="flex items-start gap-2">
+            <span className="font-medium text-foreground">Weekly Reports:</span>
+            Only Core support team members are mentioned explicitly
+          </li>
+        </ul>
+      </CardContent>
+    </Card>
+    </div>
   );
 };
 


### PR DESCRIPTION
Description:

- Updated `sectionWrapper` to accomodate for the below changes
- Updated `knowledgeSettings` and `teamSettings` page
  - Added a card to make it more appealing to the eye
  - Made the table occupy the entire width in teamSettings page
- WIP - Customers and InApp Settings
- WIP - Integrations and Preferences 

Before (Knowledge and Team Settings Page)

https://github.com/user-attachments/assets/c6ba7ea6-480a-49af-a62c-64a414074e7e

After (Knowledge and Team Settings Page)

https://github.com/user-attachments/assets/2ce87ccf-847b-4f57-89e8-d038efd2bd50




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned settings pages with a consistent card-based layout for improved readability and organization.
  * Added a dedicated section explaining support team assignment rules in the team settings.

* **UI Improvements**
  * Enhanced responsiveness and spacing across settings components.
  * Improved empty state messages and loading indicators for clarity.
  * Updated button placements and form layouts for better usability.
  * Refined input and dropdown sizing for team member management.

* **User Feedback**
  * Toast notifications now provide clearer success messages for actions like adding or deleting knowledge and websites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->