### PR TITLE
fix(marketing) : update the integration guide

### DIFF
--- a/packages/marketing/app/help/page.tsx
+++ b/packages/marketing/app/help/page.tsx
@@ -31,7 +31,7 @@ export default function HelpPage() {
                 <p className="text-sm text-gray-300">Learn the basics of setting up Helper for your support team</p>
               </Link>
               <Link
-                href="/docs/widget"
+                href="/docs/integrations"
                 className="border border-[#5A3A3A] rounded-lg p-4 hover:bg-[#5A3A3A] transition-colors"
               >
                 <h3 className="font-medium mb-2">Integration Guides</h3>

--- a/packages/marketing/app/help/page.tsx
+++ b/packages/marketing/app/help/page.tsx
@@ -31,7 +31,7 @@ export default function HelpPage() {
                 <p className="text-sm text-gray-300">Learn the basics of setting up Helper for your support team</p>
               </Link>
               <Link
-                href="/docs/integrations"
+                href="/docs/widget/06-custom"
                 className="border border-[#5A3A3A] rounded-lg p-4 hover:bg-[#5A3A3A] transition-colors"
               >
                 <h3 className="font-medium mb-2">Integration Guides</h3>


### PR DESCRIPTION
### What 
Fix broken link from `/help` page "Integration Guides" section that was pointing to non-existent `/docs/widget`

### Before 

https://github.com/user-attachments/assets/d9e6eb4d-55c1-49cd-8e1f-c1a709e9b9d8

### After 


https://github.com/user-attachments/assets/b840bfc6-d912-4842-af4c-256259cf84e9

### Testing 

https://helper.ai/help -> Click on Integration Guide

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the "Integration Guides" link on the Help page to direct users to the correct URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->