### PR TITLE
fix: help articles E2E tests

### DIFF
--- a/tests/e2e/help-article-search/helpArticleSearch.spec.ts
+++ b/tests/e2e/help-article-search/helpArticleSearch.spec.ts
@@ -7,6 +7,17 @@ import { conversationFactory } from "../../../tests/support/factories/conversati
 
 test.use({ storageState: "tests/e2e/.auth/user.json" });
 
+const mockHelpArticles = [
+  { title: "How to manage your account", url: "https://help.example.com/account" },
+  { title: "Getting started guide", url: "https://help.example.com/getting-started" },
+  { title: "Account settings", url: "https://help.example.com/account-settings" },
+  { title: "Billing and payments", url: "https://help.example.com/billing" },
+  { title: "API documentation", url: "https://help.example.com/api" },
+  { title: "Security best practices", url: "https://help.example.com/security" },
+  { title: "Troubleshooting common issues", url: "https://help.example.com/troubleshooting" },
+  { title: "Contact support", url: "https://help.example.com/contact" },
+];
+
 test.describe("Help Article Search", () => {
   let testConversationId: number | null = null;
   let testUserId: string | null = null;
@@ -49,7 +60,26 @@ test.describe("Help Article Search", () => {
     }
   });
 
-  test.beforeEach(async ({ page }) => {
+  test.beforeEach(async ({ page, context }) => {
+    await context.route("**/api/trpc/**", async (route) => {
+      const url = route.request().url();
+      if (url.includes("mailbox.websites.pages")) {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            result: {
+              data: {
+                json: mockHelpArticles,
+              },
+            },
+          }),
+        });
+      } else {
+        await route.continue();
+      }
+    });
+
     await page.goto("/mine", { timeout: 15000 });
     await page.waitForLoadState("networkidle", { timeout: 10000 });
 


### PR DESCRIPTION
Ref:- https://github.com/antiwork/helper/issues/992

This PR fixes the 3 failing E2E tests in tests/e2e/help-article-search/helpArticleSearch.spec.ts. The reason it was failing was because there were no help articles in the seeded data so i had to mock the request here

Before:-
![Screenshot 2025-09-01 at 1 57 26 AM](https://github.com/user-attachments/assets/bfd3650a-0196-482c-85d9-fb85b6f8fcb1)


After:-
![Screenshot 2025-09-01 at 2 28 55 AM](https://github.com/user-attachments/assets/16b370e3-ddad-4205-b416-aca0056a8314)
