### PR TITLE
feat: auto assign replies to self

### DIFF
--- a/app/(dashboard)/[category]/conversation/messageActions.tsx
+++ b/app/(dashboard)/[category]/conversation/messageActions.tsx
@@ -419,7 +419,7 @@ export const MessageActions = () => {
               <Button
                 size={isAboveMd ? "default" : "sm"}
                 variant="outlined"
-                onClick={() => handleSend({ assign: false, close: false })}
+                onClick={() => handleSend({ assign: !conversation?.cc, close: false })}
                 disabled={sendDisabled}
               >
                 Reply


### PR DESCRIPTION
resolves #1008

Before:
When a ticket is unassigned and a user replies to that ticket the ticket remains unassigned

After:
When a ticket is unassigned and a user replies to that the replying user is assigned for that ticket

Demo:
<video src="https://github.com/user-attachments/assets/7c6fbde5-5684-4a7f-b3d4-262776ffcff7" height="300px" />

AI Disclosure
No AI was used to write any code

