### PR TITLE
test: add conversation details E2E test

### DIFF
--- a/app/(dashboard)/[category]/conversation/conversation.tsx
+++ b/app/(dashboard)/[category]/conversation/conversation.tsx
@@ -140,6 +140,7 @@ const ScrollToTopButton = ({
           onClick={scrollToTop}
           aria-label="Scroll to top"
           tabIndex={show ? 0 : -1}
+          data-testid="scroll-to-top-button"
         >
           <ArrowUp className="h-4 w-4 text-foreground" />
         </button>
@@ -163,9 +164,9 @@ const MessageThreadPanel = ({
   const { data: conversationInfo } = useConversationContext();
 
   return (
-    <div className="grow overflow-y-auto relative" ref={scrollRef}>
+    <div className="grow overflow-y-auto relative" ref={scrollRef} data-testid="message-thread-panel">
       <div ref={contentRef as React.RefObject<HTMLDivElement>} className="relative">
-        <div className="flex flex-col gap-8 px-4 py-4 h-full">
+        <div className="flex flex-col gap-8 px-4 py-4 h-full" data-testid="message-thread-container">
           {conversationInfo && (
             <MessageThread
               conversation={conversationInfo}
@@ -218,26 +219,52 @@ const ConversationHeader = ({
         !conversationInfo && "hidden",
       )}
       style={{ minHeight: 48 }}
+      data-testid="conversation-header"
     >
       <div className="flex items-center min-w-0 flex-shrink-0 z-10 lg:w-44">
-        <Button variant="ghost" size="sm" iconOnly onClick={minimize} className="text-primary hover:text-foreground">
+        <Button
+          variant="ghost"
+          size="sm"
+          iconOnly
+          onClick={minimize}
+          className="text-primary hover:text-foreground"
+          data-testid="close-conversation-button"
+        >
           <X className="h-4 w-4" />
         </Button>
         <div className="flex items-center ml-2">
-          <Button variant="ghost" size="sm" iconOnly onClick={moveToPreviousConversation}>
+          <Button
+            variant="ghost"
+            size="sm"
+            iconOnly
+            onClick={moveToPreviousConversation}
+            data-testid="previous-conversation-button"
+          >
             <ChevronLeft className="h-4 w-4" />
           </Button>
-          <span className="text-sm text-muted-foreground whitespace-nowrap text-center mx-1">
+          <span
+            className="text-sm text-muted-foreground whitespace-nowrap text-center mx-1"
+            data-testid="conversation-counter"
+          >
             {currentIndex + 1} of {currentTotal}
             {hasNextPage ? "+" : ""}
           </span>
-          <Button variant="ghost" size="sm" iconOnly onClick={moveToNextConversation}>
+          <Button
+            variant="ghost"
+            size="sm"
+            iconOnly
+            onClick={moveToNextConversation}
+            data-testid="next-conversation-button"
+          >
             <ChevronRight className="h-4 w-4" />
           </Button>
         </div>
       </div>
       <div className="flex-1 min-w-0 flex justify-center">
-        <div className="truncate text-base font-semibold text-foreground text-center max-w-full">
+        <div
+          className="truncate text-base font-semibold text-foreground text-center max-w-full"
+          data-testid="conversation-subject"
+        >
           {subject ?? "(no subject)"}
         </div>
       </div>
@@ -249,6 +276,7 @@ const ConversationHeader = ({
           size="sm"
           iconOnly
           onClick={() => setSidebarVisible(!sidebarVisible)}
+          data-testid="toggle-sidebar-button"
         >
           {isAboveSm ? (
             sidebarVisible ? (

--- a/app/(dashboard)/[category]/conversation/eventItem.tsx
+++ b/app/(dashboard)/[category]/conversation/eventItem.tsx
@@ -82,10 +82,11 @@ export const EventItem = ({ event }: { event: ConversationEvent }) => {
           : User;
 
   return (
-    <div className="flex flex-col mx-auto">
+    <div className="flex flex-col mx-auto" data-testid="event-item">
       <button
         className="flex items-center justify-center gap-1 text-sm text-muted-foreground hover:text-foreground"
         onClick={() => setDetailsExpanded(!detailsExpanded)}
+        data-testid="event-summary-button"
       >
         {hasDetails && (detailsExpanded ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />)}
         <Icon className="h-4 w-4" />
@@ -97,7 +98,7 @@ export const EventItem = ({ event }: { event: ConversationEvent }) => {
       </button>
 
       {hasDetails && detailsExpanded && (
-        <div className="mt-2 text-sm text-muted-foreground border rounded p-4">
+        <div className="mt-2 text-sm text-muted-foreground border rounded p-4" data-testid="event-details">
           <div className="flex flex-col gap-1">
             {byUserName && (
               <div>

--- a/app/(dashboard)/[category]/conversation/messageItem.tsx
+++ b/app/(dashboard)/[category]/conversation/messageItem.tsx
@@ -192,10 +192,16 @@ const MessageItem = ({
   });
 
   return (
-    <div data-message-item data-type={message.type} data-id={message.id} className="responsive-break-words grid">
+    <div
+      data-message-item
+      data-type={message.type}
+      data-id={message.id}
+      className="responsive-break-words grid"
+      data-testid="message-item"
+    >
       <div className={`flex ${rightAlignedMessage ? "justify-end" : ""}`}>
         <div className={`flex flex-col gap-2 ${rightAlignedMessage ? "items-end" : ""}`}>
-          <div className="flex items-center gap-1 text-xs text-muted-foreground">
+          <div className="flex items-center gap-1 text-xs text-muted-foreground" data-testid="message-header">
             {addSeparator(messageLabels, "·")}
           </div>
           <div className="flex items-start gap-2">
@@ -208,6 +214,7 @@ const MessageItem = ({
                     ? "border md:bg-muted md:border-none"
                     : "bg-muted",
               )}
+              data-testid="message-content"
             >
               {mainContent}
               {quotedContext ? (
@@ -220,6 +227,7 @@ const MessageItem = ({
                         ? "bg-muted-foreground text-muted-foreground"
                         : "bg-border text-muted-foreground hover:text-muted-foreground",
                     )}
+                    data-testid="expand-quoted-context-button"
                   >
                     <MoreHorizontal className="h-8 w-8" />
                   </button>
@@ -228,7 +236,7 @@ const MessageItem = ({
               ) : null}
             </div>
           </div>
-          <div className="flex w-full items-center gap-3 text-sm text-muted-foreground">
+          <div className="flex w-full items-center gap-3 text-sm text-muted-foreground" data-testid="message-footer">
             {message.type === "message" && message.isMerged && (
               <TooltipProvider delayDuration={0}>
                 <Tooltip>
@@ -255,7 +263,10 @@ const MessageItem = ({
             {hasReasoning && !userMessage && (
               <Popover>
                 <PopoverTrigger asChild>
-                  <button className="inline-flex items-center gap-1 text-muted-foreground hover:text-foreground">
+                  <button
+                    className="inline-flex items-center gap-1 text-muted-foreground hover:text-foreground"
+                    data-testid="view-ai-reasoning-button"
+                  >
                     <Sparkles className="h-4 w-4" />
                     <span className="text-xs">View AI reasoning</span>
                   </button>
@@ -330,6 +341,7 @@ const MessageItem = ({
           {message.files.length ? (
             <div
               className={`flex flex-wrap gap-2 overflow-x-auto pb-2 ${rightAlignedMessage ? "flex-row-reverse" : ""}`}
+              data-testid="message-attachments"
             >
               {message.files.map((file, idx) => (
                 <a

--- a/app/(dashboard)/[category]/conversation/messageThread.tsx
+++ b/app/(dashboard)/[category]/conversation/messageThread.tsx
@@ -14,10 +14,13 @@ export const MessageThread = ({
   onPreviewAttachment: (message: Message, index: number) => void;
 }) => {
   return (
-    <div className="flex h-full flex-col">
-      <div className="flex flex-1 flex-col gap-8 pb-4 mb-4">
+    <div className="flex h-full flex-col" data-testid="message-thread">
+      <div className="flex flex-1 flex-col gap-8 pb-4 mb-4" data-testid="messages-container">
         {conversation.isPrompt && (
-          <div className="flex items-center justify-center gap-1 text-sm text-muted-foreground">
+          <div
+            className="flex items-center justify-center gap-1 text-sm text-muted-foreground"
+            data-testid="prompt-indicator"
+          >
             <HelpCircle className="h-4 w-4 text-muted-foreground" />
             <span>Started this conversation from a prompt</span>
           </div>
@@ -45,7 +48,7 @@ export const MessageThread = ({
           ),
         )}
         {conversation.summary && conversation.summary.length > 0 && (
-          <div className="mx-auto flex max-w-2xl flex-col gap-2">
+          <div className="mx-auto flex max-w-2xl flex-col gap-2" data-testid="conversation-summary">
             <div className="flex items-center gap-1 text-base text-muted-foreground">
               <MessagesSquare className="h-4 w-4 shrink-0" />
               Conversation summary

--- a/app/(dashboard)/[category]/list/conversationListItem.tsx
+++ b/app/(dashboard)/[category]/list/conversationListItem.tsx
@@ -63,7 +63,7 @@ export const ConversationListItem = ({
   }
 
   return (
-    <div className="px-1 md:px-2">
+    <div className="px-1 md:px-2" data-testid="conversation-list-item">
       <div
         className={cn(
           "flex w-full cursor-pointer flex-col  transition-colors border-b border-border py-3 md:py-4",

--- a/app/(dashboard)/settings/sectionWrapper.tsx
+++ b/app/(dashboard)/settings/sectionWrapper.tsx
@@ -12,11 +12,20 @@ type SectionWrapperProps = {
   className?: string;
   action?: React.ReactNode;
   children: React.ReactNode;
+  "data-testid"?: string;
 };
 
-const SectionWrapper = ({ title, description, fullWidth, className, action, children }: SectionWrapperProps) => {
+const SectionWrapper = ({
+  title,
+  description,
+  fullWidth,
+  className,
+  action,
+  children,
+  "data-testid": dataTestId,
+}: SectionWrapperProps) => {
   return (
-    <section className="flex flex-col gap-4 border-b py-8 first:pt-4 lg:flex-row">
+    <section className="flex flex-col gap-4 border-b py-8 first:pt-4 lg:flex-row" data-testid={dataTestId}>
       <div className="flex w-full flex-col gap-3 lg:max-w-xs">
         <div className="flex w-full flex-col gap-1">
           <h2 className="text-base flex items-center gap-2">{title}</h2>

--- a/components/tiptap/editor.tsx
+++ b/components/tiptap/editor.tsx
@@ -402,6 +402,7 @@ const TipTapEditor = ({
             uploadFiles.current(files);
           }}
           ref={editorContentContainerRef}
+          data-testid="tiptap-editor-content"
         >
           <div className="grow">
             <EditorContent editor={editor} />

--- a/tests/e2e/conversation-details/conversationDetails.spec.ts
+++ b/tests/e2e/conversation-details/conversationDetails.spec.ts
@@ -1,0 +1,284 @@
+import { expect, test } from "@playwright/test";
+import { ConversationDetailsPage } from "../utils/page-objects/conversationDetailsPage";
+import { generateRandomString } from "../utils/test-helpers";
+
+test.use({ storageState: "tests/e2e/.auth/user.json" });
+
+test.describe("Conversation Details", () => {
+  let conversationDetailsPage: ConversationDetailsPage;
+
+  test.beforeEach(async ({ page }) => {
+    conversationDetailsPage = new ConversationDetailsPage(page);
+  });
+
+  test("should display conversation details page", async () => {
+    await conversationDetailsPage.navigateToConversation();
+    await conversationDetailsPage.waitForConversationLoad();
+
+    await conversationDetailsPage.expectConversationLoaded();
+    await conversationDetailsPage.expectNavigationControls();
+  });
+
+  test("should show conversation subject", async () => {
+    await conversationDetailsPage.navigateToConversation();
+    await conversationDetailsPage.waitForConversationLoad();
+
+    const subject = await conversationDetailsPage.getConversationSubject();
+    expect(subject.length).toBeGreaterThan(0);
+  });
+
+  test("should display messages in conversation", async () => {
+    await conversationDetailsPage.navigateToConversation();
+    await conversationDetailsPage.waitForConversationLoad();
+
+    const messageCount = await conversationDetailsPage.getMessageCount();
+    expect(messageCount).toBeGreaterThan(0);
+  });
+
+  test("should navigate between conversations", async () => {
+    await conversationDetailsPage.navigateToConversation();
+    await conversationDetailsPage.waitForConversationLoad();
+
+    const initialSubject = await conversationDetailsPage.getConversationSubject();
+    const initialCounter = await conversationDetailsPage.getConversationCounter();
+
+    // Try to go to next conversation
+    await conversationDetailsPage.goToNextConversation();
+    await conversationDetailsPage.waitForConversationLoad();
+
+    const nextSubject = await conversationDetailsPage.getConversationSubject();
+    const nextCounter = await conversationDetailsPage.getConversationCounter();
+
+    // Counter should change (assuming there's more than one conversation)
+    if (nextCounter !== initialCounter) {
+      expect(nextSubject).not.toBe(initialSubject);
+    }
+  });
+
+  test("should toggle sidebar", async () => {
+    await conversationDetailsPage.navigateToConversation();
+    await conversationDetailsPage.waitForConversationLoad();
+
+    // Click toggle sidebar button
+    await conversationDetailsPage.toggleSidebar();
+
+    // The button should still be visible regardless of sidebar state
+    await expect(conversationDetailsPage.page.getByTestId("toggle-sidebar-button")).toBeVisible();
+  });
+
+  test("should close conversation", async () => {
+    await conversationDetailsPage.navigateToConversation();
+    await conversationDetailsPage.waitForConversationLoad();
+
+    await conversationDetailsPage.closeConversation();
+
+    // Should navigate back to conversations list
+    await expect(conversationDetailsPage.page.url()).toContain("/conversations");
+  });
+
+  test("should display conversation with multiple messages", async () => {
+    await conversationDetailsPage.navigateToConversation();
+    await conversationDetailsPage.waitForConversationLoad();
+
+    // Verify basic conversation structure
+    await conversationDetailsPage.expectConversationLoaded();
+    await conversationDetailsPage.expectNavigationControls();
+
+    const messageCount = await conversationDetailsPage.getMessageCount();
+    expect(messageCount).toBeGreaterThan(0);
+
+    // Test message structure for each message
+    const messages = conversationDetailsPage.page.getByTestId("message-item");
+    const count = await messages.count();
+
+    for (let i = 0; i < Math.min(count, 3); i++) {
+      // Test first 3 messages
+      const message = messages.nth(i);
+      await expect(message).toBeVisible();
+      await expect(message.getByTestId("message-header")).toBeVisible();
+      await expect(message.getByTestId("message-content")).toBeVisible();
+      await expect(message.getByTestId("message-footer")).toBeVisible();
+    }
+  });
+
+  test("should handle conversation navigation properly", async () => {
+    await conversationDetailsPage.navigateToConversation();
+    await conversationDetailsPage.waitForConversationLoad();
+
+    const initialSubject = await conversationDetailsPage.getConversationSubject();
+    const initialCounter = await conversationDetailsPage.getConversationCounter();
+
+    // Test previous/next navigation
+    await conversationDetailsPage.goToNextConversation();
+    await conversationDetailsPage.waitForConversationLoad();
+
+    const nextSubject = await conversationDetailsPage.getConversationSubject();
+    const nextCounter = await conversationDetailsPage.getConversationCounter();
+
+    // If there are multiple conversations, subjects should be different
+    if (initialCounter !== nextCounter) {
+      expect(nextSubject).not.toBe(initialSubject);
+    }
+
+    // Navigate back
+    await conversationDetailsPage.goToPreviousConversation();
+    await conversationDetailsPage.waitForConversationLoad();
+
+    // Should be back to original conversation
+    const backSubject = await conversationDetailsPage.getConversationSubject();
+    expect(backSubject).toBe(initialSubject);
+  });
+
+  test("should test scroll functionality in long conversations", async () => {
+    await conversationDetailsPage.navigateToConversation();
+    await conversationDetailsPage.waitForConversationLoad();
+
+    const messageCount = await conversationDetailsPage.getMessageCount();
+
+    if (messageCount > 0) {
+      const messageThreadPanel = conversationDetailsPage.page.getByTestId("message-thread-panel");
+
+      // Scroll down
+      await messageThreadPanel.evaluate((el) => {
+        el.scrollTop = 300;
+      });
+
+      // Wait for scroll event processing
+      await conversationDetailsPage.page.waitForTimeout(300);
+
+      // Check if scroll to top button exists
+      const scrollButton = conversationDetailsPage.page.getByTestId("scroll-to-top-button");
+      await expect(scrollButton).toBeAttached();
+
+      // If visible, test clicking it
+      if (await scrollButton.isVisible()) {
+        await scrollButton.click();
+        await conversationDetailsPage.page.waitForTimeout(200);
+
+        // Verify scroll position changed
+        const newScrollTop = await messageThreadPanel.evaluate((el) => el.scrollTop);
+        expect(newScrollTop).toBeLessThan(300);
+      }
+    }
+  });
+
+  test("should close conversation and return to list", async () => {
+    await conversationDetailsPage.navigateToConversation();
+    await conversationDetailsPage.waitForConversationLoad();
+
+    // Test conversation close
+    await conversationDetailsPage.closeConversation();
+
+    // Should be back at conversations list
+    await conversationDetailsPage.page.waitForLoadState("networkidle");
+    await expect(conversationDetailsPage.page.url()).toContain("/conversations");
+
+    // Should see conversation list items
+    await expect(conversationDetailsPage.page.getByTestId("conversation-list-item").first()).toBeVisible();
+  });
+
+  test("should handle conversation counter display correctly", async () => {
+    await conversationDetailsPage.navigateToConversation();
+    await conversationDetailsPage.waitForConversationLoad();
+
+    const counter = await conversationDetailsPage.getConversationCounter();
+
+    // Counter should be in format "X of Y" or "X of Y+"
+    expect(counter).toMatch(/^\d+ of \d+\+?$/);
+
+    // Extract numbers to verify they make sense
+    const match = counter.match(/^(\d+) of (\d+)\+?$/);
+    if (match) {
+      const current = parseInt(match[1]);
+      const total = parseInt(match[2]);
+      expect(current).toBeGreaterThan(0);
+      expect(current).toBeLessThanOrEqual(total);
+    }
+  });
+
+  test("should create and display AI assistant message", async () => {
+    // Navigate to an existing conversation
+    await conversationDetailsPage.navigateToConversation();
+    await conversationDetailsPage.waitForConversationLoad();
+
+    // Get current conversation URL to extract conversation ID
+    const url = conversationDetailsPage.page.url();
+    const conversationSlug = url.split("id=")[1]?.split("&")[0];
+
+    if (conversationSlug) {
+      // Create an AI message via API call
+      const testAIMessage = `AI assistant response ${generateRandomString(8)}`;
+
+      // Make API call to create AI message (simulating AI response)
+      await conversationDetailsPage.page.evaluate(
+        async (data) => {
+          await fetch("/api/chat", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              conversation_slug: data.slug,
+              query: "Test query for AI response",
+              email: "test@example.com",
+            }),
+          });
+        },
+        { slug: conversationSlug },
+      );
+
+      // Wait for the page to update
+      await conversationDetailsPage.page.waitForTimeout(2000);
+      await conversationDetailsPage.page.reload();
+      await conversationDetailsPage.waitForConversationLoad();
+
+      // Verify we have messages with different roles
+      const messages = conversationDetailsPage.page.getByTestId("message-item");
+      const messageCount = await messages.count();
+      expect(messageCount).toBeGreaterThan(0);
+
+      // Look for AI reasoning button if available
+      const reasoningButtons = conversationDetailsPage.page.getByTestId("view-ai-reasoning-button");
+      const reasoningCount = await reasoningButtons.count();
+
+      if (reasoningCount > 0) {
+        await reasoningButtons.first().click();
+        await expect(conversationDetailsPage.page.locator('[role="dialog"]')).toBeVisible();
+        await conversationDetailsPage.page.keyboard.press("Escape");
+      }
+    }
+  });
+
+  test("should create and display internal note", async () => {
+    await conversationDetailsPage.navigateToConversation();
+    await conversationDetailsPage.waitForConversationLoad();
+
+    // Look for add note functionality in message actions
+    const addNoteButton = conversationDetailsPage.page
+      .locator("button")
+      .filter({ hasText: /note|internal/i })
+      .first();
+    const addNoteExists = await addNoteButton.count();
+
+    if (addNoteExists > 0 && (await addNoteButton.isVisible())) {
+      const testNote = `Internal note ${generateRandomString(8)}`;
+
+      await addNoteButton.click();
+
+      // Look for note input field (could be textarea or TipTap editor)
+      const noteInput = conversationDetailsPage.page
+        .locator('textarea, [data-testid="tiptap-editor-content"] .ProseMirror')
+        .first();
+      if (await noteInput.isVisible()) {
+        await noteInput.fill(testNote);
+
+        // Submit the note
+        const submitButton = conversationDetailsPage.page.getByRole("button", { name: /save|add|submit/i });
+        await submitButton.click();
+
+        await conversationDetailsPage.page.waitForLoadState("networkidle");
+
+        // Verify note was created
+        await conversationDetailsPage.expectMessageExists(testNote);
+      }
+    }
+  });
+});

--- a/tests/e2e/utils/page-objects/conversationDetailsPage.ts
+++ b/tests/e2e/utils/page-objects/conversationDetailsPage.ts
@@ -1,0 +1,214 @@
+import { expect, Page } from "@playwright/test";
+
+export class ConversationDetailsPage {
+  readonly page: Page;
+
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  async navigateToConversation(conversationId?: string) {
+    if (conversationId) {
+      await this.page.goto(`/conversations?id=${conversationId}`);
+    } else {
+      // Navigate to conversations list and click first conversation
+      await this.page.goto("/conversations");
+      await this.page.waitForLoadState("networkidle");
+
+      const firstConversation = this.page.getByTestId("conversation-list-item").first();
+      // Click on the actual link within the conversation item
+      const conversationLink = firstConversation.locator("a").first();
+      await conversationLink.click();
+    }
+    await this.page.waitForLoadState("networkidle");
+  }
+
+  async waitForConversationLoad() {
+    await expect(this.page.getByTestId("conversation-header")).toBeVisible();
+    await expect(this.page.getByTestId("message-thread")).toBeVisible();
+  }
+
+  // Header actions
+  async closeConversation() {
+    await this.page.getByTestId("close-conversation-button").click();
+  }
+
+  async goToPreviousConversation() {
+    await this.page.getByTestId("previous-conversation-button").click();
+    await this.page.waitForLoadState("networkidle");
+  }
+
+  async goToNextConversation() {
+    await this.page.getByTestId("next-conversation-button").click();
+    await this.page.waitForLoadState("networkidle");
+  }
+
+  async toggleSidebar() {
+    await this.page.getByTestId("toggle-sidebar-button").click();
+  }
+
+  // Conversation information
+  async getConversationSubject() {
+    const subject = await this.page.getByTestId("conversation-subject").textContent();
+    return subject?.trim() || "";
+  }
+
+  async getConversationCounter() {
+    const counter = await this.page.getByTestId("conversation-counter").textContent();
+    return counter?.trim() || "";
+  }
+
+  async expectConversationSubject(expectedSubject: string) {
+    await expect(this.page.getByTestId("conversation-subject")).toContainText(expectedSubject);
+  }
+
+  // Message thread interactions
+  async getMessageCount() {
+    const messages = this.page.getByTestId("message-item");
+    return await messages.count();
+  }
+
+  async getEventCount() {
+    const events = this.page.getByTestId("event-item");
+    return await events.count();
+  }
+
+  async expectMessageExists(messageContent: string) {
+    const messageItem = this.page.getByTestId("message-item").filter({ hasText: messageContent });
+    await expect(messageItem).toBeVisible();
+  }
+
+  async expectEventExists(eventDescription: string) {
+    const eventItem = this.page.getByTestId("event-item").filter({ hasText: eventDescription });
+    await expect(eventItem).toBeVisible();
+  }
+
+  async clickMessage(messageContent: string) {
+    const messageItem = this.page.getByTestId("message-item").filter({ hasText: messageContent });
+    await messageItem.click();
+  }
+
+  async expandEventDetails(eventDescription: string) {
+    const eventItem = this.page.getByTestId("event-item").filter({ hasText: eventDescription });
+    const summaryButton = eventItem.getByTestId("event-summary-button");
+    await summaryButton.click();
+
+    const eventDetails = eventItem.getByTestId("event-details");
+    await expect(eventDetails).toBeVisible();
+  }
+
+  async expectEventDetails(eventDescription: string, detailsText: string) {
+    const eventItem = this.page.getByTestId("event-item").filter({ hasText: eventDescription });
+    const eventDetails = eventItem.getByTestId("event-details");
+    await expect(eventDetails).toContainText(detailsText);
+  }
+
+  // Message interactions
+  async expandQuotedContext(messageContent: string) {
+    const messageItem = this.page.getByTestId("message-item").filter({ hasText: messageContent });
+    const expandButton = messageItem.getByTestId("expand-quoted-context-button");
+    await expandButton.click();
+  }
+
+  async viewAIReasoning(messageContent: string) {
+    const messageItem = this.page.getByTestId("message-item").filter({ hasText: messageContent });
+    const reasoningButton = messageItem.getByTestId("view-ai-reasoning-button");
+    await reasoningButton.click();
+
+    // Wait for popover to appear
+    await expect(this.page.locator('[role="dialog"]')).toBeVisible();
+  }
+
+  async expectAIReasoningPopover(reasoningText: string) {
+    const popover = this.page.locator('[role="dialog"]');
+    await expect(popover).toContainText(reasoningText);
+  }
+
+  // Attachments
+  async expectMessageHasAttachments(messageContent: string) {
+    const messageItem = this.page.getByTestId("message-item").filter({ hasText: messageContent });
+    const attachments = messageItem.getByTestId("message-attachments");
+    await expect(attachments).toBeVisible();
+  }
+
+  async getAttachmentCount(messageContent: string) {
+    const messageItem = this.page.getByTestId("message-item").filter({ hasText: messageContent });
+    const attachments = messageItem.getByTestId("message-attachments").locator("a");
+    return await attachments.count();
+  }
+
+  async clickAttachment(messageContent: string, attachmentIndex: number = 0) {
+    const messageItem = this.page.getByTestId("message-item").filter({ hasText: messageContent });
+    const attachments = messageItem.getByTestId("message-attachments").locator("a");
+    await attachments.nth(attachmentIndex).click();
+  }
+
+  // Scroll and navigation
+  async scrollToTop() {
+    const scrollButton = this.page.getByTestId("scroll-to-top-button");
+    if (await scrollButton.isVisible()) {
+      await scrollButton.click();
+    }
+  }
+
+  async scrollToBottom() {
+    await this.page.getByTestId("message-thread-panel").evaluate((el) => {
+      el.scrollTop = el.scrollHeight;
+    });
+  }
+
+  // Conversation summary
+  async expectConversationSummary() {
+    await expect(this.page.getByTestId("conversation-summary")).toBeVisible();
+  }
+
+  async expectPromptIndicator() {
+    await expect(this.page.getByTestId("prompt-indicator")).toBeVisible();
+  }
+
+  // Message types
+  async expectUserMessage(messageContent: string) {
+    const messageItem = this.page.getByTestId("message-item").filter({ hasText: messageContent });
+    await expect(messageItem).toHaveAttribute("data-type", "message");
+
+    const header = messageItem.getByTestId("message-header");
+    await expect(header).toBeVisible();
+  }
+
+  async expectAIMessage(messageContent: string) {
+    const messageItem = this.page.getByTestId("message-item").filter({ hasText: messageContent });
+    await expect(messageItem).toHaveAttribute("data-type", "message");
+
+    const content = messageItem.getByTestId("message-content");
+    await expect(content).toBeVisible();
+  }
+
+  async expectNote(noteContent: string) {
+    const messageItem = this.page.getByTestId("message-item").filter({ hasText: noteContent });
+    await expect(messageItem).toHaveAttribute("data-type", "note");
+  }
+
+  // Wait for real-time updates
+  async waitForNewMessage(messageContent: string, timeout: number = 10000) {
+    const messageItem = this.page.getByTestId("message-item").filter({ hasText: messageContent });
+    await expect(messageItem).toBeVisible({ timeout });
+  }
+
+  // General expectations
+  async expectConversationLoaded() {
+    await expect(this.page.getByTestId("conversation-header")).toBeVisible();
+    await expect(this.page.getByTestId("message-thread")).toBeVisible();
+    await expect(this.page.getByTestId("messages-container")).toBeVisible();
+  }
+
+  async expectConversationEmpty() {
+    const messageCount = await this.getMessageCount();
+    expect(messageCount).toBe(0);
+  }
+
+  async expectNavigationControls() {
+    await expect(this.page.getByTestId("previous-conversation-button")).toBeVisible();
+    await expect(this.page.getByTestId("next-conversation-button")).toBeVisible();
+    await expect(this.page.getByTestId("conversation-counter")).toBeVisible();
+  }
+}


### PR DESCRIPTION
Conversation details (e.g. viewing a conversation, navigating to previous/next, rendering types of messages/events)
https://github.com/antiwork/helper/issues/584

Attaching screenshot 

![Screenshot 2025-08-01 at 7 39 31 AM](https://github.com/user-attachments/assets/88e506db-ded3-435f-af1e-93e96044a5ec)
