### PR TITLE
Add ticket count dashboard at /stats with leaderboard and day filtering

### DIFF
--- a/app/stats/layout.tsx
+++ b/app/stats/layout.tsx
@@ -1,0 +1,26 @@
+import "@/app/globals.css";
+import type { Metadata } from "next";
+import { NuqsAdapter } from "nuqs/adapters/next/app";
+import { SentryContext } from "@/components/sentryContext";
+import { Toaster } from "@/components/ui/sonner";
+import { TRPCReactProvider } from "@/trpc/react";
+import { HydrateClient } from "@/trpc/server";
+
+export const metadata: Metadata = {
+  title: "Helper Stats",
+  description: "Ticket count dashboard",
+};
+
+export default function StatsLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <NuqsAdapter>
+      <Toaster richColors />
+      <TRPCReactProvider>
+        <HydrateClient>
+          <SentryContext />
+          <main className="min-h-screen bg-background p-8">{children}</main>
+        </HydrateClient>
+      </TRPCReactProvider>
+    </NuqsAdapter>
+  );
+}

--- a/app/stats/page.tsx
+++ b/app/stats/page.tsx
@@ -26,7 +26,7 @@ export default function StatsPage() {
           {dayOptions.map((option) => (
             <Button
               key={option.value}
-              variant={selectedDays === option.value ? "default" : "outline"}
+              variant={selectedDays === option.value ? "default" : "outlined"}
               onClick={() => setSelectedDays(option.value)}
               className="text-lg px-6 py-3"
             >

--- a/app/stats/page.tsx
+++ b/app/stats/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { useState } from "react";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { api } from "@/trpc/react";
 
 const dayOptions = [
@@ -14,7 +14,7 @@ const dayOptions = [
 
 export default function StatsPage() {
   const [selectedDays, setSelectedDays] = useState(7);
-  
+
   const { data: openCounts } = api.mailbox.openCount.useQuery();
   const { data: leaderboardData } = api.mailbox.leaderboard.useQuery({ days: selectedDays });
 
@@ -42,9 +42,7 @@ export default function StatsPage() {
             <CardTitle className="text-2xl text-muted-foreground">All Open</CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="text-8xl font-bold text-blue-600">
-              {openCounts?.all ?? 0}
-            </div>
+            <div className="text-8xl font-bold text-blue-600">{openCounts?.all ?? 0}</div>
           </CardContent>
         </Card>
 
@@ -53,9 +51,7 @@ export default function StatsPage() {
             <CardTitle className="text-2xl text-muted-foreground">Assigned</CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="text-8xl font-bold text-green-600">
-              {openCounts?.assigned ?? 0}
-            </div>
+            <div className="text-8xl font-bold text-green-600">{openCounts?.assigned ?? 0}</div>
           </CardContent>
         </Card>
 
@@ -64,9 +60,7 @@ export default function StatsPage() {
             <CardTitle className="text-2xl text-muted-foreground">Unassigned</CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="text-8xl font-bold text-orange-600">
-              {openCounts?.unassigned ?? 0}
-            </div>
+            <div className="text-8xl font-bold text-orange-600">{openCounts?.unassigned ?? 0}</div>
           </CardContent>
         </Card>
 
@@ -75,41 +69,30 @@ export default function StatsPage() {
             <CardTitle className="text-2xl text-muted-foreground">Mine</CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="text-8xl font-bold text-purple-600">
-              {openCounts?.mine ?? 0}
-            </div>
+            <div className="text-8xl font-bold text-purple-600">{openCounts?.mine ?? 0}</div>
           </CardContent>
         </Card>
       </div>
 
       <Card>
         <CardHeader>
-          <CardTitle className="text-4xl text-center">
-            Team Leaderboard - Last {selectedDays} days
-          </CardTitle>
+          <CardTitle className="text-4xl text-center">Team Leaderboard - Last {selectedDays} days</CardTitle>
         </CardHeader>
         <CardContent>
           <div className="space-y-4">
             {leaderboardData?.leaderboard.map((member, index) => (
-              <div
-                key={member.userId}
-                className="flex items-center justify-between p-6 bg-muted/50 rounded-lg"
-              >
+              <div key={member.userId} className="flex items-center justify-between p-6 bg-muted/50 rounded-lg">
                 <div className="flex items-center gap-4">
-                  <div className="text-4xl font-bold text-muted-foreground w-12">
-                    #{index + 1}
-                  </div>
+                  <div className="text-4xl font-bold text-muted-foreground w-12">#{index + 1}</div>
                   <div>
                     <div className="text-2xl font-semibold">{member.displayName}</div>
                     <div className="text-lg text-muted-foreground">{member.email}</div>
                   </div>
                 </div>
-                <div className="text-5xl font-bold text-primary">
-                  {member.replyCount}
-                </div>
+                <div className="text-5xl font-bold text-primary">{member.replyCount}</div>
               </div>
             ))}
-            {(!leaderboardData?.leaderboard.length) && (
+            {!leaderboardData?.leaderboard.length && (
               <div className="text-center text-2xl text-muted-foreground py-12">
                 No activity in the selected time period
               </div>

--- a/app/stats/page.tsx
+++ b/app/stats/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { Crown } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { api } from "@/trpc/react";
@@ -81,9 +82,20 @@ export default function StatsPage() {
         <CardContent>
           <div className="space-y-4">
             {leaderboardData?.leaderboard.map((member, index) => (
-              <div key={member.userId} className="flex items-center justify-between p-6 bg-muted/50 rounded-lg">
+              <div
+                key={member.userId}
+                data-testid="leaderboard-entry"
+                className="flex items-center justify-between p-6 bg-muted/50 rounded-lg"
+              >
                 <div className="flex items-center gap-4">
-                  <div className="text-4xl font-bold text-muted-foreground w-12">#{index + 1}</div>
+                  <div className="flex items-center gap-2 w-16">
+                    {index === 0 && (
+                      <Crown className="h-8 w-8 text-yellow-500 fill-yellow-500" />
+                    )}
+                    <div className="text-4xl font-bold text-muted-foreground">
+                      #{index + 1}
+                    </div>
+                  </div>
                   <div>
                     <div className="text-2xl font-semibold">{member.displayName}</div>
                     <div className="text-lg text-muted-foreground">{member.email}</div>

--- a/app/stats/page.tsx
+++ b/app/stats/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState } from "react";
 import { Crown } from "lucide-react";
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { api } from "@/trpc/react";
@@ -89,12 +89,8 @@ export default function StatsPage() {
               >
                 <div className="flex items-center gap-4">
                   <div className="flex items-center gap-2 w-16">
-                    {index === 0 && (
-                      <Crown className="h-8 w-8 text-yellow-500 fill-yellow-500" />
-                    )}
-                    <div className="text-4xl font-bold text-muted-foreground">
-                      #{index + 1}
-                    </div>
+                    {index === 0 && <Crown className="h-8 w-8 text-yellow-500 fill-yellow-500" />}
+                    <div className="text-4xl font-bold text-muted-foreground">#{index + 1}</div>
                   </div>
                   <div>
                     <div className="text-2xl font-semibold">{member.displayName}</div>

--- a/app/stats/page.tsx
+++ b/app/stats/page.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { api } from "@/trpc/react";
+
+const dayOptions = [
+  { value: 1, label: "Today" },
+  { value: 7, label: "7 days" },
+  { value: 30, label: "30 days" },
+  { value: 90, label: "90 days" },
+];
+
+export default function StatsPage() {
+  const [selectedDays, setSelectedDays] = useState(7);
+  
+  const { data: openCounts } = api.mailbox.openCount.useQuery();
+  const { data: leaderboardData } = api.mailbox.leaderboard.useQuery({ days: selectedDays });
+
+  return (
+    <div className="space-y-8">
+      <div className="text-center">
+        <h1 className="text-6xl font-bold text-foreground mb-4">Ticket Dashboard</h1>
+        <div className="flex justify-center gap-2">
+          {dayOptions.map((option) => (
+            <Button
+              key={option.value}
+              variant={selectedDays === option.value ? "default" : "outline"}
+              onClick={() => setSelectedDays(option.value)}
+              className="text-lg px-6 py-3"
+            >
+              {option.label}
+            </Button>
+          ))}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-6">
+        <Card className="text-center">
+          <CardHeader>
+            <CardTitle className="text-2xl text-muted-foreground">All Open</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-8xl font-bold text-blue-600">
+              {openCounts?.all ?? 0}
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card className="text-center">
+          <CardHeader>
+            <CardTitle className="text-2xl text-muted-foreground">Assigned</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-8xl font-bold text-green-600">
+              {openCounts?.assigned ?? 0}
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card className="text-center">
+          <CardHeader>
+            <CardTitle className="text-2xl text-muted-foreground">Unassigned</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-8xl font-bold text-orange-600">
+              {openCounts?.unassigned ?? 0}
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card className="text-center">
+          <CardHeader>
+            <CardTitle className="text-2xl text-muted-foreground">Mine</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-8xl font-bold text-purple-600">
+              {openCounts?.mine ?? 0}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-4xl text-center">
+            Team Leaderboard - Last {selectedDays} days
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-4">
+            {leaderboardData?.leaderboard.map((member, index) => (
+              <div
+                key={member.userId}
+                className="flex items-center justify-between p-6 bg-muted/50 rounded-lg"
+              >
+                <div className="flex items-center gap-4">
+                  <div className="text-4xl font-bold text-muted-foreground w-12">
+                    #{index + 1}
+                  </div>
+                  <div>
+                    <div className="text-2xl font-semibold">{member.displayName}</div>
+                    <div className="text-lg text-muted-foreground">{member.email}</div>
+                  </div>
+                </div>
+                <div className="text-5xl font-bold text-primary">
+                  {member.replyCount}
+                </div>
+              </div>
+            ))}
+            {(!leaderboardData?.leaderboard.length) && (
+              <div className="text-center text-2xl text-muted-foreground py-12">
+                No activity in the selected time period
+              </div>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/lib/data/stats.ts
+++ b/lib/data/stats.ts
@@ -3,7 +3,6 @@ import { db } from "@/db/client";
 import { conversations, conversationMessages as emails, userProfiles } from "@/db/schema";
 import { authUsers } from "@/db/supabaseSchema/auth";
 import { getFullName } from "@/lib/auth/authUtils";
-import { UserRole, UserRoles } from "@/lib/data/user";
 
 type DateRange = {
   startDate?: Date;
@@ -15,7 +14,6 @@ export type MemberStats = {
   email: string | undefined;
   displayName: string | null;
   replyCount: number;
-  role: UserRole;
 }[];
 
 export async function getMemberStats(dateRange?: DateRange): Promise<MemberStats> {
@@ -61,7 +59,6 @@ export async function getMemberStats(dateRange?: DateRange): Promise<MemberStats
         email: user.email ?? undefined,
         displayName: getFullName(user),
         replyCount: replyCounts[user.id] || 0,
-        role: user.access?.role || UserRoles.AFK,
       };
     })
     .sort((a, b) => b.replyCount - a.replyCount);

--- a/tests/e2e/stats/stats.spec.ts
+++ b/tests/e2e/stats/stats.spec.ts
@@ -35,10 +35,10 @@ test.describe("Stats Dashboard", () => {
     await expect(unassignedCard).toBeVisible();
     await expect(mineCard).toBeVisible();
 
-    const largeNumbers = page.locator('.text-8xl');
+    const largeNumbers = page.locator(".text-8xl");
     await expect(largeNumbers).toHaveCount(4);
 
-    const allOpenNumber = allOpenCard.locator('.text-8xl');
+    const allOpenNumber = allOpenCard.locator(".text-8xl");
     const allOpenText = await allOpenNumber.textContent();
     expect(allOpenText).toMatch(/^\d+$/);
 
@@ -56,19 +56,19 @@ test.describe("Stats Dashboard", () => {
 
     const leaderboardEntries = page.locator('[data-testid="leaderboard-entry"]');
     const emptyMessage = page.locator('div:has-text("No activity in the selected time period")');
-    
-    const hasEntries = await leaderboardEntries.count() > 0;
+
+    const hasEntries = (await leaderboardEntries.count()) > 0;
     const hasEmptyMessage = await emptyMessage.isVisible();
-    
+
     expect(hasEntries || hasEmptyMessage).toBe(true);
 
     if (hasEntries) {
       const firstEntry = leaderboardEntries.first();
       await expect(firstEntry.locator('div:has-text("#1")')).toBeVisible();
-      
-      const replyCount = firstEntry.locator('.text-5xl');
+
+      const replyCount = firstEntry.locator(".text-5xl");
       await expect(replyCount).toBeVisible();
-      
+
       const replyCountText = await replyCount.textContent();
       expect(replyCountText).toMatch(/^\d+$/);
     }
@@ -91,13 +91,13 @@ test.describe("Stats Dashboard", () => {
 
     await todayButton.click();
     await waitForNetworkIdle(page);
-    
+
     const todayTitle = page.locator('h2:has-text("Team Leaderboard - Last 1 days")');
     await expect(todayTitle).toBeVisible();
 
     await thirtyDaysButton.click();
     await waitForNetworkIdle(page);
-    
+
     const thirtyDaysTitle = page.locator('h2:has-text("Team Leaderboard - Last 30 days")');
     await expect(thirtyDaysTitle).toBeVisible();
 
@@ -105,26 +105,26 @@ test.describe("Stats Dashboard", () => {
   });
 
   test("should be optimized for wall projection", async ({ page }) => {
-    const largeHeading = page.locator('.text-6xl');
+    const largeHeading = page.locator(".text-6xl");
     await expect(largeHeading).toBeVisible();
 
-    const largeNumbers = page.locator('.text-8xl');
+    const largeNumbers = page.locator(".text-8xl");
     await expect(largeNumbers).toHaveCount(4);
 
-    const largeReplyCount = page.locator('.text-5xl');
+    const largeReplyCount = page.locator(".text-5xl");
     const replyCountElements = await largeReplyCount.count();
     expect(replyCountElements).toBeGreaterThanOrEqual(0);
 
-    const mainContainer = page.locator('main');
+    const mainContainer = page.locator("main");
     await expect(mainContainer).toHaveClass(/p-8/);
 
-    const cardGrid = page.locator('.grid');
+    const cardGrid = page.locator(".grid");
     await expect(cardGrid).toBeVisible();
 
-    const blueNumbers = page.locator('.text-blue-600');
-    const greenNumbers = page.locator('.text-green-600');
-    const orangeNumbers = page.locator('.text-orange-600');
-    const purpleNumbers = page.locator('.text-purple-600');
+    const blueNumbers = page.locator(".text-blue-600");
+    const greenNumbers = page.locator(".text-green-600");
+    const orangeNumbers = page.locator(".text-orange-600");
+    const purpleNumbers = page.locator(".text-purple-600");
 
     await expect(blueNumbers).toHaveCount(1);
     await expect(greenNumbers).toHaveCount(1);
@@ -145,7 +145,7 @@ test.describe("Stats Dashboard", () => {
 
     await waitForNetworkIdle(page);
 
-    const numbers = page.locator('.text-8xl');
+    const numbers = page.locator(".text-8xl");
     await expect(numbers).toHaveCount(4);
 
     for (let i = 0; i < 4; i++) {

--- a/tests/e2e/stats/stats.spec.ts
+++ b/tests/e2e/stats/stats.spec.ts
@@ -1,0 +1,158 @@
+import { expect, test } from "@playwright/test";
+import { takeDebugScreenshot, waitForNetworkIdle } from "../utils/test-helpers";
+
+test.use({ storageState: "tests/e2e/.auth/user.json" });
+
+test.describe("Stats Dashboard", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/stats");
+    await waitForNetworkIdle(page);
+  });
+
+  test("should display stats dashboard without navigation", async ({ page }) => {
+    await expect(page).toHaveTitle("Helper Stats");
+
+    const heading = page.locator("h1", { hasText: "Ticket Dashboard" });
+    await expect(heading).toBeVisible();
+
+    const sidebar = page.locator('[data-testid="sidebar"]');
+    await expect(sidebar).not.toBeVisible();
+
+    const navElements = page.locator('nav, [role="navigation"]');
+    await expect(navElements).toHaveCount(0);
+
+    await takeDebugScreenshot(page, "stats-dashboard-layout.png");
+  });
+
+  test("should display ticket count metrics with large numbers", async ({ page }) => {
+    const allOpenCard = page.locator('div:has-text("All Open")').first();
+    const assignedCard = page.locator('div:has-text("Assigned")').first();
+    const unassignedCard = page.locator('div:has-text("Unassigned")').first();
+    const mineCard = page.locator('div:has-text("Mine")').first();
+
+    await expect(allOpenCard).toBeVisible();
+    await expect(assignedCard).toBeVisible();
+    await expect(unassignedCard).toBeVisible();
+    await expect(mineCard).toBeVisible();
+
+    const largeNumbers = page.locator('.text-8xl');
+    await expect(largeNumbers).toHaveCount(4);
+
+    const allOpenNumber = allOpenCard.locator('.text-8xl');
+    const allOpenText = await allOpenNumber.textContent();
+    expect(allOpenText).toMatch(/^\d+$/);
+
+    await takeDebugScreenshot(page, "stats-ticket-counts.png");
+  });
+
+  test("should display team leaderboard", async ({ page }) => {
+    const leaderboardCard = page.locator('div:has-text("Team Leaderboard")').first();
+    await expect(leaderboardCard).toBeVisible();
+
+    const leaderboardTitle = page.locator('h2:has-text("Team Leaderboard - Last")');
+    await expect(leaderboardTitle).toBeVisible();
+
+    await page.waitForTimeout(2000);
+
+    const leaderboardEntries = page.locator('[data-testid="leaderboard-entry"]');
+    const emptyMessage = page.locator('div:has-text("No activity in the selected time period")');
+    
+    const hasEntries = await leaderboardEntries.count() > 0;
+    const hasEmptyMessage = await emptyMessage.isVisible();
+    
+    expect(hasEntries || hasEmptyMessage).toBe(true);
+
+    if (hasEntries) {
+      const firstEntry = leaderboardEntries.first();
+      await expect(firstEntry.locator('div:has-text("#1")')).toBeVisible();
+      
+      const replyCount = firstEntry.locator('.text-5xl');
+      await expect(replyCount).toBeVisible();
+      
+      const replyCountText = await replyCount.textContent();
+      expect(replyCountText).toMatch(/^\d+$/);
+    }
+
+    await takeDebugScreenshot(page, "stats-leaderboard.png");
+  });
+
+  test("should have functional day filtering", async ({ page }) => {
+    const todayButton = page.locator('button:has-text("Today")');
+    const sevenDaysButton = page.locator('button:has-text("7 days")');
+    const thirtyDaysButton = page.locator('button:has-text("30 days")');
+    const ninetyDaysButton = page.locator('button:has-text("90 days")');
+
+    await expect(todayButton).toBeVisible();
+    await expect(sevenDaysButton).toBeVisible();
+    await expect(thirtyDaysButton).toBeVisible();
+    await expect(ninetyDaysButton).toBeVisible();
+
+    await expect(sevenDaysButton).toHaveClass(/bg-primary|variant-default/);
+
+    await todayButton.click();
+    await waitForNetworkIdle(page);
+    
+    const todayTitle = page.locator('h2:has-text("Team Leaderboard - Last 1 days")');
+    await expect(todayTitle).toBeVisible();
+
+    await thirtyDaysButton.click();
+    await waitForNetworkIdle(page);
+    
+    const thirtyDaysTitle = page.locator('h2:has-text("Team Leaderboard - Last 30 days")');
+    await expect(thirtyDaysTitle).toBeVisible();
+
+    await takeDebugScreenshot(page, "stats-day-filtering.png");
+  });
+
+  test("should be optimized for wall projection", async ({ page }) => {
+    const largeHeading = page.locator('.text-6xl');
+    await expect(largeHeading).toBeVisible();
+
+    const largeNumbers = page.locator('.text-8xl');
+    await expect(largeNumbers).toHaveCount(4);
+
+    const largeReplyCount = page.locator('.text-5xl');
+    const replyCountElements = await largeReplyCount.count();
+    expect(replyCountElements).toBeGreaterThanOrEqual(0);
+
+    const mainContainer = page.locator('main');
+    await expect(mainContainer).toHaveClass(/p-8/);
+
+    const cardGrid = page.locator('.grid');
+    await expect(cardGrid).toBeVisible();
+
+    const blueNumbers = page.locator('.text-blue-600');
+    const greenNumbers = page.locator('.text-green-600');
+    const orangeNumbers = page.locator('.text-orange-600');
+    const purpleNumbers = page.locator('.text-purple-600');
+
+    await expect(blueNumbers).toHaveCount(1);
+    await expect(greenNumbers).toHaveCount(1);
+    await expect(orangeNumbers).toHaveCount(1);
+    await expect(purpleNumbers).toHaveCount(1);
+
+    await takeDebugScreenshot(page, "stats-wall-projection-ready.png");
+  });
+
+  test("should handle loading states gracefully", async ({ page }) => {
+    await page.reload();
+
+    const heading = page.locator("h1", { hasText: "Ticket Dashboard" });
+    await expect(heading).toBeVisible();
+
+    const filterButtons = page.locator('button:has-text("days")');
+    await expect(filterButtons).toHaveCount(4);
+
+    await waitForNetworkIdle(page);
+
+    const numbers = page.locator('.text-8xl');
+    await expect(numbers).toHaveCount(4);
+
+    for (let i = 0; i < 4; i++) {
+      const numberText = await numbers.nth(i).textContent();
+      expect(numberText).toMatch(/^\d+$/);
+    }
+
+    await takeDebugScreenshot(page, "stats-loading-complete.png");
+  });
+});

--- a/trpc/router/mailbox/index.ts
+++ b/trpc/router/mailbox/index.ts
@@ -156,7 +156,7 @@ export const mailboxRouter = {
         )
         .groupBy(conversationMessages.userId);
 
-      const userIds = staffReplies.map(r => r.userId).filter(Boolean);
+      const userIds = staffReplies.map(r => r.userId).filter((id): id is string => id !== null);
       const users = await db.query.userProfiles.findMany({
         where: inArray(userProfiles.id, userIds),
         with: {

--- a/trpc/router/mailbox/index.ts
+++ b/trpc/router/mailbox/index.ts
@@ -156,7 +156,7 @@ export const mailboxRouter = {
         )
         .groupBy(conversationMessages.userId);
 
-      const userIds = staffReplies.map(r => r.userId).filter((id): id is string => id !== null);
+      const userIds = staffReplies.map((r) => r.userId).filter((id): id is string => id !== null);
       const users = await db.query.userProfiles.findMany({
         where: inArray(userProfiles.id, userIds),
         with: {
@@ -167,11 +167,11 @@ export const mailboxRouter = {
       });
 
       const leaderboard = staffReplies
-        .map(reply => {
-          const user = users.find(u => u.id === reply.userId);
+        .map((reply) => {
+          const user = users.find((u) => u.id === reply.userId);
           return {
             userId: reply.userId,
-            displayName: user?.displayName || user?.user?.email || 'Unknown',
+            displayName: user?.displayName || user?.user?.email || "Unknown",
             email: user?.user?.email,
             replyCount: reply.count,
           };

--- a/trpc/router/mailbox/index.ts
+++ b/trpc/router/mailbox/index.ts
@@ -1,5 +1,4 @@
 import { TRPCError, type TRPCRouterRecord } from "@trpc/server";
-import { subDays } from "date-fns";
 import { and, count, eq, gte, inArray, isNotNull, isNull, SQL } from "drizzle-orm";
 import { z } from "zod";
 import { db } from "@/db/client";
@@ -138,7 +137,10 @@ export const mailboxRouter = {
       }),
     )
     .query(async ({ input }) => {
-      const staffReplyAnalyticsByUser = await db
+      const startDate = new Date();
+      startDate.setDate(startDate.getDate() - input.days);
+
+      const staffReplies = await db
         .select({
           userId: conversationMessages.userId,
           count: count(),
@@ -148,17 +150,15 @@ export const mailboxRouter = {
           and(
             eq(conversationMessages.role, "staff"),
             isNotNull(conversationMessages.userId),
-            gte(conversationMessages.createdAt, subDays(new Date(), input.days)),
+            gte(conversationMessages.createdAt, startDate),
             isNull(conversationMessages.deletedAt),
           ),
         )
         .groupBy(conversationMessages.userId);
 
+      const userIds = staffReplies.map((r) => r.userId).filter((id): id is string => id !== null);
       const users = await db.query.userProfiles.findMany({
-        where: inArray(
-          userProfiles.id,
-          staffReplyAnalyticsByUser.flatMap((r) => (r.userId ? [r.userId] : [])),
-        ),
+        where: inArray(userProfiles.id, userIds),
         with: {
           user: {
             columns: { email: true },
@@ -166,14 +166,14 @@ export const mailboxRouter = {
         },
       });
 
-      const leaderboard = staffReplyAnalyticsByUser
-        .map((staffReplyAnalytics) => {
-          const { user, displayName } = users.find((u) => u.id === staffReplyAnalytics.userId) ?? {};
+      const leaderboard = staffReplies
+        .map((reply) => {
+          const user = users.find((u) => u.id === reply.userId);
           return {
-            userId: staffReplyAnalytics.userId,
-            displayName: displayName || user?.email || "Unknown",
-            email: user?.email,
-            replyCount: staffReplyAnalytics.count,
+            userId: reply.userId,
+            displayName: user?.displayName || user?.user?.email || "Unknown",
+            email: user?.user?.email,
+            replyCount: reply.count,
           };
         })
         .sort((a, b) => b.replyCount - a.replyCount);


### PR DESCRIPTION
(Opening a separate PR based on #983 because I can't directly push to that branch)

(AI disclosure: Devin wrote the first draft; I used Cursor for rote work when rearranging code)

### What
- Adds a `/stats` page (designed for wall projection with no navigation) showing:
  - Current open ticket counts (all, assigned, unassigned, mine)
  - Team leaderboard showing staff reply counts over selectable time periods (1, 7, 30, 90 days)
  
TODO
- [ ] Screenshots and e2e specs once the design is finalized