### PR TITLE
fix: E2E tests and remove page object from newMessageWithsavedRepliesPage

### DIFF
--- a/tests/e2e/conversations/newMessageWithSavedReplies.spec.ts
+++ b/tests/e2e/conversations/newMessageWithSavedReplies.spec.ts
@@ -1,117 +1,11 @@
-import { expect, test, type Page } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 import { eq, or } from "drizzle-orm";
 import { db } from "../../../db/client";
 import { savedReplies } from "../../../db/schema";
+import { createSavedReply } from "../saved-replies/savedReplies.spec";
 import { generateRandomString, takeDebugScreenshot } from "../utils/test-helpers";
-import { waitForToast } from "../utils/toastHelpers";
 
 test.use({ storageState: "tests/e2e/.auth/user.json" });
-
-async function expectCreateDialogVisible(page: Page) {
-  const createDialog = page.locator('[role="dialog"]:has-text("New saved reply")');
-  await expect(createDialog).toBeVisible();
-  await expect(page.locator('[role="dialog"] h2')).toContainText("New saved reply");
-}
-
-async function clickCreateOneButton(page: Page) {
-  await page.locator('button:has-text("Create one")').click();
-}
-
-async function clickFloatingAddButton(page: Page) {
-  await page.locator("button.fixed").click();
-}
-
-async function fillSavedReplyForm(page: Page, name: string, content: string) {
-  const nameInput = page.locator('input[placeholder*="Welcome Message"]');
-  const contentEditor = page.locator('[role="textbox"][contenteditable="true"]');
-  await nameInput.fill(name);
-  await contentEditor.click();
-  await contentEditor.fill(content);
-}
-
-async function clickSaveButton(page: Page) {
-  const addBtn = page.locator('button:has-text("Add")');
-  const updateBtn = page.locator('button:has-text("Update")');
-  const saveBtn = page.locator('button:has-text("Save")');
-  const createDialog = page.locator('[role="dialog"]:has-text("New saved reply")');
-  const editDialog = page.locator('[role="dialog"]:has-text("Edit saved reply")');
-
-  // Map each button to its waitFor promise, returning the button when visible
-  const buttonPromises = [
-    updateBtn
-      .waitFor({ state: "visible", timeout: 5000 })
-      .then(() => updateBtn)
-      .catch(() => null),
-    addBtn
-      .waitFor({ state: "visible", timeout: 5000 })
-      .then(() => addBtn)
-      .catch(() => null),
-    saveBtn
-      .waitFor({ state: "visible", timeout: 5000 })
-      .then(() => saveBtn)
-      .catch(() => null),
-  ];
-
-  // Wait for the first button to become visible and capture it
-  const winningButton = await Promise.race(buttonPromises);
-
-  if (!winningButton) {
-    throw new Error("No save button (Add/Update/Save) found");
-  }
-
-  // Click the winning button directly
-  await winningButton.scrollIntoViewIfNeeded();
-  await winningButton.click();
-
-  // Wait for either dialog to close
-  await Promise.race([
-    createDialog.waitFor({ state: "hidden", timeout: 5000 }).catch(() => null),
-    editDialog.waitFor({ state: "hidden", timeout: 5000 }).catch(() => null),
-  ]);
-}
-
-async function openCreateDialog(page: Page) {
-  await page.waitForTimeout(500);
-
-  const emptyState = page.locator('text="No saved replies yet"');
-  const floatingAddButton = page.locator("button.fixed");
-  const createOneButton = page.locator('button:has-text("Create one")');
-  const emptyStateVisible = await emptyState.isVisible().catch(() => false);
-
-  if (emptyStateVisible) {
-    await clickCreateOneButton(page);
-  } else {
-    const fabVisible = await floatingAddButton.isVisible().catch(() => false);
-
-    if (fabVisible) {
-      await clickFloatingAddButton(page);
-    } else {
-      try {
-        await Promise.race([
-          createOneButton.waitFor({ state: "visible", timeout: 5000 }).then(() => "createOne"),
-          floatingAddButton.waitFor({ state: "visible", timeout: 5000 }).then(() => "floating"),
-        ]).then(async (buttonType) => {
-          if (buttonType === "createOne") {
-            await clickCreateOneButton(page);
-          } else {
-            await clickFloatingAddButton(page);
-          }
-        });
-      } catch {
-        throw new Error("Neither 'Create one' nor floating add button found");
-      }
-    }
-  }
-
-  await expectCreateDialogVisible(page);
-}
-
-async function createSavedReply(page: Page, name: string, content: string) {
-  await openCreateDialog(page);
-  await fillSavedReplyForm(page, name, content);
-  await clickSaveButton(page);
-  await waitForToast(page, "Saved reply created successfully");
-}
 
 test.describe("New Message with Saved Replies", () => {
   let firstTestReplyName: string;

--- a/tests/e2e/saved-replies/savedReplies.spec.ts
+++ b/tests/e2e/saved-replies/savedReplies.spec.ts
@@ -249,7 +249,7 @@ async function openCreateDialog(page: Page) {
   await expectCreateDialogVisible(page);
 }
 
-async function createSavedReply(page: Page, name: string, content: string) {
+export async function createSavedReply(page: Page, name: string, content: string) {
   await openCreateDialog(page);
   await fillSavedReplyForm(page, name, content);
   await clickSaveButton(page);


### PR DESCRIPTION
<img width="1920" height="1080" alt="Screenshot From 2025-08-10 15-32-21" src="https://github.com/user-attachments/assets/88bf9731-083f-4663-b20e-0efe768d7a31" />

ref: #584 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end tests for saved replies in conversations by making UI interactions more robust and reliable.
  * Enhanced test setup and error handling to ensure consistent creation and verification of saved replies during testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->