### PR TITLE
fix: basepage import from website learning spec

### DIFF
--- a/tests/e2e/utils/page-objects/websiteLearningPage.ts
+++ b/tests/e2e/utils/page-objects/websiteLearningPage.ts
@@ -1,13 +1,13 @@
 import { expect, Page } from "@playwright/test";
 import { waitForToast } from "../toastHelpers";
-import { BasePage } from "./basePage";
 
 interface TestWebsite {
   name: string;
   url: string;
 }
 
-export class WebsiteLearningPage extends BasePage {
+export class WebsiteLearningPage {
+  protected page: Page;
   private readonly websiteLearningTitle = 'h2:has-text("Website Learning")';
   private readonly websiteDescription =
     'text="Helper will learn about your product by reading your websites to provide better responses."';
@@ -20,12 +20,12 @@ export class WebsiteLearningPage extends BasePage {
   private readonly externalLinks = 'a[target="_blank"]';
 
   constructor(page: Page) {
-    super(page);
+    this.page = page;
   }
 
   async navigateToKnowledgeSettings() {
-    await this.goto("/settings/knowledge");
-    await this.waitForPageLoad();
+    await this.page.goto("/settings/knowledge");
+    await this.page.waitForLoadState("networkidle");
   }
 
   async expectWebsiteLearningSection() {


### PR DESCRIPTION
<img width="1351" height="213" alt="image" src="https://github.com/user-attachments/assets/a55b6a08-50ce-4018-a97e-a470d9ec7474" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the structure of the WebsiteLearningPage class for better maintainability and clarity in end-to-end tests. No changes to user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->