### PR TITLE
Don't require OpenAI API key env var in test

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,3 +1,5 @@
+IS_TEST_ENV=1
+
 # Supabase configuration for local testing (required for testing environment)
 # Ensure these ports do not conflict with other services on your machine.
 # The project ID should be unique to avoid conflicts with other instances.

--- a/.env.test.local.sample
+++ b/.env.test.local.sample
@@ -1,4 +1,0 @@
-# These variables are used to configure the local testing environment.
-# Make sure to set them according to your local setup in `.env.test.local`.
-
-OPENAI_API_KEY="sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"

--- a/lib/ai/mockOpenAI.ts
+++ b/lib/ai/mockOpenAI.ts
@@ -1,7 +1,5 @@
 import { MockEmbeddingModelV1, MockLanguageModelV1 } from "ai/test";
-import { env } from "@/lib/env";
-
-const isTesting = env.NODE_ENV === "test" || env.CI;
+import { isAIMockingEnabled } from "@/lib/env";
 
 const createMockLanguageModel = () =>
   new MockLanguageModelV1({
@@ -47,7 +45,7 @@ const createMockEmbeddingModel = () =>
   });
 
 export const createMockOpenAI = () => {
-  if (!isTesting) {
+  if (!isAIMockingEnabled) {
     throw new Error(`Mock OpenAI should only be used in testing/CI environments`);
   }
 
@@ -58,5 +56,3 @@ export const createMockOpenAI = () => {
 
   return mockProvider;
 };
-
-export const isMockingEnabled = () => isTesting;

--- a/lib/ai/openai.ts
+++ b/lib/ai/openai.ts
@@ -1,8 +1,8 @@
 import { createOpenAI } from "@ai-sdk/openai";
-import { createMockOpenAI, isMockingEnabled } from "@/lib/ai/mockOpenAI";
-import { env } from "@/lib/env";
+import { createMockOpenAI } from "@/lib/ai/mockOpenAI";
+import { env, isAIMockingEnabled } from "@/lib/env";
 
-const openai = isMockingEnabled()
+const openai = isAIMockingEnabled
   ? createMockOpenAI()
   : createOpenAI({
       apiKey: env.OPENAI_API_KEY,

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -10,6 +10,9 @@ const defaultRootUrl =
     ? `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`
     : `https://${process.env.VERCEL_URL ?? "helperai.dev"}`;
 
+// `next dev` forces NODE_ENV to "development" so we need to use a different environment variable
+export const isAIMockingEnabled = process.env.IS_TEST_ENV === "1";
+
 export const env = createEnv({
   extends: [vercel()],
   shared: {
@@ -29,7 +32,7 @@ export const env = createEnv({
    */
   server: {
     // Set this for both local development and when deploying
-    OPENAI_API_KEY: z.string().min(1), // API key from https://platform.openai.com for AI models
+    OPENAI_API_KEY: isAIMockingEnabled ? z.string().min(1).default("mock-openai-api-key") : z.string().min(1), // API key from https://platform.openai.com for AI models
 
     // Set this before deploying
     ENCRYPT_COLUMN_SECRET: defaultUnlessDeployed(

--- a/tests/support/setup.ts
+++ b/tests/support/setup.ts
@@ -5,6 +5,7 @@ beforeAll(() => {
   vi.stubEnv("POSTGRES_URL", inject("TEST_DATABASE_URL"));
 
   vi.mock("@/lib/env", () => ({
+    isAIMockingEnabled: false,
     env: {
       POSTGRES_URL: inject("TEST_DATABASE_URL"),
       CRYPTO_SECRET: "secret",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an environment variable to explicitly mark the test environment.
  * Updated environment configuration to better support mocked OpenAI API keys during testing.
  * Removed a sample local test environment file.
* **Refactor**
  * Changed how the app determines when to use a mocked OpenAI provider, improving clarity and reliability.
  * Streamlined the use of environment flags for AI mocking across the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->