### PR TITLE
feat: add next conversation preview

### DIFF
--- a/app/(dashboard)/[category]/conversation/conversation.tsx
+++ b/app/(dashboard)/[category]/conversation/conversation.tsx
@@ -432,7 +432,7 @@ const ConversationContent = () => {
   const { isAboveSm } = useBreakpoint("sm");
 
   const defaultSize =
-    typeof window !== "undefined" ? Number(localStorage.getItem("conversationHeightRange") ?? 65) : 65;
+    typeof window !== "undefined" ? Number(localStorage.getItem("conversationHeightRange") ?? 55) : 55;
 
   const [sidebarVisible, setSidebarVisible] = useState(isAboveSm);
 

--- a/app/(dashboard)/[category]/conversation/messageActions.tsx
+++ b/app/(dashboard)/[category]/conversation/messageActions.tsx
@@ -28,6 +28,7 @@ import { api } from "@/trpc/react";
 import { useConversationListContext } from "../list/conversationListContext";
 import { useConversationsListInput } from "../shared/queries";
 import { TicketCommandBar } from "../ticketCommandBar";
+import { NextTicketPreview } from "./nextTicketPreview";
 import { useUndoneEmailStore } from "./useUndoneEmailStore";
 
 export const FAILED_ATTACHMENTS_TOOLTIP_MESSAGE = "Remove the failed file attachments first";
@@ -65,7 +66,7 @@ const useKnowledgeBankDialogState = create<
 }));
 
 export const MessageActions = () => {
-  const { navigateToConversation, removeConversation } = useConversationListContext();
+  const { navigateToConversation, removeConversation, getNextTicket } = useConversationListContext();
   const { data: conversation, updateStatus } = useConversationContext();
   const { searchParams } = useConversationsListInput();
   const utils = api.useUtils();
@@ -429,8 +430,11 @@ export const MessageActions = () => {
     setStoredMessage(content);
   };
 
+  const nextTicket = getNextTicket();
+
   return (
     <div className="flex flex-col h-full pt-4">
+      {nextTicket && !showCommandBar && <NextTicketPreview nextTicket={nextTicket} className="mb-3 flex-shrink-0" />}
       <TicketCommandBar
         open={showCommandBar}
         onOpenChange={setShowCommandBar}

--- a/app/(dashboard)/[category]/conversation/nextTicketPreview.tsx
+++ b/app/(dashboard)/[category]/conversation/nextTicketPreview.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { ChevronDown, ChevronRight, Clock } from "lucide-react";
+import { useEffect, useState } from "react";
+import HumanizedTime from "@/components/humanizedTime";
+import { Avatar } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { RouterOutputs } from "@/trpc";
+import { useConversationListContext } from "../list/conversationListContext";
+
+type NextTicketPreviewProps = {
+  nextTicket: RouterOutputs["mailbox"]["conversations"]["list"]["conversations"][0] | null;
+  className?: string;
+};
+
+export const NextTicketPreview = ({ nextTicket, className }: NextTicketPreviewProps) => {
+  const { moveToNextConversation } = useConversationListContext();
+  const [isMounted, setIsMounted] = useState(false);
+  const [isExpanded, setIsExpanded] = useState(true);
+
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
+  if (!nextTicket) {
+    return null;
+  }
+
+  const getCustomerName = () => {
+    return nextTicket.emailFrom || "Anonymous";
+  };
+
+  const getAvatarFallback = () => {
+    return nextTicket.emailFrom ?? "?";
+  };
+
+  const handleToggleExpanded = (e: React.MouseEvent) => {
+    // Don't toggle if clicking on the Switch to button
+    if ((e.target as HTMLElement).closest("button[data-switch-to]")) {
+      return;
+    }
+    setIsExpanded(!isExpanded);
+  };
+
+  return (
+    <div className={cn("border border-border rounded-lg bg-muted/30", className)}>
+      <div
+        className="p-3 flex items-center justify-between cursor-pointer hover:bg-muted/50 transition-colors"
+        onClick={handleToggleExpanded}
+      >
+        <div className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
+          <ChevronDown className={cn("h-4 w-4 transition-transform duration-200", !isExpanded && "rotate-[-90deg]")} />
+          <span>Next Ticket:</span>
+          <span className="font-normal">#{nextTicket.id}</span>
+        </div>
+        <Button
+          variant="link"
+          onClick={moveToNextConversation}
+          data-switch-to
+          className="text-xs p-0 h-auto text-orange-600 hover:text-orange-700 font-medium flex items-center gap-1"
+        >
+          Switch to
+          <ChevronRight className="h-3 w-3" />
+        </Button>
+      </div>
+
+      <div
+        className={cn(
+          "overflow-hidden transition-all duration-300 ease-in-out",
+          isExpanded ? "max-h-96 opacity-100" : "max-h-0 opacity-0",
+        )}
+      >
+        <div className="p-3 border-t border-border">
+          <div className="flex items-start gap-3">
+            <Avatar fallback={getAvatarFallback()} size="lg" />
+
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-2 mb-1">
+                <span
+                  className={cn(
+                    "font-semibold text-sm truncate",
+                    nextTicket.emailFrom ? "text-foreground" : "text-muted-foreground",
+                  )}
+                  title={getCustomerName()}
+                >
+                  {getCustomerName()}
+                </span>
+                <div className="text-xs text-muted-foreground">{nextTicket.emailFrom || "no-email@example.com"}</div>
+                {nextTicket.status && nextTicket.status !== "open" && (
+                  <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-red-100 text-red-800 dark:bg-red-900/20 dark:text-red-300">
+                    {nextTicket.status}
+                  </span>
+                )}
+              </div>
+
+              <div className="font-medium text-sm text-foreground line-clamp-2 mb-2">
+                {nextTicket.subject || "(no subject)"}
+              </div>
+
+              {(nextTicket.recentMessageText || nextTicket.matchedMessageText) && (
+                <div className="text-sm text-muted-foreground line-clamp-2 mb-2">
+                  {nextTicket.matchedMessageText || nextTicket.recentMessageText}
+                </div>
+              )}
+
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                  <Clock className="h-3 w-3" />
+                  {isMounted && (
+                    <>
+                      <span>
+                        Created <HumanizedTime time={nextTicket.createdAt} />
+                      </span>
+                      <span>•</span>
+                      <span>
+                        Updated <HumanizedTime time={nextTicket.updatedAt} />
+                      </span>
+                    </>
+                  )}
+                </div>
+
+                <div className="flex gap-1 flex-wrap">
+                  {nextTicket.assignedToAI && (
+                    <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-purple-100 text-purple-800 dark:bg-purple-900/20 dark:text-purple-300">
+                      AI
+                    </span>
+                  )}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/app/(dashboard)/[category]/conversation/nextTicketPreview.tsx
+++ b/app/(dashboard)/[category]/conversation/nextTicketPreview.tsx
@@ -1,10 +1,12 @@
 "use client";
 
-import { ChevronDown, ChevronRight, Clock } from "lucide-react";
+import { ChevronDown, ChevronRight, Clock, DollarSign } from "lucide-react";
 import { useEffect, useState } from "react";
 import HumanizedTime from "@/components/humanizedTime";
 import { Avatar } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { formatCurrency } from "@/components/utils/currency";
 import { cn } from "@/lib/utils";
 import { RouterOutputs } from "@/trpc";
 import { useConversationListContext } from "../list/conversationListContext";
@@ -35,8 +37,7 @@ export const NextTicketPreview = ({ nextTicket, className }: NextTicketPreviewPr
     return nextTicket.emailFrom ?? "?";
   };
 
-  const handleToggleExpanded = (e: React.MouseEvent) => {
-    // Don't toggle if clicking on the Switch to button
+  const handleToggleExpanded = (e: React.SyntheticEvent) => {
     if ((e.target as HTMLElement).closest("button[data-switch-to]")) {
       return;
     }
@@ -47,7 +48,16 @@ export const NextTicketPreview = ({ nextTicket, className }: NextTicketPreviewPr
     <div className={cn("border border-border rounded-lg bg-muted/30", className)}>
       <div
         className="p-3 flex items-center justify-between cursor-pointer hover:bg-muted/50 transition-colors"
+        role="button"
+        tabIndex={0}
+        aria-expanded={isExpanded}
         onClick={handleToggleExpanded}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            handleToggleExpanded(e);
+          }
+        }}
       >
         <div className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
           <ChevronDown className={cn("h-4 w-4 transition-transform duration-200", !isExpanded && "rotate-[-90deg]")} />
@@ -87,6 +97,12 @@ export const NextTicketPreview = ({ nextTicket, className }: NextTicketPreviewPr
                   {getCustomerName()}
                 </span>
                 <div className="text-xs text-muted-foreground">{nextTicket.emailFrom || "no-email@example.com"}</div>
+                {nextTicket.platformCustomer?.isVip && <Badge variant="bright">VIP</Badge>}
+                {nextTicket.platformCustomer?.value && nextTicket.platformCustomer.value > 0 && (
+                  <div className="ml-auto flex items-center gap-1 text-xs text-muted-foreground">
+                    {formatCurrency(Number(nextTicket.platformCustomer.value))}
+                  </div>
+                )}
                 {nextTicket.status && nextTicket.status !== "open" && (
                   <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-red-100 text-red-800 dark:bg-red-900/20 dark:text-red-300">
                     {nextTicket.status}

--- a/app/(dashboard)/[category]/conversation/nextTicketPreview.tsx
+++ b/app/(dashboard)/[category]/conversation/nextTicketPreview.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ChevronDown, ChevronRight, Clock, DollarSign } from "lucide-react";
+import { ChevronDown, ChevronRight, Clock } from "lucide-react";
 import { useEffect, useState } from "react";
 import HumanizedTime from "@/components/humanizedTime";
 import { Avatar } from "@/components/ui/avatar";
@@ -51,6 +51,8 @@ export const NextTicketPreview = ({ nextTicket, className }: NextTicketPreviewPr
         role="button"
         tabIndex={0}
         aria-expanded={isExpanded}
+        aria-controls={`next-ticket-preview-panel-${nextTicket.id}`}
+        id={`next-ticket-preview-header-${nextTicket.id}`}
         onClick={handleToggleExpanded}
         onKeyDown={(e) => {
           if (e.key === "Enter" || e.key === " ") {
@@ -80,6 +82,9 @@ export const NextTicketPreview = ({ nextTicket, className }: NextTicketPreviewPr
           "overflow-hidden transition-all duration-300 ease-in-out",
           isExpanded ? "max-h-96 opacity-100" : "max-h-0 opacity-0",
         )}
+        aria-labelledby={`next-ticket-preview-header-${nextTicket.id}`}
+        aria-hidden={!isExpanded}
+        role="region"
       >
         <div className="p-3 border-t border-border">
           <div className="flex items-start gap-3">
@@ -98,7 +103,7 @@ export const NextTicketPreview = ({ nextTicket, className }: NextTicketPreviewPr
                 </span>
                 <div className="text-xs text-muted-foreground">{nextTicket.emailFrom || "no-email@example.com"}</div>
                 {nextTicket.platformCustomer?.isVip && <Badge variant="bright">VIP</Badge>}
-                {nextTicket.platformCustomer?.value && nextTicket.platformCustomer.value > 0 && (
+                {nextTicket.platformCustomer?.value && (
                   <div className="ml-auto flex items-center gap-1 text-xs text-muted-foreground">
                     {formatCurrency(Number(nextTicket.platformCustomer.value))}
                   </div>

--- a/app/(dashboard)/[category]/list/conversationListContext.tsx
+++ b/app/(dashboard)/[category]/list/conversationListContext.tsx
@@ -88,7 +88,7 @@ export const ConversationListContextProvider = ({
     const nextIndex = currentIndex + 1;
     if (nextIndex >= conversations.length) return null;
 
-    return conversations[nextIndex];
+    return conversations[nextIndex] ?? null;
   };
 
   const router = useRouter();
@@ -190,7 +190,16 @@ export const ConversationListContextProvider = ({
       navigateToConversation: setId,
       getNextTicket,
     }),
-    [currentConversationSlug, conversations, lastPage, isPending, isFetching, isFetchingNextPage, hasNextPage],
+    [
+      currentConversationSlug,
+      conversations,
+      lastPage,
+      isPending,
+      isFetching,
+      isFetchingNextPage,
+      hasNextPage,
+      getNextTicket,
+    ],
   );
 
   return <ConversationListContext.Provider value={value}>{children}</ConversationListContext.Provider>;

--- a/app/(dashboard)/[category]/list/conversationListContext.tsx
+++ b/app/(dashboard)/[category]/list/conversationListContext.tsx
@@ -26,6 +26,7 @@ type ConversationListContextType = {
   removeConversation: () => void;
   removeConversationKeepActive: () => void;
   navigateToConversation: (conversationSlug: string) => void;
+  getNextTicket: () => RouterOutputs["mailbox"]["conversations"]["list"]["conversations"][0] | null;
 };
 
 const ConversationListContext = createContext<ConversationListContextType | null>(null);
@@ -79,6 +80,15 @@ export const ConversationListContextProvider = ({
         currentIndex === 0 ? conversations[conversations.length - 1] : conversations[currentIndex - 1];
     }
     setId(previousConversation?.slug ?? null);
+  };
+
+  const getNextTicket = () => {
+    if (!conversations.length || currentIndex === -1) return null;
+
+    const nextIndex = currentIndex + 1;
+    if (nextIndex >= conversations.length) return null;
+
+    return conversations[nextIndex];
   };
 
   const router = useRouter();
@@ -178,6 +188,7 @@ export const ConversationListContextProvider = ({
       removeConversation,
       removeConversationKeepActive,
       navigateToConversation: setId,
+      getNextTicket,
     }),
     [currentConversationSlug, conversations, lastPage, isPending, isFetching, isFetchingNextPage, hasNextPage],
   );


### PR DESCRIPTION
Fixes: https://github.com/antiwork/helper/issues/918

Made the next ticket preview collapsible and

https://github.com/user-attachments/assets/3a4a924a-3184-4b60-b0d2-24c76c49e497


![Screenshot 2025-08-15 at 3 39 02 AM](https://github.com/user-attachments/assets/76ada141-6539-4fb7-95de-8a0afe382824)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Next Ticket” collapsible preview card with a quick “Switch to” action, displayed when a next ticket exists and the command bar is hidden.

* **Improvements**
  * Adjusted the default conversation split to a 55/45 top/bottom layout for a more balanced initial view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->