### PR TITLE
fix: show & sort conversations by latest message time

### DIFF
--- a/app/(dashboard)/[category]/list/conversationListItem.tsx
+++ b/app/(dashboard)/[category]/list/conversationListItem.tsx
@@ -131,8 +131,15 @@ export const ConversationListItem = ({
                       <HumanizedTime time={conversation.closedAt ?? conversation.updatedAt} titlePrefix="Closed on" />
                     ) : (
                       <HumanizedTime
-                        time={conversation.lastUserEmailCreatedAt ?? conversation.updatedAt}
-                        titlePrefix="Last email received on"
+                        // Show latest activity (reply or received), falling back safely
+                        time={
+                          conversation.latestMessageAt ??
+                          // recentMessageAt comes from the lateral join in the list query
+                          (conversation as any).recentMessageAt ??
+                          conversation.lastUserEmailCreatedAt ??
+                          conversation.updatedAt
+                        }
+                        titlePrefix="Last activity on"
                       />
                     )}
                   </div>

--- a/app/api/chat/conversations/route.ts
+++ b/app/api/chat/conversations/route.ts
@@ -54,15 +54,18 @@ export const GET = withWidgetAuth(async ({ request }, { session, mailbox }) => {
     .groupBy(conversationMessages.conversationId);
 
   const conversations = results
-    .map((conv) => ({
-      slug: conv.slug,
-      subject: conv.subject ?? "(no subject)",
-      createdAt: conv.createdAt.toISOString(),
-      latestMessage: conv.recentMessageText || null,
-      latestMessageAt: conv.recentMessageAt?.toISOString() || null,
-      messageCount: messageCounts.find((m) => m.conversationId === conv.id)?.count || 0,
-      isUnread: !!conv.recentMessageAt && (!conv.lastReadAt || conv.recentMessageAt > conv.lastReadAt),
-    }))
+    .map((conv) => {
+      const latest = conv.lastMessageAt ?? conv.recentMessageAt ?? conv.createdAt;
+      return {
+        slug: conv.slug,
+        subject: conv.subject ?? "(no subject)",
+        createdAt: conv.createdAt.toISOString(),
+        latestMessage: conv.recentMessageText || null,
+        latestMessageAt: latest ? latest.toISOString() : null,
+        messageCount: messageCounts.find((m) => m.conversationId === conv.id)?.count || 0,
+        isUnread: !!conv.recentMessageAt && (!conv.lastReadAt || conv.recentMessageAt > conv.lastReadAt),
+      };
+    })
     .filter((conv) => conv.messageCount > 0);
 
   return corsResponse<ConversationsResult>({

--- a/components/widget/PreviousConversations.tsx
+++ b/components/widget/PreviousConversations.tsx
@@ -10,6 +10,7 @@ type Conversation = {
   slug: string;
   subject: string;
   createdAt: string;
+  latestMessageAt?: string | null;
   latestMessage: string | null;
 };
 
@@ -127,7 +128,7 @@ export default function PreviousConversations({ token, onSelectConversation, isA
               <div className="flex items-center justify-between">
                 <div className="text-sm font-medium text-foreground">{conversation.subject}</div>
                 <div className="text-xs text-muted-foreground">
-                  <HumanizedTime time={conversation.createdAt} />
+                  <HumanizedTime time={conversation.latestMessageAt ?? conversation.createdAt} />
                 </div>
               </div>
               {conversation.latestMessage && (

--- a/lib/data/conversation.ts
+++ b/lib/data/conversation.ts
@@ -235,6 +235,7 @@ export const serializeConversation = (
     lastUserEmailCreatedAt: conversation.lastUserEmailCreatedAt,
     lastReadAt: conversation.lastReadAt,
     lastMessageAt: conversation.lastMessageAt,
+    latestMessageAt: conversation.lastMessageAt ?? null,
     assignedToId: conversation.assignedToId,
     assignedToAI: conversation.assignedToAI,
     issueGroupId: conversation.issueGroupId,


### PR DESCRIPTION
# fix: show & sort conversations by latest message time (closes #899)


**Summary**  
Use the **latest message time** for both **display** and **ordering** in conversation lists.  
UI uses `latestMessageAt ?? createdAt`. Closed conversations still sort by `closedAt`.

**Demo**

https://github.com/user-attachments/assets/13430ecd-e2b8-4098-a2f5-69e98c679ffd




**User impact**
- Replying to any thread immediately bumps it to the top.
- The timestamp chip reflects the **last message**, not the thread’s creation time.
- Closed view behavior is unchanged.

**How to test**
1. In **All → Newest**, reply to an older conversation → it should jump to the top and show “just now/1m”.
2. Create a brand-new conversation with no replies → it shows a sensible time from `createdAt`.
3. Switch to **Closed** → ordering remains by `closedAt`.

**Notes**
- If local DB predates the new column, run once: `pnpm db:backfill-last-message-at`.

**Closes** #899