### PR TITLE
feat(tests-e2e): add global JavaScript error tracking for e2e tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "test:e2e": "bash scripts/e2e.sh playwright test",
     "test:e2e:debug": "bash scripts/e2e.sh playwright test --debug",
     "test:e2e:headed": "bash scripts/e2e.sh playwright test --headed",
+    "test:e2e:no-js-errors": "FAIL_ON_JS_ERRORS=false bash scripts/e2e.sh playwright test",
+    "test:e2e:js-errors-only": "bash scripts/e2e.sh playwright test tests/e2e/examples/jsErrorTracking.spec.ts",
     "typecheck": "pnpm run with-dev-env pnpm run build && pnpm run-on-packages typecheck && pnpm run with-dev-env tsc --noEmit && pnpm run db:check",
     "services:start": "pnpm with-dev-env pnpm supabase start && (docker ps | grep helperai-nginx || pnpm nginx:start)",
     "services:stop": "pnpm supabase stop && docker stop helperai-nginx || true",

--- a/tests/e2e/baseTest.ts
+++ b/tests/e2e/baseTest.ts
@@ -1,0 +1,30 @@
+import { test as base, expect, Page } from "@playwright/test";
+import { JSErrorTracker } from "./utils/jsErrorTracker";
+
+export const test = base.extend({
+  page: async ({ page }, use, testInfo) => {
+    const tracker = new JSErrorTracker(page);
+    
+    await use(page);
+    
+    const errors = await tracker.getAllErrors();
+    if (errors.length > 0) {
+      const errorDetails = await tracker.getErrorsAsString();
+      
+      await testInfo.attach("javascript-errors.txt", {
+        body: errorDetails,
+        contentType: "text/plain",
+      });
+      
+      console.error(`JavaScript errors detected in test "${testInfo.title}":\n${errorDetails}`);
+      
+      if (process.env.FAIL_ON_JS_ERRORS !== "false") {
+        expect(errors.length, `Found ${errors.length} JavaScript error(s) during test execution. Set FAIL_ON_JS_ERRORS=false to disable this check.\n\nErrors:\n${errorDetails}`).toBe(0);
+      } else {
+        console.warn(`JavaScript errors were detected but test will continue due to FAIL_ON_JS_ERRORS=false`);
+      }
+    }
+  },
+});
+
+export { expect } from "@playwright/test";

--- a/tests/e2e/examples/jsErrorDemo.spec.ts
+++ b/tests/e2e/examples/jsErrorDemo.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from "../baseTest";
+
+test.use({ storageState: "tests/e2e/.auth/user.json" });
+
+test.describe("JS Error Detection Demo", () => {
+  test.skip("should fail when JavaScript errors occur", async ({ page }) => {
+    await page.goto("/mine");
+    await page.waitForLoadState("networkidle");
+    
+    await page.evaluate(() => {
+      (window as any).undefinedFunction();
+    });
+    
+    const searchInput = page.locator('input[placeholder="Search conversations"]');
+    await expect(searchInput).toBeVisible();
+  });
+
+  test.skip("should fail on unhandled promise rejection", async ({ page }) => {
+    await page.goto("/mine");
+    await page.waitForLoadState("networkidle");
+    
+    await page.evaluate(() => {
+      Promise.reject(new Error("Intentional unhandled rejection"));
+    });
+    
+    await page.waitForTimeout(1000);
+    
+    const searchInput = page.locator('input[placeholder="Search conversations"]');
+    await expect(searchInput).toBeVisible();
+  });
+
+  test("should pass when FAIL_ON_JS_ERRORS is false", async ({ page }) => {
+
+    await page.goto("/mine");
+    await page.waitForLoadState("networkidle");
+    
+    if (process.env.FAIL_ON_JS_ERRORS === "false") {
+      await page.evaluate(() => {
+        console.error("This is a test console error");
+      });
+    }
+    
+    const searchInput = page.locator('input[placeholder="Search conversations"]');
+    await expect(searchInput).toBeVisible();
+  });
+});

--- a/tests/e2e/examples/jsErrorTracking.spec.ts
+++ b/tests/e2e/examples/jsErrorTracking.spec.ts
@@ -38,33 +38,28 @@ test.describe("JavaScript Error Tracking Examples", () => {
   });
 
   test.describe("Manual JS Error Tracking", () => {
-    playwrightTest.use({ storageState: "tests/e2e/.auth/user.json" });
-    
-    playwrightTest("manual error checking at specific points", async ({ page }) => {
+    test("manual error checking at specific points", async ({ page }) => {
       const jsTracker = await createJSErrorTracker(page);
       
       await page.goto("/mine");
       await page.waitForLoadState("networkidle");
       
       await checkForJavaScriptErrors(page);
-
       const searchInput = page.locator('input[placeholder="Search conversations"]');
       await searchInput.fill("test search");
-
       await checkForJavaScriptErrors(page);
       
       await searchInput.clear();
-
       await checkForJavaScriptErrors(page);
     });
 
     playwrightTest("advanced error handling with custom logic", async ({ page }) => {
       const { JSErrorTracker } = await import("../utils/jsErrorTracker");
       const tracker = new JSErrorTracker(page);
-      
-      await page.goto("/mine");
 
       tracker.clearErrors();
+      
+      await page.goto("/mine");
 
       await page.click('button:has-text("open")');
 

--- a/tests/e2e/examples/jsErrorTracking.spec.ts
+++ b/tests/e2e/examples/jsErrorTracking.spec.ts
@@ -1,7 +1,5 @@
 import { test, expect } from "../baseTest";
-import { test as playwrightTest } from "@playwright/test";
 import { createJSErrorTracker, checkForJavaScriptErrors } from "../utils/test-helpers";
-
 test.use({ storageState: "tests/e2e/.auth/user.json" });
 
 test.describe("JavaScript Error Tracking Examples", () => {

--- a/tests/e2e/examples/jsErrorTracking.spec.ts
+++ b/tests/e2e/examples/jsErrorTracking.spec.ts
@@ -1,0 +1,102 @@
+import { test, expect } from "../baseTest";
+import { test as playwrightTest } from "@playwright/test";
+import { createJSErrorTracker, checkForJavaScriptErrors } from "../utils/test-helpers";
+
+test.use({ storageState: "tests/e2e/.auth/user.json" });
+
+test.describe("JavaScript Error Tracking Examples", () => {
+  test.describe("Automatic JS Error Tracking", () => {
+    test("should automatically detect and report JS errors", async ({ page }) => {
+      await page.goto("/mine");
+      await page.waitForLoadState("networkidle");
+
+      const searchInput = page.locator('input[placeholder="Search conversations"]');
+      await expect(searchInput).toBeVisible();
+
+    });
+
+    test("should work with responsive design tests", async ({ page }) => {
+      await page.goto("/mine");
+
+      await page.setViewportSize({ width: 375, height: 667 });
+      await page.waitForLoadState("networkidle");
+      
+      const openFilter = page.locator('button:has-text("open")');
+      await expect(openFilter).toBeVisible();
+
+      await page.setViewportSize({ width: 768, height: 1024 });
+      await page.waitForLoadState("networkidle");
+      
+      await expect(openFilter).toBeVisible();
+
+      await page.setViewportSize({ width: 1024, height: 768 });
+      await page.waitForLoadState("networkidle");
+      
+      await expect(openFilter).toBeVisible();
+
+    });
+  });
+
+  test.describe("Manual JS Error Tracking", () => {
+    playwrightTest.use({ storageState: "tests/e2e/.auth/user.json" });
+    
+    playwrightTest("manual error checking at specific points", async ({ page }) => {
+      const jsTracker = await createJSErrorTracker(page);
+      
+      await page.goto("/mine");
+      await page.waitForLoadState("networkidle");
+      
+      await checkForJavaScriptErrors(page);
+
+      const searchInput = page.locator('input[placeholder="Search conversations"]');
+      await searchInput.fill("test search");
+
+      await checkForJavaScriptErrors(page);
+      
+      await searchInput.clear();
+
+      await checkForJavaScriptErrors(page);
+    });
+
+    playwrightTest("advanced error handling with custom logic", async ({ page }) => {
+      const { JSErrorTracker } = await import("../utils/jsErrorTracker");
+      const tracker = new JSErrorTracker(page);
+      
+      await page.goto("/mine");
+
+      tracker.clearErrors();
+
+      await page.click('button:has-text("open")');
+
+      const allErrors = await tracker.getAllErrors();
+      const hasErrors = await tracker.hasAnyErrors();
+      
+      if (hasErrors) {
+        const errorDetails = await tracker.getErrorsAsString();
+        console.log("Detailed error information:", errorDetails);
+
+        const criticalErrors = allErrors.filter(error => 
+          error.message.includes('TypeError') || 
+          error.message.includes('ReferenceError')
+        );
+        
+        expect(criticalErrors).toHaveLength(0);
+      }
+    });
+  });
+
+  test.describe("Error Tracking with Environment Variables", () => {
+    test("should respect FAIL_ON_JS_ERRORS environment variable", async ({ page }) => {
+
+      await page.goto("/mine");
+      await page.waitForLoadState("networkidle");
+      
+      const searchInput = page.locator('input[placeholder="Search conversations"]');
+      await expect(searchInput).toBeVisible();
+
+      await searchInput.fill("test search");
+      await page.keyboard.press("Enter");
+
+    });
+  });
+});

--- a/tests/e2e/utils/jsErrorTracker.ts
+++ b/tests/e2e/utils/jsErrorTracker.ts
@@ -1,0 +1,115 @@
+import { Page } from "@playwright/test";
+
+export interface JSError {
+  message: string;
+  stack?: string;
+  url?: string;
+  line?: number;
+  column?: number;
+  timestamp: number;
+}
+
+export class JSErrorTracker {
+  private errors: JSError[] = [];
+  private page: Page;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.setupErrorListeners();
+  }
+
+  private setupErrorListeners() {
+    this.page.on("pageerror", (error) => {
+      this.errors.push({
+        message: error.message,
+        stack: error.stack,
+        timestamp: Date.now(),
+      });
+    });
+
+    this.page.on("console", (msg) => {
+      if (msg.type() === "error") {
+        this.errors.push({
+          message: msg.text(),
+          timestamp: Date.now(),
+        });
+      }
+    });
+
+    this.page.addInitScript(() => {
+      window.addEventListener("error", (event) => {
+        (window as any).__jsErrors = (window as any).__jsErrors || [];
+        (window as any).__jsErrors.push({
+          message: event.message,
+          filename: event.filename,
+          line: event.lineno,
+          column: event.colno,
+          stack: event.error?.stack,
+          timestamp: Date.now(),
+        });
+      });
+
+      window.addEventListener("unhandledrejection", (event) => {
+        (window as any).__jsErrors = (window as any).__jsErrors || [];
+        (window as any).__jsErrors.push({
+          message: `Unhandled Promise Rejection: ${event.reason}`,
+          stack: event.reason?.stack,
+          timestamp: Date.now(),
+        });
+      });
+    });
+  }
+
+  async getClientSideErrors(): Promise<JSError[]> {
+    try {
+      const clientErrors = await this.page.evaluate(() => {
+        return (window as any).__jsErrors || [];
+      });
+      return clientErrors;
+    } catch {
+      return [];
+    }
+  }
+
+  getServerSideErrors(): JSError[] {
+    return [...this.errors];
+  }
+
+  async getAllErrors(): Promise<JSError[]> {
+    const clientErrors = await this.getClientSideErrors();
+    const serverErrors = this.getServerSideErrors();
+    return [...serverErrors, ...clientErrors];
+  }
+
+  clearErrors() {
+    this.errors = [];
+    this.page.evaluate(() => {
+      (window as any).__jsErrors = [];
+    }).catch(() => {});
+  }
+
+  hasErrors(): boolean {
+    return this.errors.length > 0;
+  }
+
+  async hasAnyErrors(): Promise<boolean> {
+    const allErrors = await this.getAllErrors();
+    return allErrors.length > 0;
+  }
+
+  async getErrorsAsString(): Promise<string> {
+    const allErrors = await this.getAllErrors();
+    if (allErrors.length === 0) return "";
+
+    return allErrors
+      .map((error, index) => {
+        let errorStr = `Error ${index + 1}: ${error.message}`;
+        if (error.url) errorStr += `\n  File: ${error.url}`;
+        if (error.line) errorStr += `\n  Line: ${error.line}`;
+        if (error.column) errorStr += `\n  Column: ${error.column}`;
+        if (error.stack) errorStr += `\n  Stack: ${error.stack}`;
+        return errorStr;
+      })
+      .join("\n\n");
+  }
+}

--- a/tests/e2e/utils/test-helpers.ts
+++ b/tests/e2e/utils/test-helpers.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from "fs";
 import { Page } from "@playwright/test";
+import { JSErrorTracker } from "./jsErrorTracker";
 
 export async function waitForNetworkIdle(page: Page, timeout = 5000) {
   await page.waitForLoadState("networkidle", { timeout });
@@ -96,4 +97,18 @@ export async function debugWait(page: Page, ms = 1000) {
   if (process.env.HEADED === "true" || process.env.DEBUG === "true") {
     await page.waitForTimeout(ms);
   }
+}
+
+export async function checkForJavaScriptErrors(page: Page): Promise<void> {
+  const tracker = new JSErrorTracker(page);
+  const errors = await tracker.getAllErrors();
+  
+  if (errors.length > 0) {
+    const errorDetails = await tracker.getErrorsAsString();
+    throw new Error(`JavaScript errors detected:\n${errorDetails}`);
+  }
+}
+
+export async function createJSErrorTracker(page: Page): Promise<JSErrorTracker> {
+  return new JSErrorTracker(page);
 }


### PR DESCRIPTION
#584 

Implements a comprehensive JavaScript error tracking for all e2e tests, as suggested in the comment https://github.com/antiwork/helper/pull/840#discussion_r2250112151

<img width="885" height="392" alt="image" src="https://github.com/user-attachments/assets/a6b588a5-fe6c-4bc6-a894-5fe21cb673b2" />

It may help as: 
- Captures uncaught exceptions, unhandled promise rejections, and console errors
- Existing tests work unchanged, just update import statements
- Configurable Behavior, Detailed Reporting, Multiple Usage Patterns

### Usage

```typescript
// Before
import { test, expect } from "@playwright/test";

// After  
import { test, expect } from "../baseTest";
// JS errors are automatically tracked

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced automatic JavaScript error tracking in end-to-end tests, providing detailed error reports and test failure options based on environment settings.
  * Added new test suites and utilities to detect and report JavaScript errors and unhandled promise rejections during UI testing.
  * Provided new npm scripts for flexible JavaScript error handling in test runs.

* **Tests**
  * Added comprehensive test cases to verify JavaScript error detection and handling under various scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->