### PR TITLE
fix: spam event empty details and add reopen functionality

### DIFF
--- a/app/(dashboard)/[category]/conversation/eventItem.tsx
+++ b/app/(dashboard)/[category]/conversation/eventItem.tsx
@@ -58,7 +58,7 @@ export const EventItem = ({ event }: { event: ConversationEvent }) => {
         .filter(Boolean)
         .join(" and ");
 
-  const byUserName = getUserDisplayName(event.byUserId);
+  const byUserName = event.byUserDisplayName || getUserDisplayName(event.byUserId);
   const hasDetails = (event.byUserId && byUserName) || event.reason || event.changes.status === "spam";
 
   const Icon = event.changes.assignedToAI ? Bot : event.changes.status ? statusIcons[event.changes.status] : User;

--- a/app/(dashboard)/[category]/conversation/eventItem.tsx
+++ b/app/(dashboard)/[category]/conversation/eventItem.tsx
@@ -77,7 +77,9 @@ export const EventItem = ({ event }: { event: ConversationEvent }) => {
   const handleReopen = async () => {
     try {
       await updateStatus("open");
-    } catch {}
+    } catch (error) {
+      console.error("Failed to reopen conversation:", error);
+    }
   };
 
   const Icon = event.changes.assignedToAI ? Bot : event.changes.status ? statusIcons[event.changes.status] : User;

--- a/app/(dashboard)/[category]/conversation/eventItem.tsx
+++ b/app/(dashboard)/[category]/conversation/eventItem.tsx
@@ -1,5 +1,14 @@
 import { upperFirst } from "lodash-es";
-import { AlertCircle, ArrowLeftFromLine, ArrowRightFromLine, Bot, ChevronDown, ChevronRight, RotateCcw, User } from "lucide-react";
+import {
+  AlertCircle,
+  ArrowLeftFromLine,
+  ArrowRightFromLine,
+  Bot,
+  ChevronDown,
+  ChevronRight,
+  RotateCcw,
+  User,
+} from "lucide-react";
 import { useState } from "react";
 import { ConversationEvent } from "@/app/types/global";
 import HumanizedTime from "@/components/humanizedTime";
@@ -68,8 +77,7 @@ export const EventItem = ({ event }: { event: ConversationEvent }) => {
   const handleReopen = async () => {
     try {
       await updateStatus("open");
-    } catch {
-    }
+    } catch {}
   };
 
   const Icon = event.changes.assignedToAI ? Bot : event.changes.status ? statusIcons[event.changes.status] : User;
@@ -108,7 +116,7 @@ export const EventItem = ({ event }: { event: ConversationEvent }) => {
             {isSpamEvent && (
               <div className="flex justify-center pt-2 border-t">
                 <Button
-                  variant="outline"
+                  variant="outlined"
                   size="sm"
                   onClick={handleReopen}
                   disabled={isUpdating}

--- a/app/(dashboard)/[category]/conversation/eventItem.tsx
+++ b/app/(dashboard)/[category]/conversation/eventItem.tsx
@@ -1,20 +1,9 @@
 import { upperFirst } from "lodash-es";
-import {
-  AlertCircle,
-  ArrowLeftFromLine,
-  ArrowRightFromLine,
-  Bot,
-  ChevronDown,
-  ChevronRight,
-  RotateCcw,
-  User,
-} from "lucide-react";
+import { AlertCircle, ArrowLeftFromLine, ArrowRightFromLine, Bot, ChevronDown, ChevronRight, User } from "lucide-react";
 import { useState } from "react";
 import { ConversationEvent } from "@/app/types/global";
 import HumanizedTime from "@/components/humanizedTime";
-import { Button } from "@/components/ui/button";
 import { useMembers } from "@/components/useMembers";
-import { useConversationContext } from "./conversationContext";
 
 const eventDescriptions = {
   request_human_support: "Human support requested",
@@ -36,7 +25,6 @@ const statusIcons = {
 
 export const EventItem = ({ event }: { event: ConversationEvent }) => {
   const [detailsExpanded, setDetailsExpanded] = useState(false);
-  const { updateStatus, isUpdating } = useConversationContext();
   const { data: orgMembers, isLoading: isLoadingMembers, error: membersError } = useMembers();
 
   const getUserDisplayName = (userId: string | null | undefined): string | null => {
@@ -72,15 +60,6 @@ export const EventItem = ({ event }: { event: ConversationEvent }) => {
 
   const byUserName = getUserDisplayName(event.byUserId);
   const hasDetails = (event.byUserId && byUserName) || event.reason || event.changes.status === "spam";
-  const isSpamEvent = event.changes.status === "spam";
-
-  const handleReopen = async () => {
-    try {
-      await updateStatus("open");
-    } catch (error) {
-      console.error("Failed to reopen conversation:", error);
-    }
-  };
 
   const Icon = event.changes.assignedToAI ? Bot : event.changes.status ? statusIcons[event.changes.status] : User;
 
@@ -115,20 +94,6 @@ export const EventItem = ({ event }: { event: ConversationEvent }) => {
                 </div>
               )}
             </div>
-            {isSpamEvent && (
-              <div className="flex justify-center pt-2 border-t">
-                <Button
-                  variant="outlined"
-                  size="sm"
-                  onClick={handleReopen}
-                  disabled={isUpdating}
-                  className="h-7 text-xs"
-                >
-                  <RotateCcw className="h-3 w-3 mr-1" />
-                  {isUpdating ? "Reopening..." : "Reopen"}
-                </Button>
-              </div>
-            )}
           </div>
         </section>
       )}

--- a/app/(dashboard)/[category]/conversation/messageActions.tsx
+++ b/app/(dashboard)/[category]/conversation/messageActions.tsx
@@ -366,46 +366,46 @@ export const MessageActions = () => {
   const actionButtons = (
     <>
       <div className="flex items-center gap-4 md:flex-row-reverse">
-        {(conversation?.status ?? searchParams.status) !== "spam" &&
-          ((conversation?.status ?? searchParams.status) === "closed" ? (
-            <Button variant="outlined" onClick={() => updateStatus("open")}>
-              <CornerUpLeft className="mr-2 h-4 w-4" />
-              Reopen
+        {(conversation?.status ?? searchParams.status) === "closed" ||
+        (conversation?.status ?? searchParams.status) === "spam" ? (
+          <Button variant="outlined" onClick={() => updateStatus("open")}>
+            <CornerUpLeft className="mr-2 h-4 w-4" />
+            Reopen
+          </Button>
+        ) : (
+          <>
+            <Button
+              size={isAboveMd ? "default" : "sm"}
+              variant="outlined"
+              onClick={() => updateStatus("closed")}
+              disabled={conversation?.status === "closed"}
+            >
+              Close
+              {isMacOS() && <KeyboardShortcut className="ml-2 text-sm border-primary/50">C</KeyboardShortcut>}
             </Button>
-          ) : (
-            <>
-              <Button
-                size={isAboveMd ? "default" : "sm"}
-                variant="outlined"
-                onClick={() => updateStatus("closed")}
-                disabled={conversation?.status === "closed"}
-              >
-                Close
-                {isMacOS() && <KeyboardShortcut className="ml-2 text-sm border-primary/50">C</KeyboardShortcut>}
-              </Button>
-              <Button
-                size={isAboveMd ? "default" : "sm"}
-                variant="outlined"
-                onClick={() => handleSend({ assign: false, close: false })}
-                disabled={sendDisabled}
-              >
-                Reply
-                {!sending && isMacOS() && (
-                  <KeyboardShortcut className="ml-2 text-sm border-primary/50">⌥⏎</KeyboardShortcut>
-                )}
-              </Button>
-              <Button
-                size={isAboveMd ? "default" : "sm"}
-                onClick={() => handleSend({ assign: false })}
-                disabled={sendDisabled}
-              >
-                {sending ? "Replying..." : "Reply and close"}
-                {!sending && isMacOS() && (
-                  <KeyboardShortcut className="ml-2 text-sm border-bright-foreground/50">⌘⏎</KeyboardShortcut>
-                )}
-              </Button>
-            </>
-          ))}
+            <Button
+              size={isAboveMd ? "default" : "sm"}
+              variant="outlined"
+              onClick={() => handleSend({ assign: false, close: false })}
+              disabled={sendDisabled}
+            >
+              Reply
+              {!sending && isMacOS() && (
+                <KeyboardShortcut className="ml-2 text-sm border-primary/50">⌥⏎</KeyboardShortcut>
+              )}
+            </Button>
+            <Button
+              size={isAboveMd ? "default" : "sm"}
+              onClick={() => handleSend({ assign: false })}
+              disabled={sendDisabled}
+            >
+              {sending ? "Replying..." : "Reply and close"}
+              {!sending && isMacOS() && (
+                <KeyboardShortcut className="ml-2 text-sm border-bright-foreground/50">⌘⏎</KeyboardShortcut>
+              )}
+            </Button>
+          </>
+        )}
       </div>
     </>
   );

--- a/lib/data/conversationMessage.ts
+++ b/lib/data/conversationMessage.ts
@@ -161,7 +161,7 @@ export const getMessages = async (conversationId: number, mailbox: typeof mailbo
   );
 
   const eventInfos = await Promise.all(
-    eventRecords.map((event) => ({
+    eventRecords.map(async (event) => ({
       ...event,
       changes: {
         ...event.changes,
@@ -169,6 +169,7 @@ export const getMessages = async (conversationId: number, mailbox: typeof mailbo
         assignedToAI: event.changes?.assignedToAI,
       },
       byUserId: event.byUserId,
+      byUserDisplayName: await getStaffName(event.byUserId),
       eventType: event.type,
       type: "event" as const,
     })),


### PR DESCRIPTION
Part of #930 

### Issue 
When clicking `Marked as spam` events, the expand arrow appeared but showed empty details boxes, creating user confusion. Also there is no way for quick recovery for spam mails.

### What 
- Fixed empty expandable details for spam events to only show when there is actual content.
- Added quick reopen button for spam recovery.


### Before 

https://github.com/user-attachments/assets/0f9fa875-68d8-47e1-adb2-c2e6fc50d191



### After 


https://github.com/user-attachments/assets/8f0b0bd8-729f-42ed-8b31-26b37737807f




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a Reopen button for spam-marked events, enabling users to restore conversations from spam.
  - Reopen action shows a loading state (“Reopening…”) and is temporarily disabled during processing.

- Style
  - Refined event details layout: clearer “By” and “Reason” sections with improved spacing.
  - Reopen button appears centered under a separated section when applicable, with an updated icon for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->