### PR TITLE
[BUG] Cross chat contamination

### DIFF
--- a/components/widget/Conversation.tsx
+++ b/components/widget/Conversation.tsx
@@ -184,6 +184,7 @@ export default function Conversation({
       setData(undefined);
       setIsAgentTyping(false);
       setMessages([]);
+      setIsEscalated(false);
     }
   }, [selectedConversationSlug, conversationSlug, setMessages]);
 

--- a/components/widget/Conversation.tsx
+++ b/components/widget/Conversation.tsx
@@ -177,6 +177,13 @@ export default function Conversation({
     }
   }, [selectedConversationSlug, isNewConversation, setConversationSlug]);
 
+  useEffect(() => {
+    // Clear messages when switching conversations to prevent cross-contamination
+    if (selectedConversationSlug && selectedConversationSlug !== conversationSlug) {
+      setMessages([]);
+    }
+  }, [selectedConversationSlug, conversationSlug, setMessages]);
+
   const isLoading = status === "streaming" || status === "submitted";
   const lastAIMessage = messages?.findLast((msg) => msg.role === "assistant");
 

--- a/components/widget/Conversation.tsx
+++ b/components/widget/Conversation.tsx
@@ -180,6 +180,9 @@ export default function Conversation({
   useEffect(() => {
     // Clear messages when switching conversations to prevent cross-contamination
     if (selectedConversationSlug && selectedConversationSlug !== conversationSlug) {
+      stop();
+      setData(undefined);
+      setIsAgentTyping(false);
       setMessages([]);
     }
   }, [selectedConversationSlug, conversationSlug, setMessages]);


### PR DESCRIPTION
Resolves: https://github.com/antiwork/helper/issues/930

If you try to send a message in conversation A, you will see the same message and reply in all other conversations :exploding_head: 


### Before
https://www.loom.com/share/9688534261bc4cf38de063eb2e2bb69e
### After
https://www.loom.com/share/f32c4cfb971f44cabf9a66ef7d50e238

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where messages and typing/escalation status could carry over when switching conversations.
  * Conversation views now reset per-conversation state on switch, preventing cross-contamination and ensuring the correct state is shown for each conversation.
  * Improves reliability and clarity when navigating between conversations, with no changes to the public API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->