### PR TITLE
fix: fixes failing e2e tests, move saved reply helper functions to a new utility file

### DIFF
--- a/tests/e2e/conversations/newMessageWithSavedReplies.spec.ts
+++ b/tests/e2e/conversations/newMessageWithSavedReplies.spec.ts
@@ -2,7 +2,7 @@ import { expect, test } from "@playwright/test";
 import { eq, or } from "drizzle-orm";
 import { db } from "../../../db/client";
 import { savedReplies } from "../../../db/schema";
-import { createSavedReply } from "../saved-replies/savedReplies.spec";
+import { createSavedReply } from "../utils/replyHelpers";
 import { generateRandomString, takeDebugScreenshot } from "../utils/test-helpers";
 
 test.use({ storageState: "tests/e2e/.auth/user.json" });

--- a/tests/e2e/utils/replyHelpers.ts
+++ b/tests/e2e/utils/replyHelpers.ts
@@ -1,0 +1,106 @@
+import { expect, type Page } from "@playwright/test";
+import { waitForToast } from "./toastHelpers";
+
+// Clicks the create one button in the saved replies page
+export async function clickCreateOneButton(page: Page) {
+  await page.locator('button:has-text("Create one")').click();
+}
+
+// Clicks the floating add button in the saved replies page
+export async function clickFloatingAddButton(page: Page) {
+  await page.locator("button.fixed").click();
+}
+
+// Opens the create dialog in the saved replies page
+export async function openCreateDialog(page: Page) {
+  await page.waitForTimeout(500);
+
+  const emptyState = page.locator('text="No saved replies yet"');
+  const floatingAddButton = page.locator("button.fixed");
+  const createOneButton = page.locator('button:has-text("Create one")');
+  const emptyStateVisible = await emptyState.isVisible().catch(() => false);
+
+  if (emptyStateVisible) {
+    await clickCreateOneButton(page);
+  } else {
+    const fabVisible = await floatingAddButton.isVisible().catch(() => false);
+
+    if (fabVisible) {
+      await clickFloatingAddButton(page);
+    } else {
+      // Fallback: try both buttons with a timeout
+      try {
+        await Promise.race([createOneButton.click({ timeout: 2000 }), floatingAddButton.click({ timeout: 2000 })]);
+      } catch (error) {
+        throw new Error(`Could not find any add button. EmptyState: ${emptyStateVisible}, FAB: ${fabVisible}`);
+      }
+    }
+  }
+  await page.waitForTimeout(200);
+}
+
+// Fills the saved reply form in the create or edit dialog
+export async function fillSavedReplyForm(page: Page, name: string, content: string) {
+  const nameInput = page.locator('input[placeholder*="Welcome Message"]');
+  const contentEditor = page.locator('[role="textbox"][contenteditable="true"]');
+  await nameInput.fill(name);
+  await contentEditor.click();
+  await contentEditor.fill(content);
+}
+
+// Clicks the save button in the create or edit dialog
+export async function clickSaveButton(page: Page) {
+  const addBtn = page.locator('button:has-text("Add")');
+  const updateBtn = page.locator('button:has-text("Update")');
+  const saveBtn = page.locator('button:has-text("Save")');
+  const createDialog = page.locator('[role="dialog"]:has-text("New saved reply")');
+  const editDialog = page.locator('[role="dialog"]:has-text("Edit saved reply")');
+
+  // Map each button to its waitFor promise, returning the button when visible
+  const buttonPromises = [
+    updateBtn
+      .waitFor({ state: "visible", timeout: 5000 })
+      .then(() => updateBtn)
+      .catch(() => null),
+    addBtn
+      .waitFor({ state: "visible", timeout: 5000 })
+      .then(() => addBtn)
+      .catch(() => null),
+    saveBtn
+      .waitFor({ state: "visible", timeout: 5000 })
+      .then(() => saveBtn)
+      .catch(() => null),
+  ];
+
+  // Wait for any button to become visible
+  const buttons = await Promise.all(buttonPromises);
+  const visibleButton = buttons.find((btn) => btn !== null);
+
+  if (visibleButton) {
+    await visibleButton.click();
+  } else {
+    // Fallback logic for context-specific buttons
+    const isCreateContext = await createDialog.isVisible().catch(() => false);
+    const isEditContext = await editDialog.isVisible().catch(() => false);
+
+    if (isCreateContext) {
+      const fallbackAddBtn = createDialog.locator('button:has-text("Add")');
+      await expect(fallbackAddBtn).toBeVisible({ timeout: 5000 });
+      await fallbackAddBtn.click();
+    } else if (isEditContext) {
+      const fallbackUpdateBtn = editDialog.locator('button:has-text("Update")');
+      await expect(fallbackUpdateBtn).toBeVisible({ timeout: 5000 });
+      await fallbackUpdateBtn.click();
+    } else {
+      throw new Error("No save button found in current context");
+    }
+  }
+}
+
+// Creates a new saved reply by opening the create dialog, filling the form, and saving
+export async function createSavedReply(page: Page, name: string, content: string) {
+  await openCreateDialog(page);
+  await fillSavedReplyForm(page, name, content);
+  await clickSaveButton(page);
+  await waitForToast(page, "Saved reply created successfully");
+}


### PR DESCRIPTION
This PR extracts common test utilities for saved replies into a reusable helper file, improving test maintainability and reducing code duplication.

**Failing tests:**

<img width="809" height="526" alt="image" src="https://github.com/user-attachments/assets/f1a9b4d3-afa6-43bb-a51b-32cfd05f5b5f" />

**Fixed:**

<img width="786" height="393" alt="image" src="https://github.com/user-attachments/assets/65620079-c049-4390-be1a-f31e01257587" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Consolidated saved-replies end-to-end interactions into shared utilities and updated scenarios to use them, improving consistency, readability, and resilience. Minor import path updates.
- **Chores**
  - Reduced test duplication and improved stability, aiding faster, more reliable CI runs.
- **User Impact**
  - No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->