### PR TITLE
fix(e2e): mock FIRECRAWL_API_KEY in CI & improve accessibility selectors

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,6 +17,7 @@ jobs:
     env:
       CI: true
       OPENAI_API_KEY: test-openai-api-key
+      FIRECRAWL_API_KEY: test-firecrawl-api-key
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/app/(dashboard)/settings/knowledge/websiteCrawlSetting.tsx
+++ b/app/(dashboard)/settings/knowledge/websiteCrawlSetting.tsx
@@ -145,7 +145,6 @@ const WebsiteCrawlSetting = () => {
                   key={website.id}
                   className="group relative flex items-center gap-4 rounded-lg border p-4 hover:bg-muted/50"
                   role="listitem"
-                  aria-label={`Configure ${website.name}`}
                 >
                   <div className="flex-1 min-w-0 space-y-2">
                     <div className="flex items-center gap-2">

--- a/app/(dashboard)/settings/knowledge/websiteCrawlSetting.tsx
+++ b/app/(dashboard)/settings/knowledge/websiteCrawlSetting.tsx
@@ -123,7 +123,7 @@ const WebsiteCrawlSetting = () => {
           </>
         }
       >
-        <div className="space-y-4">
+        <div role="list" className="space-y-4">
           {isLoadingWebsites ? (
             <>
               {Array.from({ length: 2 }).map((_, i) => (
@@ -144,7 +144,8 @@ const WebsiteCrawlSetting = () => {
                 <div
                   key={website.id}
                   className="group relative flex items-center gap-4 rounded-lg border p-4 hover:bg-muted/50"
-                  data-testid="website-item"
+                  role="listitem"
+                  aria-label={`Configure ${website.name}`}
                 >
                   <div className="flex-1 min-w-0 space-y-2">
                     <div className="flex items-center gap-2">

--- a/tests/e2e/website-learning/websiteLearning.spec.ts
+++ b/tests/e2e/website-learning/websiteLearning.spec.ts
@@ -51,7 +51,9 @@ test.describe("Website Learning UI Smoke Tests", () => {
     await page.waitForLoadState("networkidle");
 
     await waitForToast(page, "Website added!");
-    const websiteItem = page.getByRole("listitem", { name: `Configure ${testName}` });
+    const websiteItem = page.getByRole("listitem").filter({
+      has: page.getByRole("link", { name: testUrl }),
+    });
     await expect(websiteItem).toBeVisible();
   });
 });

--- a/tests/e2e/website-learning/websiteLearning.spec.ts
+++ b/tests/e2e/website-learning/websiteLearning.spec.ts
@@ -17,24 +17,24 @@ test.describe("Website Learning UI Smoke Tests", () => {
     ).toBeVisible();
     await expect(page.getByRole("button", { name: "Add website" })).toBeVisible();
     await page.getByRole("button", { name: "Add website" }).click();
-    await expect(page.locator('label[for="url"]')).toBeVisible();
-    await expect(page.locator("input#url")).toBeVisible();
+
+    await expect(page.getByRole("textbox", { name: "URL" })).toBeVisible();
     await expect(page.getByRole("button", { name: "Cancel" })).toBeVisible();
-    await expect(page.locator('form button[type="submit"]')).toBeVisible();
+    await expect(page.getByRole("button", { name: "Add website" })).toBeVisible();
   });
 
   test("hides form when cancelled", async ({ page }) => {
     await expect(page.getByRole("heading", { name: "Website Learning" })).toBeVisible();
     await page.getByRole("button", { name: "Add website" }).click();
     await page.getByRole("button", { name: "Cancel" }).click();
-    await expect(page.locator("input#url")).not.toBeVisible();
+    await expect(page.getByRole("textbox", { name: "URL" })).not.toBeVisible();
   });
 
   test("validates invalid URL format", async ({ page }) => {
     await expect(page.getByRole("heading", { name: "Website Learning" })).toBeVisible();
     await page.getByRole("button", { name: "Add website" }).click();
-    await page.locator("input#url").fill("invalid url");
-    await page.locator('form button[type="submit"]').click();
+    await page.getByRole("textbox", { name: "URL" }).fill("invalid url");
+    await page.getByRole("button", { name: "Add website" }).click();
     await page.waitForLoadState("networkidle");
     await expect(page.getByText("Failed to add website. Please try again.")).toBeVisible();
   });
@@ -44,14 +44,14 @@ test.describe("Website Learning UI Smoke Tests", () => {
     const timestamp = Date.now();
     const testUrl = `https://test-${timestamp}.example.com`;
     const testName = `test-${timestamp}.example.com`;
+
     await page.getByRole("button", { name: "Add website" }).click();
-    await page.locator("input#url").fill(testUrl);
-    await page.locator('form button[type="submit"]').click();
+    await page.getByRole("textbox", { name: "URL" }).fill(testUrl);
+    await page.getByRole("button", { name: "Add website" }).click();
     await page.waitForLoadState("networkidle");
+
     await waitForToast(page, "Website added!");
-    const websiteItem = page.locator('[data-testid="website-item"]').filter({
-      has: page.locator(`text="${testName}"`),
-    });
+    const websiteItem = page.getByRole("listitem", { name: `Configure ${testName}` });
     await expect(websiteItem).toBeVisible();
   });
 });


### PR DESCRIPTION
- Added missing `FIRECRAWL_API_KEY` to CI env to fix failing E2E runs caused by a dynamic component requiring it.
- Updated `WebsiteCrawlSetting` to use semantic roles and aria labels, improving accessibility and making Playwright tests more robust by using `getByRole` instead of CSS selectors.

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/b3e19c30-9d0d-4da8-8131-4f670ce50b56" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility**
  * Improved accessibility in the website list by adding ARIA roles and labels for better screen reader support.

* **Tests**
  * Updated end-to-end tests to use more semantic, accessible role-based selectors for improved reliability and alignment with accessibility best practices.

* **Chores**
  * Updated environment variables in the end-to-end testing workflow configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->