### PR TITLE
tests: add test for auto focus reply field

### DIFF
--- a/tests/e2e/conversation-details/conversationDetails.spec.ts
+++ b/tests/e2e/conversation-details/conversationDetails.spec.ts
@@ -270,6 +270,7 @@ test.describe("Conversation Details", () => {
     await expect(replyEditor).toBeFocused();
 
     await goToNextConversation(page);
+    await setupConversation(page);
 
     const nextReplyEditor = page.locator(".ProseMirror").first();
     await expect(nextReplyEditor).toBeVisible();

--- a/tests/e2e/conversation-details/conversationDetails.spec.ts
+++ b/tests/e2e/conversation-details/conversationDetails.spec.ts
@@ -261,4 +261,18 @@ test.describe("Conversation Details", () => {
     await setupConversation(page);
     await attemptInternalNoteCreation(page);
   });
+
+  test("should focus reply editor when opening conversation", async ({ page }) => {
+    await setupConversation(page);
+
+    const replyEditor = page.locator(".ProseMirror").first();
+    await expect(replyEditor).toBeVisible();
+    await expect(replyEditor).toBeFocused();
+
+    await goToNextConversation(page);
+
+    const nextReplyEditor = page.locator(".ProseMirror").first();
+    await expect(nextReplyEditor).toBeVisible();
+    await expect(nextReplyEditor).toBeFocused();
+  });
 });


### PR DESCRIPTION
Fixes: https://github.com/antiwork/helper/issues/916

![Screenshot 2025-08-15 at 2 08 15 AM](https://github.com/user-attachments/assets/00dd0b43-555a-42a6-afbd-7401ffe68e7a)

Screenshot of test passing locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an end-to-end test verifying the reply editor auto-focuses when opening a conversation and after navigating to the next conversation.
  * Improves confidence in keyboard-first workflows and faster replying across conversations.
  * Increases reliability of the conversation details experience and regression protection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->