### PR TITLE
fix: stats e2e tests

### DIFF
--- a/app/stats/page.tsx
+++ b/app/stats/page.tsx
@@ -31,7 +31,7 @@ export default function StatsPage() {
         <Image src="/logo-white.svg" alt="Helper" width={120} height={32} />
       </div>
 
-      <div className="space-y-8 max-w-screen-lg mx-auto">
+      <main className="space-y-8 max-w-screen-lg mx-auto" data-testid="stats-main-content">
         <div className="text-center">
           {/* Centered Calendar Icon with Dropdown - Replaces Ticket Dashboard title */}
           <div className="flex justify-center mb-8">
@@ -60,45 +60,53 @@ export default function StatsPage() {
           </div>
         </div>
 
-        <div className="grid grid-cols-2 lg:grid-cols-4 gap-6">
-          <Card className="text-center bg-[#331111] border-none text-white">
+        <section className="grid grid-cols-2 lg:grid-cols-4 gap-6" data-testid="metrics-grid">
+          <Card className="text-center bg-[#331111] border-none text-white" data-testid="metric-card-all-open">
             <CardHeader>
               <CardTitle className="text-2xl text-amber-100">All Open</CardTitle>
             </CardHeader>
             <CardContent>
-              <div className="text-8xl font-bold text-bright">{openCounts?.all ?? 0}</div>
+              <div className="text-8xl font-bold text-bright" data-testid="metric-value-all-open">
+                {openCounts?.all ?? 0}
+              </div>
             </CardContent>
           </Card>
 
-          <Card className="text-center bg-[#331111] border-none text-white">
+          <Card className="text-center bg-[#331111] border-none text-white" data-testid="metric-card-assigned">
             <CardHeader>
               <CardTitle className="text-2xl text-amber-100">Assigned</CardTitle>
             </CardHeader>
             <CardContent>
-              <div className="text-8xl font-bold text-[#459EFD]">{openCounts?.assigned ?? 0}</div>
+              <div className="text-8xl font-bold text-[#459EFD]" data-testid="metric-value-assigned">
+                {openCounts?.assigned ?? 0}
+              </div>
             </CardContent>
           </Card>
 
-          <Card className="text-center bg-[#331111] border-none text-white">
+          <Card className="text-center bg-[#331111] border-none text-white" data-testid="metric-card-unassigned">
             <CardHeader>
               <CardTitle className="text-2xl text-amber-100">Unassigned</CardTitle>
             </CardHeader>
             <CardContent>
-              <div className="text-8xl font-bold text-[#FF4343]">{openCounts?.unassigned ?? 0}</div>
+              <div className="text-8xl font-bold text-[#FF4343]" data-testid="metric-value-unassigned">
+                {openCounts?.unassigned ?? 0}
+              </div>
             </CardContent>
           </Card>
 
-          <Card className="text-center bg-[#331111] border-none text-white">
+          <Card className="text-center bg-[#331111] border-none text-white" data-testid="metric-card-mine">
             <CardHeader>
               <CardTitle className="text-2xl text-amber-100">Mine</CardTitle>
             </CardHeader>
             <CardContent>
-              <div className="text-8xl font-bold text-[#FF90E8]">{openCounts?.mine ?? 0}</div>
+              <div className="text-8xl font-bold text-[#FF90E8]" data-testid="metric-value-mine">
+                {openCounts?.mine ?? 0}
+              </div>
             </CardContent>
           </Card>
-        </div>
+        </section>
 
-        <div className="space-y-4">
+        <section className="space-y-4" data-testid="leaderboard-section">
           {leaderboardData?.leaderboard.map((member, index) => (
             <div
               key={member.userId}
@@ -137,8 +145,8 @@ export default function StatsPage() {
           {!leaderboardData?.leaderboard.length && (
             <div className="text-center text-2xl text-white/70 py-12">No activity in the selected time period</div>
           )}
-        </div>
-      </div>
+        </section>
+      </main>
     </div>
   );
 }

--- a/tests/e2e/stats/stats.spec.ts
+++ b/tests/e2e/stats/stats.spec.ts
@@ -10,10 +10,10 @@ test.describe("Stats Dashboard", () => {
   });
 
   test("should display stats dashboard without navigation", async ({ page }) => {
-    await expect(page).toHaveTitle("Helper Stats");
+    const timeframeDisplay = page.locator("span.text-5xl");
+    await expect(timeframeDisplay).toBeVisible();
 
-    const heading = page.locator("h1", { hasText: "Ticket Dashboard" });
-    await expect(heading).toBeVisible();
+    await expect(timeframeDisplay).toHaveText("This week");
 
     const sidebar = page.locator('[data-testid="sidebar"]');
     await expect(sidebar).not.toBeVisible();
@@ -24,135 +24,83 @@ test.describe("Stats Dashboard", () => {
     await takeDebugScreenshot(page, "stats-dashboard-layout.png");
   });
 
-  test("should display ticket count metrics with large numbers", async ({ page }) => {
-    const allOpenCard = page.locator('div:has-text("All Open")').first();
-    const assignedCard = page.locator('div:has-text("Assigned")').first();
-    const unassignedCard = page.locator('div:has-text("Unassigned")').first();
-    const mineCard = page.locator('div:has-text("Mine")').first();
+  test("should display metrics optimized for wall projection", async ({ page }) => {
+    const allOpenCard = page.getByTestId("metric-card-all-open");
+    const assignedCard = page.getByTestId("metric-card-assigned");
+    const unassignedCard = page.getByTestId("metric-card-unassigned");
+    const mineCard = page.getByTestId("metric-card-mine");
 
     await expect(allOpenCard).toBeVisible();
     await expect(assignedCard).toBeVisible();
     await expect(unassignedCard).toBeVisible();
     await expect(mineCard).toBeVisible();
 
+    await expect(allOpenCard.getByText("All Open")).toBeVisible();
+    await expect(assignedCard.getByText("Assigned")).toBeVisible();
+    await expect(unassignedCard.getByText("Unassigned")).toBeVisible();
+    await expect(mineCard.getByText("Mine")).toBeVisible();
+
     const largeNumbers = page.locator(".text-8xl");
     await expect(largeNumbers).toHaveCount(4);
 
-    const allOpenNumber = allOpenCard.locator(".text-8xl");
-    const allOpenText = await allOpenNumber.textContent();
+    const allOpenValue = page.getByTestId("metric-value-all-open");
+    const assignedValue = page.getByTestId("metric-value-assigned");
+    const unassignedValue = page.getByTestId("metric-value-unassigned");
+    const mineValue = page.getByTestId("metric-value-mine");
+
+    await expect(allOpenValue).toBeVisible();
+    await expect(assignedValue).toBeVisible();
+    await expect(unassignedValue).toBeVisible();
+    await expect(mineValue).toBeVisible();
+
+    const allOpenText = await allOpenValue.textContent();
     expect(allOpenText).toMatch(/^\d+$/);
 
-    await takeDebugScreenshot(page, "stats-ticket-counts.png");
+    const largeTimeframe = page.locator(".text-5xl");
+    const timeframeCount = await largeTimeframe.count();
+    expect(timeframeCount).toBeGreaterThanOrEqual(1);
+
+    const leaderboardSection = page.getByTestId("leaderboard-section");
+    await expect(leaderboardSection).toBeVisible();
+
+    await takeDebugScreenshot(page, "stats-wall-projection.png");
   });
 
   test("should display team leaderboard", async ({ page }) => {
-    const leaderboardCard = page.locator('div:has-text("Team Leaderboard")').first();
-    await expect(leaderboardCard).toBeVisible();
-
-    const leaderboardTitle = page.locator('h2:has-text("Team Leaderboard - Last")');
-    await expect(leaderboardTitle).toBeVisible();
-
-    await page.waitForTimeout(2000);
-
     const leaderboardEntries = page.locator('[data-testid="leaderboard-entry"]');
-    const emptyMessage = page.locator('div:has-text("No activity in the selected time period")');
 
-    const hasEntries = (await leaderboardEntries.count()) > 0;
-    const hasEmptyMessage = await emptyMessage.isVisible();
-
-    expect(hasEntries || hasEmptyMessage).toBe(true);
-
-    if (hasEntries) {
-      const firstEntry = leaderboardEntries.first();
-      await expect(firstEntry.locator('div:has-text("#1")')).toBeVisible();
-
-      const replyCount = firstEntry.locator(".text-5xl");
-      await expect(replyCount).toBeVisible();
-
-      const replyCountText = await replyCount.textContent();
-      expect(replyCountText).toMatch(/^\d+$/);
-    }
+    const supportEmailEntry = leaderboardEntries.filter({ hasText: "support@gumroad.com" });
+    await expect(supportEmailEntry).toBeVisible();
 
     await takeDebugScreenshot(page, "stats-leaderboard.png");
   });
 
   test("should have functional day filtering", async ({ page }) => {
-    const todayButton = page.locator('button:has-text("Today")');
-    const sevenDaysButton = page.locator('button:has-text("7 days")');
-    const thirtyDaysButton = page.locator('button:has-text("30 days")');
-    const ninetyDaysButton = page.locator('button:has-text("90 days")');
+    const timeframeDisplay = page.locator("span.text-5xl");
 
-    await expect(todayButton).toBeVisible();
-    await expect(sevenDaysButton).toBeVisible();
-    await expect(thirtyDaysButton).toBeVisible();
-    await expect(ninetyDaysButton).toBeVisible();
+    await expect(timeframeDisplay).toHaveText("This week");
 
-    await expect(sevenDaysButton).toHaveClass(/bg-primary|variant-default/);
+    await timeframeDisplay.hover();
 
-    await todayButton.click();
+    const todayOption = page.getByRole("button", { name: "Today" });
+    const weekOption = page.getByRole("button", { name: "This week" });
+    const monthOption = page.getByRole("button", { name: "This month" });
+    const threeMonthsOption = page.getByRole("button", { name: "Three months" });
+
+    await expect(todayOption).toBeVisible();
+    await expect(weekOption).toBeVisible();
+    await expect(monthOption).toBeVisible();
+    await expect(threeMonthsOption).toBeVisible();
+
+    await todayOption.click();
     await waitForNetworkIdle(page);
+    await expect(timeframeDisplay).toHaveText("Today");
 
-    const todayTitle = page.locator('h2:has-text("Team Leaderboard - Last 1 days")');
-    await expect(todayTitle).toBeVisible();
-
-    await thirtyDaysButton.click();
+    await timeframeDisplay.hover();
+    await monthOption.click();
     await waitForNetworkIdle(page);
-
-    const thirtyDaysTitle = page.locator('h2:has-text("Team Leaderboard - Last 30 days")');
-    await expect(thirtyDaysTitle).toBeVisible();
+    await expect(timeframeDisplay).toHaveText("This month");
 
     await takeDebugScreenshot(page, "stats-day-filtering.png");
-  });
-
-  test("should be optimized for wall projection", async ({ page }) => {
-    const largeHeading = page.locator(".text-6xl");
-    await expect(largeHeading).toBeVisible();
-
-    const largeNumbers = page.locator(".text-8xl");
-    await expect(largeNumbers).toHaveCount(4);
-
-    const largeReplyCount = page.locator(".text-5xl");
-    const replyCountElements = await largeReplyCount.count();
-    expect(replyCountElements).toBeGreaterThanOrEqual(0);
-
-    const mainContainer = page.locator("main");
-    await expect(mainContainer).toHaveClass(/p-8/);
-
-    const cardGrid = page.locator(".grid");
-    await expect(cardGrid).toBeVisible();
-
-    const blueNumbers = page.locator(".text-blue-600");
-    const greenNumbers = page.locator(".text-green-600");
-    const orangeNumbers = page.locator(".text-orange-600");
-    const purpleNumbers = page.locator(".text-purple-600");
-
-    await expect(blueNumbers).toHaveCount(1);
-    await expect(greenNumbers).toHaveCount(1);
-    await expect(orangeNumbers).toHaveCount(1);
-    await expect(purpleNumbers).toHaveCount(1);
-
-    await takeDebugScreenshot(page, "stats-wall-projection-ready.png");
-  });
-
-  test("should handle loading states gracefully", async ({ page }) => {
-    await page.reload();
-
-    const heading = page.locator("h1", { hasText: "Ticket Dashboard" });
-    await expect(heading).toBeVisible();
-
-    const filterButtons = page.locator('button:has-text("days")');
-    await expect(filterButtons).toHaveCount(4);
-
-    await waitForNetworkIdle(page);
-
-    const numbers = page.locator(".text-8xl");
-    await expect(numbers).toHaveCount(4);
-
-    for (let i = 0; i < 4; i++) {
-      const numberText = await numbers.nth(i).textContent();
-      expect(numberText).toMatch(/^\d+$/);
-    }
-
-    await takeDebugScreenshot(page, "stats-loading-complete.png");
   });
 });


### PR DESCRIPTION
Ref:- A bunch of tests are flaky or failing in https://github.com/antiwork/helper/issues/992

This PR fixes all the 5 E2E tests that were failing on /stats page introduced here https://github.com/antiwork/helper/pull/999. I have also removed an un necessary test and combined some.

Before:

![Screenshot 2025-09-01 at 12 48 40 AM](https://github.com/user-attachments/assets/fba31ee4-db98-40f2-a194-6e2f55c8f08c)



After

![Screenshot 2025-09-01 at 1 40 11 AM](https://github.com/user-attachments/assets/2f6cf7af-4edd-4895-b2f9-505671ae9da6)




AI Disclosure:-
Some code is written by Claude Code


