### PR TITLE
test(e2e) : add tests for website learning

### DIFF
--- a/app/(dashboard)/settings/knowledge/websiteCrawlSetting.tsx
+++ b/app/(dashboard)/settings/knowledge/websiteCrawlSetting.tsx
@@ -144,6 +144,7 @@ const WebsiteCrawlSetting = () => {
                 <div
                   key={website.id}
                   className="group relative flex items-center gap-4 rounded-lg border p-4 hover:bg-muted/50"
+                  data-testid="website-item"
                 >
                   <div className="flex-1 min-w-0 space-y-2">
                     <div className="flex items-center gap-2">

--- a/tests/e2e/utils/page-objects/savedRepliesPage.ts
+++ b/tests/e2e/utils/page-objects/savedRepliesPage.ts
@@ -1,5 +1,6 @@
 import { expect, Locator, Page } from "@playwright/test";
 import { BasePage } from "./basePage";
+import { waitForToast } from "../toastHelpers";
 
 export class SavedRepliesPage extends BasePage {
   readonly pageTitle: Locator;
@@ -213,31 +214,7 @@ export class SavedRepliesPage extends BasePage {
   }
 
   async waitForToast(message: string) {
-    try {
-      const toastSelectors = [
-        `[role="alert"]:has-text("${message}")`,
-        `[data-testid="toast"]:has-text("${message}")`,
-        `.toast:has-text("${message}")`,
-        `*:has-text("${message}")[role="status"]`,
-      ];
-
-      let toastFound = false;
-      for (const selector of toastSelectors) {
-        try {
-          await this.page.locator(selector).waitFor({ state: "visible", timeout: 2000 });
-          toastFound = true;
-          break;
-        } catch {
-          // Try next selector
-        }
-      }
-
-      if (!toastFound) {
-        await this.page.waitForSelector(`text="${message}"`, { timeout: 1000 });
-      }
-    } catch (error) {
-      console.log(`Toast message "${message}" not found, continuing...`);
-    }
+    await waitForToast(this.page, message);
   }
 
   async openCreateDialog() {

--- a/tests/e2e/utils/page-objects/savedRepliesPage.ts
+++ b/tests/e2e/utils/page-objects/savedRepliesPage.ts
@@ -1,6 +1,6 @@
 import { expect, Locator, Page } from "@playwright/test";
-import { BasePage } from "./basePage";
 import { waitForToast } from "../toastHelpers";
+import { BasePage } from "./basePage";
 
 export class SavedRepliesPage extends BasePage {
   readonly pageTitle: Locator;

--- a/tests/e2e/utils/page-objects/websiteLearningPage.ts
+++ b/tests/e2e/utils/page-objects/websiteLearningPage.ts
@@ -1,6 +1,6 @@
 import { expect, Page } from "@playwright/test";
-import { BasePage } from "./basePage";
 import { waitForToast } from "../toastHelpers";
+import { BasePage } from "./basePage";
 
 interface TestWebsite {
   name: string;
@@ -9,9 +9,10 @@ interface TestWebsite {
 
 export class WebsiteLearningPage extends BasePage {
   private readonly websiteLearningTitle = 'h2:has-text("Website Learning")';
-  private readonly websiteDescription = 'text="Helper will learn about your product by reading your websites to provide better responses."';
+  private readonly websiteDescription =
+    'text="Helper will learn about your product by reading your websites to provide better responses."';
   private readonly addWebsiteButton = 'button:has-text("Add website")';
-  private readonly urlInput = 'input#url';
+  private readonly urlInput = "input#url";
   private readonly urlLabel = 'label[for="url"]';
   private readonly cancelButton = 'button:has-text("Cancel")';
   private readonly submitButton = 'form button[type="submit"]';
@@ -84,7 +85,7 @@ export class WebsiteLearningPage extends BasePage {
     const websiteItem = this.page.locator(this.websiteItems).filter({
       has: this.page.locator(`text="${websiteName}"`),
     });
-    
+
     await expect(websiteItem).toBeVisible({ timeout: 15000 });
   }
 }

--- a/tests/e2e/utils/page-objects/websiteLearningPage.ts
+++ b/tests/e2e/utils/page-objects/websiteLearningPage.ts
@@ -1,0 +1,113 @@
+import { expect, Page } from "@playwright/test";
+import { BasePage } from "./basePage";
+
+interface TestWebsite {
+  name: string;
+  url: string;
+}
+
+export class WebsiteLearningPage extends BasePage {
+  private readonly websiteLearningTitle = 'h2:has-text("Website Learning")';
+  private readonly websiteDescription = 'text="Helper will learn about your product by reading your websites to provide better responses."';
+  private readonly addWebsiteButton = 'button:has-text("Add website")';
+  private readonly urlInput = 'input#url';
+  private readonly urlLabel = 'label[for="url"]';
+  private readonly cancelButton = 'button:has-text("Cancel")';
+  private readonly submitButton = 'form button[type="submit"]';
+  private readonly errorText = '.text-sm.text-destructive';
+  private readonly websiteItems = 'div.rounded-lg.border';
+  private readonly externalLinks = 'a[target="_blank"]';
+
+  constructor(page: Page) {
+    super(page);
+  }
+
+  async navigateToKnowledgeSettings() {
+    await this.goto("/settings/knowledge");
+    await this.waitForPageLoad();
+  }
+
+  async expectWebsiteLearningSection() {
+    await expect(this.page.locator(this.websiteLearningTitle)).toBeVisible();
+    await expect(this.page.locator(this.websiteDescription)).toBeVisible();
+  }
+
+  async expectAddWebsiteButton() {
+    await expect(this.page.locator(this.addWebsiteButton)).toBeVisible();
+  }
+
+  async expectAddWebsiteForm() {
+    await expect(this.page.locator(this.urlLabel)).toBeVisible();
+    await expect(this.page.locator(this.urlInput)).toBeVisible();
+    await expect(this.page.locator(this.cancelButton)).toBeVisible();
+    await expect(this.page.locator(this.submitButton)).toBeVisible();
+  }
+
+  async expectFormHidden() {
+    await expect(this.page.locator(this.urlInput)).not.toBeVisible();
+  }
+
+  async clickAddWebsite() {
+    await this.page.locator(this.addWebsiteButton).click();
+    await this.page.waitForTimeout(500);
+  }
+
+  async fillWebsiteUrl(url: string) {
+    await this.page.locator(this.urlInput).fill(url);
+  }
+
+  async submitAddWebsiteForm() {
+    await this.page.locator(this.submitButton).click();
+    await this.page.waitForLoadState("networkidle");
+  }
+
+  async cancelAddWebsiteForm() {
+    await this.page.locator(this.cancelButton).click();
+  }
+
+  async expectUrlValidationError(expectedError: string) {
+    const errorElement = this.page.locator(this.errorText);
+    await expect(errorElement).toBeVisible();
+    await expect(errorElement).toContainText(expectedError);
+  }
+
+  generateTestWebsite(): TestWebsite {
+    const timestamp = Date.now();
+    const url = `https://test-${timestamp}.example.com`;
+    const name = `test-${timestamp}.example.com`;
+    return { name, url };
+  }
+
+  async expectToastMessage(message: string) {
+    const toastSelectors = [
+      '[data-sonner-toast]',
+      '[data-sonner-toaster] li',
+      '.toaster li',
+      '[role="status"]',
+      '[aria-live="polite"]'
+    ];
+    
+    let found = false;
+    for (const selector of toastSelectors) {
+      const toast = this.page.locator(selector).filter({ hasText: message });
+      if (await toast.count() > 0) {
+        await expect(toast.first()).toBeVisible({ timeout: 8000 });
+        found = true;
+        break;
+      }
+    }
+    
+    if (!found) {
+      const fallbackToast = this.page.locator(`text=${message}`).first();
+      await expect(fallbackToast).toBeVisible({ timeout: 8000 });
+    }
+  }
+
+  async expectWebsiteInList(websiteName: string) {
+    const websiteItem = this.page.locator(this.websiteItems).filter({
+      has: this.page.locator(`text="${websiteName}"`),
+    });
+    
+    await expect(websiteItem).toBeVisible({ timeout: 15000 });
+  }
+}

--- a/tests/e2e/utils/page-objects/websiteLearningPage.ts
+++ b/tests/e2e/utils/page-objects/websiteLearningPage.ts
@@ -1,5 +1,6 @@
 import { expect, Page } from "@playwright/test";
 import { BasePage } from "./basePage";
+import { waitForToast } from "../toastHelpers";
 
 interface TestWebsite {
   name: string;
@@ -14,8 +15,7 @@ export class WebsiteLearningPage extends BasePage {
   private readonly urlLabel = 'label[for="url"]';
   private readonly cancelButton = 'button:has-text("Cancel")';
   private readonly submitButton = 'form button[type="submit"]';
-  private readonly errorText = '.text-sm.text-destructive';
-  private readonly websiteItems = 'div.rounded-lg.border';
+  private readonly websiteItems = '[data-testid="website-item"]';
   private readonly externalLinks = 'a[target="_blank"]';
 
   constructor(page: Page) {
@@ -66,9 +66,7 @@ export class WebsiteLearningPage extends BasePage {
   }
 
   async expectUrlValidationError(expectedError: string) {
-    const errorElement = this.page.locator(this.errorText);
-    await expect(errorElement).toBeVisible();
-    await expect(errorElement).toContainText(expectedError);
+    await expect(this.page.getByText(expectedError)).toBeVisible();
   }
 
   generateTestWebsite(): TestWebsite {
@@ -79,28 +77,7 @@ export class WebsiteLearningPage extends BasePage {
   }
 
   async expectToastMessage(message: string) {
-    const toastSelectors = [
-      '[data-sonner-toast]',
-      '[data-sonner-toaster] li',
-      '.toaster li',
-      '[role="status"]',
-      '[aria-live="polite"]'
-    ];
-    
-    let found = false;
-    for (const selector of toastSelectors) {
-      const toast = this.page.locator(selector).filter({ hasText: message });
-      if (await toast.count() > 0) {
-        await expect(toast.first()).toBeVisible({ timeout: 8000 });
-        found = true;
-        break;
-      }
-    }
-    
-    if (!found) {
-      const fallbackToast = this.page.locator(`text=${message}`).first();
-      await expect(fallbackToast).toBeVisible({ timeout: 8000 });
-    }
+    await waitForToast(this.page, message);
   }
 
   async expectWebsiteInList(websiteName: string) {

--- a/tests/e2e/utils/toastHelpers.ts
+++ b/tests/e2e/utils/toastHelpers.ts
@@ -1,6 +1,6 @@
 import { expect, Page } from "@playwright/test";
 
 export async function waitForToast(page: Page, message: string) {
-  const toast = page.locator('[data-sonner-toast]').filter({ hasText: message });
+  const toast = page.locator("[data-sonner-toast]").filter({ hasText: message });
   await expect(toast.first()).toBeVisible({ timeout: 8000 });
 }

--- a/tests/e2e/utils/toastHelpers.ts
+++ b/tests/e2e/utils/toastHelpers.ts
@@ -10,18 +10,14 @@ export async function waitForToast(page: Page, message: string) {
     '[aria-live="polite"]'
   ];
   
-  let found = false;
   for (const selector of toastSelectors) {
     const toast = page.locator(selector).filter({ hasText: message });
-    if (await toast.count() > 0) {
-      await expect(toast.first()).toBeVisible({ timeout: 8000 });
-      found = true;
-      break;
+    try {
+      await expect(toast.first()).toBeVisible({ timeout: 2000 });
+      return; 
+    } catch {
     }
   }
   
-  if (!found) {
-    const fallbackToast = page.locator(`text=${message}`).first();
-    await expect(fallbackToast).toBeVisible({ timeout: 8000 });
-  }
+  await expect(page.getByText(message)).toBeVisible({ timeout: 8000 });
 }

--- a/tests/e2e/utils/toastHelpers.ts
+++ b/tests/e2e/utils/toastHelpers.ts
@@ -10,14 +10,18 @@ export async function waitForToast(page: Page, message: string) {
     '[aria-live="polite"]'
   ];
   
+  let toastFound = false;
   for (const selector of toastSelectors) {
     const toast = page.locator(selector).filter({ hasText: message });
     try {
       await expect(toast.first()).toBeVisible({ timeout: 2000 });
-      return; 
+      toastFound = true;
+      break;
     } catch {
     }
   }
   
-  await expect(page.getByText(message)).toBeVisible({ timeout: 8000 });
+  if (!toastFound) {
+    await expect(page.getByText(message)).toBeVisible({ timeout: 8000 });
+  }
 }

--- a/tests/e2e/utils/toastHelpers.ts
+++ b/tests/e2e/utils/toastHelpers.ts
@@ -1,0 +1,27 @@
+import { expect, Page } from "@playwright/test";
+
+export async function waitForToast(page: Page, message: string) {
+  const toastSelectors = [
+    '[data-sonner-toast]',
+    '[data-sonner-toaster] li',
+    '.toaster li',
+    '[role="status"]',
+    '[role="alert"]',
+    '[aria-live="polite"]'
+  ];
+  
+  let found = false;
+  for (const selector of toastSelectors) {
+    const toast = page.locator(selector).filter({ hasText: message });
+    if (await toast.count() > 0) {
+      await expect(toast.first()).toBeVisible({ timeout: 8000 });
+      found = true;
+      break;
+    }
+  }
+  
+  if (!found) {
+    const fallbackToast = page.locator(`text=${message}`).first();
+    await expect(fallbackToast).toBeVisible({ timeout: 8000 });
+  }
+}

--- a/tests/e2e/utils/toastHelpers.ts
+++ b/tests/e2e/utils/toastHelpers.ts
@@ -1,27 +1,6 @@
 import { expect, Page } from "@playwright/test";
 
 export async function waitForToast(page: Page, message: string) {
-  const toastSelectors = [
-    '[data-sonner-toast]',
-    '[data-sonner-toaster] li',
-    '.toaster li',
-    '[role="status"]',
-    '[role="alert"]',
-    '[aria-live="polite"]'
-  ];
-  
-  let toastFound = false;
-  for (const selector of toastSelectors) {
-    const toast = page.locator(selector).filter({ hasText: message });
-    try {
-      await expect(toast.first()).toBeVisible({ timeout: 2000 });
-      toastFound = true;
-      break;
-    } catch {
-    }
-  }
-  
-  if (!toastFound) {
-    await expect(page.getByText(message)).toBeVisible({ timeout: 8000 });
-  }
+  const toast = page.locator('[data-sonner-toast]').filter({ hasText: message });
+  await expect(toast.first()).toBeVisible({ timeout: 8000 });
 }

--- a/tests/e2e/website-learning/websiteLearning.spec.ts
+++ b/tests/e2e/website-learning/websiteLearning.spec.ts
@@ -1,0 +1,54 @@
+import { expect, test } from "@playwright/test";
+import { WebsiteLearningPage } from "../utils/page-objects/websiteLearningPage";
+
+test.use({ storageState: "tests/e2e/.auth/user.json" });
+
+test.describe("Website Learning UI Smoke Tests", () => {
+  let websiteLearningPage: WebsiteLearningPage;
+
+  test.beforeEach(async ({ page }) => {
+    websiteLearningPage = new WebsiteLearningPage(page);
+    try {
+      await websiteLearningPage.navigateToKnowledgeSettings();
+      await page.waitForLoadState("networkidle", { timeout: 10000 });
+    } catch (error) {
+      console.log("Navigation failed, retrying...", error);
+      await websiteLearningPage.navigateToKnowledgeSettings();
+      await page.waitForLoadState("domcontentloaded", { timeout: 30000 });
+    }
+  });
+
+  test("displays main website learning interface", async () => {
+    await websiteLearningPage.expectWebsiteLearningSection();
+    await websiteLearningPage.expectAddWebsiteButton();
+  });
+
+  test("shows add website form on button click", async () => {
+    await websiteLearningPage.clickAddWebsite();
+    await websiteLearningPage.expectAddWebsiteForm();
+  });
+
+  test("hides form when cancelled", async () => {
+    await websiteLearningPage.clickAddWebsite();
+    await websiteLearningPage.cancelAddWebsiteForm();
+    await websiteLearningPage.expectFormHidden();
+  });
+
+  test("validates invalid URL format", async () => {
+    await websiteLearningPage.clickAddWebsite();
+    await websiteLearningPage.fillWebsiteUrl("invalid url");
+    await websiteLearningPage.submitAddWebsiteForm();
+    await websiteLearningPage.expectUrlValidationError("Failed to add website. Please try again.");
+  });
+
+  test("adds website with valid URL", async () => {
+    const testSite = websiteLearningPage.generateTestWebsite();
+    
+    await websiteLearningPage.clickAddWebsite();
+    await websiteLearningPage.fillWebsiteUrl(testSite.url);
+    await websiteLearningPage.submitAddWebsiteForm();
+    
+    await websiteLearningPage.expectToastMessage("Website added!");
+    await websiteLearningPage.expectWebsiteInList(testSite.name);
+  });
+});

--- a/tests/e2e/website-learning/websiteLearning.spec.ts
+++ b/tests/e2e/website-learning/websiteLearning.spec.ts
@@ -40,11 +40,11 @@ test.describe("Website Learning UI Smoke Tests", () => {
 
   test("adds website with valid URL", async () => {
     const testSite = websiteLearningPage.generateTestWebsite();
-    
+
     await websiteLearningPage.clickAddWebsite();
     await websiteLearningPage.fillWebsiteUrl(testSite.url);
     await websiteLearningPage.submitAddWebsiteForm();
-    
+
     await websiteLearningPage.expectToastMessage("Website added!");
     await websiteLearningPage.expectWebsiteInList(testSite.name);
   });

--- a/tests/e2e/website-learning/websiteLearning.spec.ts
+++ b/tests/e2e/website-learning/websiteLearning.spec.ts
@@ -18,12 +18,9 @@ test.describe("Website Learning UI Smoke Tests", () => {
     }
   });
 
-  test("displays main website learning interface", async () => {
+  test("displays the website learning section and add website form", async () => {
     await websiteLearningPage.expectWebsiteLearningSection();
     await websiteLearningPage.expectAddWebsiteButton();
-  });
-
-  test("shows add website form on button click", async () => {
     await websiteLearningPage.clickAddWebsite();
     await websiteLearningPage.expectAddWebsiteForm();
   });


### PR DESCRIPTION

### What 
PR address #584 sub-point `Website learning (UI smoke test only)`

### Playwright Test Report 
<img width="1765" height="845" alt="image" src="https://github.com/user-attachments/assets/0358945f-65a1-4e02-bf70-13ca49810061" />

### Local Tests
<img width="587" height="162" alt="image" src="https://github.com/user-attachments/assets/2e9c5769-a724-43a1-8fef-8e8ae566b673" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive end-to-end tests for the Website Learning UI, including form interactions, validation, and website addition flows.
  * Introduced a new page object to streamline and standardize test interactions with the Website Learning feature.
* **Chores**
  * Improved test reliability by adding a test identifier to website list items.
  * Enhanced toast notification detection with a new utility function and refactored related test code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->