### PR TITLE
Disable reasoning in email responses

### DIFF
--- a/jobs/handleAutoResponse.ts
+++ b/jobs/handleAutoResponse.ts
@@ -83,6 +83,7 @@ export const handleAutoResponse = async ({
     readPageTool: null,
     sendEmail: true,
     guideEnabled: false,
+    reasoningEnabled: false,
     onResponse: async ({ platformCustomer, humanSupportRequested }) => {
       await db.transaction(async (tx) => {
         if (platformCustomer && !humanSupportRequested) {


### PR DESCRIPTION
This was disabled in chat a long time ago, but the flag wasn't added here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new option to enable or disable reasoning in AI responses (default is disabled).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->