### PR TITLE
fix: padding and font weight in settings

### DIFF
--- a/app/(dashboard)/settings/[tab]/page.tsx
+++ b/app/(dashboard)/settings/[tab]/page.tsx
@@ -94,7 +94,7 @@ export default function TabsPage() {
       <PageHeader title={selectedItem?.label ?? "Settings"} />
       <FileUploadProvider>
         <div className="grow overflow-y-auto">
-          <div className="grow overflow-y-auto bg-background px-4 pb-4">{selectedItem?.content}</div>
+          <div className="grow overflow-y-auto bg-background px-6 pb-4">{selectedItem?.content}</div>
         </div>
       </FileUploadProvider>
     </div>

--- a/components/pageHeader.tsx
+++ b/components/pageHeader.tsx
@@ -18,7 +18,7 @@ export function PageHeader({ title, children, variant = "default" }: PageHeaderP
   return (
     <div
       className={cn(
-        "flex h-14 shrink-0 items-center justify-between gap-4 border-b px-6",
+        "flex h-14 shrink-0 items-center justify-between gap-4 border-b px-6 font-bold",
         variant === "mahogany" ? "bg-sidebar text-sidebar-foreground border-sidebar" : "border-border",
       )}
     >


### PR DESCRIPTION
Related to https://github.com/antiwork/helper/issues/930

Before:-

Different padding between page header and content 

![Screenshot 2025-08-16 at 10 13 07 PM](https://github.com/user-attachments/assets/a41f1a83-7b64-4a09-9a97-5ad5e75f39a8)


After:-

Heading bold and same padding

![Screenshot 2025-08-16 at 10 40 33 PM](https://github.com/user-attachments/assets/23b9db9e-f9c2-4dd9-aafe-fa1a24eede62)
