### PR TITLE
tests: add E2E tests for customer settings page

### DIFF
--- a/app/(dashboard)/settings/customers/customerSetting.tsx
+++ b/app/(dashboard)/settings/customers/customerSetting.tsx
@@ -58,16 +58,17 @@ const CustomerSetting = ({ mailbox }: { mailbox: RouterOutputs["mailbox"]["get"]
   return (
     <div className="relative">
       <div className="absolute top-2 right-4 z-10">
-        <SavingIndicator state={savingIndicator.state} />
+        <SavingIndicator state={savingIndicator.state} data-testid="saving-indicator" />
       </div>
       <SwitchSectionWrapper
         title="VIP Customers"
         description="Configure settings for high-value customers"
         initialSwitchChecked={isEnabled}
         onSwitchChange={setIsEnabled}
+        data-testid="vip-customers-section"
       >
         {isEnabled && (
-          <div className="space-y-8">
+          <div className="space-y-8" data-testid="vip-settings-content">
             <div className="space-y-4">
               <div className="max-w-2xl">
                 <Label htmlFor="vipThreshold" className="text-base font-medium">
@@ -85,6 +86,7 @@ const CustomerSetting = ({ mailbox }: { mailbox: RouterOutputs["mailbox"]["get"]
                   value={threshold}
                   onChange={(e) => setThreshold(e.target.value)}
                   className="mt-2 max-w-sm"
+                  data-testid="vip-threshold-input"
                 />
               </div>
 
@@ -103,6 +105,7 @@ const CustomerSetting = ({ mailbox }: { mailbox: RouterOutputs["mailbox"]["get"]
                     step="1"
                     value={responseHours}
                     onChange={(e) => setResponseHours(e.target.value)}
+                    data-testid="response-hours-input"
                   />
                   <span className="text-sm text-muted-foreground whitespace-nowrap">hours</span>
                 </div>
@@ -119,16 +122,17 @@ const CustomerSetting = ({ mailbox }: { mailbox: RouterOutputs["mailbox"]["get"]
                 <p className="mt-2 text-sm text-muted-foreground">
                   Choose a Slack channel to receive notifications about VIP customer messages
                 </p>
-                <div className="mt-4">
+                <div className="mt-4" data-testid="slack-notifications-section">
                   {mailbox.slackConnected ? (
                     <SlackChannels
                       id="vipChannel"
                       selectedChannelId={mailbox.vipChannelId ?? undefined}
                       mailbox={mailbox}
                       onChange={(vipChannelId) => update({ vipChannelId })}
+                      data-testid="slack-channels-selector"
                     />
                   ) : (
-                    <Alert>
+                    <Alert data-testid="slack-integration-alert">
                       <AlertDescription>
                         Slack integration is required for VIP channel notifications. Please configure Slack in the
                         Integrations tab.

--- a/app/(dashboard)/settings/sectionWrapper.tsx
+++ b/app/(dashboard)/settings/sectionWrapper.tsx
@@ -12,11 +12,20 @@ type SectionWrapperProps = {
   className?: string;
   action?: React.ReactNode;
   children: React.ReactNode;
+  "data-testid"?: string;
 };
 
-const SectionWrapper = ({ title, description, fullWidth, className, action, children }: SectionWrapperProps) => {
+const SectionWrapper = ({
+  title,
+  description,
+  fullWidth,
+  className,
+  action,
+  children,
+  "data-testid": dataTestId,
+}: SectionWrapperProps) => {
   return (
-    <section className="flex flex-col gap-4 border-b py-8 first:pt-4 lg:flex-row">
+    <section className="flex flex-col gap-4 border-b py-8 first:pt-4 lg:flex-row" data-testid={dataTestId}>
       <div className="flex w-full flex-col gap-3 lg:max-w-xs">
         <div className="flex w-full flex-col gap-1">
           <h2 className="text-base flex items-center gap-2">{title}</h2>
@@ -37,6 +46,7 @@ type SwitchSectionWrapperProps = {
   onSwitchChange: (checked: boolean) => void;
   className?: string;
   children: React.ReactNode;
+  "data-testid"?: string;
 };
 
 const SwitchSectionWrapper = ({
@@ -47,6 +57,7 @@ const SwitchSectionWrapper = ({
   onSwitchChange,
   className,
   children,
+  "data-testid": dataTestId,
 }: SwitchSectionWrapperProps) => {
   const [isSwitchChecked, setIsSwitchChecked] = useState(initialSwitchChecked);
 
@@ -68,7 +79,15 @@ const SwitchSectionWrapper = ({
       description={description}
       fullWidth={fullWidth}
       className={className}
-      action={<Switch aria-label={`${title} Switch`} checked={isSwitchChecked} onCheckedChange={handleSwitchChange} />}
+      action={
+        <Switch
+          aria-label={`${title} Switch`}
+          checked={isSwitchChecked}
+          onCheckedChange={handleSwitchChange}
+          data-testid={dataTestId ? `${dataTestId}-switch` : undefined}
+        />
+      }
+      data-testid={dataTestId}
     >
       {children}
     </SectionWrapper>

--- a/components/savingIndicator.tsx
+++ b/components/savingIndicator.tsx
@@ -5,9 +5,10 @@ import { cn } from "@/lib/utils";
 interface SavingIndicatorProps {
   state: SavingState;
   className?: string;
+  "data-testid"?: string;
 }
 
-export function SavingIndicator({ state, className }: SavingIndicatorProps) {
+export function SavingIndicator({ state, className, "data-testid": dataTestId }: SavingIndicatorProps) {
   if (state === "idle") return null;
 
   return (
@@ -20,6 +21,7 @@ export function SavingIndicator({ state, className }: SavingIndicatorProps) {
         },
         className,
       )}
+      data-testid={dataTestId}
     >
       {state === "saving" && (
         <>

--- a/tests/e2e/customer-settings/customerSettings.spec.ts
+++ b/tests/e2e/customer-settings/customerSettings.spec.ts
@@ -1,0 +1,115 @@
+import { expect, test } from "@playwright/test";
+import { CustomerSettingsPage } from "../utils/page-objects/customerSettingsPage";
+import { generateRandomString } from "../utils/test-helpers";
+
+test.use({ storageState: "tests/e2e/.auth/user.json" });
+
+test.describe("Customer Settings", () => {
+  let customerSettingsPage: CustomerSettingsPage;
+
+  test.beforeEach(async ({ page }) => {
+    customerSettingsPage = new CustomerSettingsPage(page);
+    await customerSettingsPage.navigateToCustomerSettings();
+  });
+
+  test("should enable VIP customers", async () => {
+    // First disable it if enabled
+    await customerSettingsPage.disableVipCustomers();
+    await customerSettingsPage.expectVipCustomersDisabled();
+
+    // Then enable it
+    await customerSettingsPage.enableVipCustomers();
+    await customerSettingsPage.expectVipCustomersEnabled();
+
+    // Verify all VIP settings are visible
+    await expect(customerSettingsPage.page.getByTestId("vip-threshold-input")).toBeVisible();
+    await expect(customerSettingsPage.page.getByTestId("response-hours-input")).toBeVisible();
+    await expect(customerSettingsPage.page.getByTestId("slack-notifications-section")).toBeVisible();
+  });
+
+  test("should disable VIP customers", async () => {
+    // First enable it if disabled
+    await customerSettingsPage.enableVipCustomers();
+    await customerSettingsPage.expectVipCustomersEnabled();
+
+    // Then disable it
+    await customerSettingsPage.disableVipCustomers();
+    await customerSettingsPage.expectVipCustomersDisabled();
+  });
+
+  test("should set VIP threshold value", async () => {
+    const testThreshold = "250";
+
+    await customerSettingsPage.setVipThreshold(testThreshold);
+    await customerSettingsPage.expectVipThreshold(testThreshold);
+  });
+
+  test("should set response hours", async () => {
+    const testHours = "4";
+
+    await customerSettingsPage.setResponseHours(testHours);
+    await customerSettingsPage.expectResponseHours(testHours);
+  });
+
+  test("should update threshold and response hours together", async () => {
+    const testThreshold = "500.75";
+    const testHours = "2";
+
+    // Enable VIP customers first
+    await customerSettingsPage.enableVipCustomers();
+
+    // Set both values
+    await customerSettingsPage.setVipThreshold(testThreshold);
+    await customerSettingsPage.setResponseHours(testHours);
+
+    // Verify both values are set
+    await customerSettingsPage.expectVipThreshold(testThreshold);
+    await customerSettingsPage.expectResponseHours(testHours);
+    await customerSettingsPage.waitForSaved();
+  });
+
+  test("should validate numeric input for threshold", async () => {
+    await customerSettingsPage.enableVipCustomers();
+
+    const thresholdInput = customerSettingsPage.page.getByTestId("vip-threshold-input");
+
+    // Verify input type and constraints
+    await expect(thresholdInput).toHaveAttribute("type", "number");
+    await expect(thresholdInput).toHaveAttribute("min", "0");
+    await expect(thresholdInput).toHaveAttribute("step", "0.01");
+  });
+
+  test("should validate numeric input for response hours", async () => {
+    await customerSettingsPage.enableVipCustomers();
+
+    const responseHoursInput = customerSettingsPage.page.getByTestId("response-hours-input");
+
+    // Verify input type and constraints
+    await expect(responseHoursInput).toHaveAttribute("type", "number");
+    await expect(responseHoursInput).toHaveAttribute("min", "1");
+    await expect(responseHoursInput).toHaveAttribute("step", "1");
+  });
+
+  test("should handle decimal values in threshold", async () => {
+    const decimalThreshold = "99.99";
+
+    await customerSettingsPage.setVipThreshold(decimalThreshold);
+    await customerSettingsPage.expectVipThreshold(decimalThreshold);
+    await customerSettingsPage.waitForSaved();
+  });
+
+  test("should accept input changes", async () => {
+    await customerSettingsPage.enableVipCustomers();
+
+    // Set a value and wait for any save attempts to complete
+    const thresholdInput = customerSettingsPage.page.getByTestId("vip-threshold-input");
+    await thresholdInput.click();
+    await thresholdInput.fill("123.45");
+
+    // Wait for any save operations to complete (but don't require success)
+    await customerSettingsPage.waitForSaveComplete();
+
+    // Verify the input value is set (UI state)
+    await expect(thresholdInput).toHaveValue("123.45");
+  });
+});

--- a/tests/e2e/utils/page-objects/customerSettingsPage.ts
+++ b/tests/e2e/utils/page-objects/customerSettingsPage.ts
@@ -1,0 +1,148 @@
+import { expect, type Page } from "@playwright/test";
+
+export class CustomerSettingsPage {
+  readonly page: Page;
+
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  async navigateToCustomerSettings() {
+    await this.page.goto("/settings/customers");
+    await expect(this.page.getByTestId("vip-customers-section")).toBeVisible();
+  }
+
+  async enableVipCustomers() {
+    const vipSwitch = this.page.getByTestId("vip-customers-section-switch");
+    const isChecked = await vipSwitch.isChecked();
+
+    if (!isChecked) {
+      await vipSwitch.click();
+      await this.page.waitForLoadState("networkidle");
+      await expect(this.page.getByTestId("vip-settings-content")).toBeVisible();
+    }
+  }
+
+  async disableVipCustomers() {
+    const vipSwitch = this.page.getByTestId("vip-customers-section-switch");
+    const isChecked = await vipSwitch.isChecked();
+
+    if (isChecked) {
+      await vipSwitch.click();
+      await this.page.waitForLoadState("networkidle");
+      await expect(this.page.getByTestId("vip-settings-content")).not.toBeVisible();
+    }
+  }
+
+  async setVipThreshold(threshold: string) {
+    await this.enableVipCustomers();
+
+    const thresholdInput = this.page.getByTestId("vip-threshold-input");
+    await thresholdInput.click();
+    await thresholdInput.fill(threshold);
+    await this.waitForSaveComplete();
+  }
+
+  async setResponseHours(hours: string) {
+    await this.enableVipCustomers();
+
+    const responseHoursInput = this.page.getByTestId("response-hours-input");
+    await responseHoursInput.click();
+    await responseHoursInput.fill(hours);
+    await this.waitForSaveComplete();
+  }
+
+  async clearResponseHours() {
+    await this.enableVipCustomers();
+
+    const responseHoursInput = this.page.getByTestId("response-hours-input");
+    await responseHoursInput.click();
+    await responseHoursInput.fill("");
+    await this.waitForSaveComplete();
+  }
+
+  async expectVipCustomersEnabled() {
+    const vipSwitch = this.page.getByTestId("vip-customers-section-switch");
+    await expect(vipSwitch).toBeChecked();
+    await expect(this.page.getByTestId("vip-settings-content")).toBeVisible();
+  }
+
+  async expectVipCustomersDisabled() {
+    const vipSwitch = this.page.getByTestId("vip-customers-section-switch");
+    await expect(vipSwitch).not.toBeChecked();
+    await expect(this.page.getByTestId("vip-settings-content")).not.toBeVisible();
+  }
+
+  async expectVipThreshold(expectedValue: string) {
+    await this.enableVipCustomers();
+
+    const thresholdInput = this.page.getByTestId("vip-threshold-input");
+    await expect(thresholdInput).toHaveValue(expectedValue);
+  }
+
+  async expectResponseHours(expectedValue: string) {
+    await this.enableVipCustomers();
+
+    const responseHoursInput = this.page.getByTestId("response-hours-input");
+    await expect(responseHoursInput).toHaveValue(expectedValue);
+  }
+
+  async expectSlackIntegrationAlert() {
+    await this.enableVipCustomers();
+
+    await expect(this.page.getByTestId("slack-integration-alert")).toBeVisible();
+    await expect(this.page.getByTestId("slack-integration-alert")).toContainText("Slack integration is required");
+  }
+
+  async expectSlackChannelSelector() {
+    await this.enableVipCustomers();
+
+    await expect(this.page.getByTestId("slack-channels-selector")).toBeVisible();
+    await expect(this.page.getByTestId("slack-integration-alert")).not.toBeVisible();
+  }
+
+  async expectSavingIndicator(state: "saving" | "saved" | "error") {
+    const savingIndicator = this.page.getByTestId("saving-indicator");
+
+    // Wait for the indicator to show the expected state
+    await expect(savingIndicator).toBeVisible();
+
+    if (state === "saving") {
+      await expect(savingIndicator).toContainText("Saving");
+    } else if (state === "saved") {
+      await expect(savingIndicator).toContainText("Saved");
+    } else if (state === "error") {
+      await expect(savingIndicator).toContainText("Error");
+    }
+  }
+
+  async waitForSaveComplete() {
+    // Wait for network idle to ensure any save operations are done
+    await this.page.waitForLoadState("networkidle");
+
+    // Wait a bit more to ensure any debounced saves have completed
+    await this.page.waitForTimeout(1000);
+  }
+
+  async waitForSaved() {
+    // For tests that specifically want to verify successful save
+    await this.waitForSaveComplete();
+
+    const savingIndicator = this.page.getByTestId("saving-indicator");
+    const isVisible = await savingIndicator.isVisible().catch(() => false);
+
+    if (isVisible) {
+      const indicatorText = await savingIndicator.textContent();
+
+      // If there's an error, throw to fail the test appropriately
+      if (indicatorText?.includes("Error")) {
+        throw new Error(`Save failed: ${indicatorText}`);
+      }
+
+      // If it's still saving, wait for it to complete
+      if (indicatorText?.includes("Saving")) {
+        await expect(savingIndicator).toContainText("Saved", { timeout: 10000 });
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR add E2E tests for "Customer Settings Page" as mentioned in https://github.com/antiwork/helper/issues/584