### PR TITLE
Fix tool call ID for guide messages

### DIFF
--- a/components/widget/Conversation.tsx
+++ b/components/widget/Conversation.tsx
@@ -222,7 +222,7 @@ export default function Conversation({
                   type: "tool-invocation",
                   toolInvocation: {
                     toolName: "guide_user",
-                    toolCallId: `guide_session_${guideMessage.uuid}`,
+                    toolCallId: `g_${guideMessage.uuid}`,
                     state: "call",
                     args: {
                       pendingResume: true,


### PR DESCRIPTION
[Sentry](https://gumroad-to.sentry.io/issues/6798548604/?_allp=1&project=4508049493196800&query=is%3Aunresolved&referrer=issue-stream)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the format of guide session identifiers in conversation messages to fix length limit errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->