### PR TITLE
Handle multi-widget edge cases better

### DIFF
--- a/packages/react/src/components/ClientHelperProvider.tsx
+++ b/packages/react/src/components/ClientHelperProvider.tsx
@@ -10,8 +10,21 @@ type ClientHelperProviderProps = HelperWidgetConfig & {
 
 export function ClientHelperProvider({ host, onError, ...props }: ClientHelperProviderProps) {
   useEffect(() => {
+    const scriptSrc = `${host}/widget/sdk.js`;
+    const existingScript = document.querySelector(`script[src="${scriptSrc}"]`);
+
+    if (existingScript) {
+      console.warn(
+        "Helper widget script already exists. You may have multiple HelperProvider components - please remove all but one.",
+      );
+      if (window.HelperWidget) {
+        window.HelperWidget.init(props);
+      }
+      return;
+    }
+
     const script = document.createElement("script");
-    script.src = `${host}/widget/sdk.js`;
+    script.src = scriptSrc;
     script.async = true;
     script.dataset.delayInit = "true";
 

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -879,10 +879,14 @@ class HelperWidget {
   }
 
   public static async init(config: HelperWidgetConfig): Promise<HelperWidget> {
-    if (!HelperWidget.instance) {
-      HelperWidget.instance = new HelperWidget(config);
-      await HelperWidget.instance.setup();
+    if (HelperWidget.instance) {
+      console.warn(
+        "HelperWidget.init: Destroying existing instance. If this is intentional, please call HelperWidget.destroy() before calling HelperWidget.init()",
+      );
+      HelperWidget.destroy();
     }
+    HelperWidget.instance = new HelperWidget(config);
+    await HelperWidget.instance.setup();
     return HelperWidget.instance;
   }
 


### PR DESCRIPTION
Currently if you accidentally load and initialize the Helper widget twice, the second call is ignored. This changes it to show warnings but still reload the widget the second time. Fixes the widget test page session always being anonymous.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented multiple instances of the helper widget from being created when multiple providers are present.
  * Improved handling of widget reinitialization to ensure only one instance exists at a time and state is properly reset.

* **Enhancements**
  * Added warnings to notify users about duplicate widget initialization attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->