### PR TITLE
feat: auto-assign ticket to self on first user action

### DIFF
--- a/app/(dashboard)/[category]/conversation/conversationContext.tsx
+++ b/app/(dashboard)/[category]/conversation/conversationContext.tsx
@@ -121,7 +121,7 @@ export const ConversationContextProvider = ({ children }: { children: React.Reac
     async (status: "closed" | "spam" | "open") => {
       const previousStatus = data?.status;
 
-      await update({ status });
+      await update({ status, shouldAutoAssign: true });
 
       if (status === "open") {
         toast.success("Conversation reopened");

--- a/app/(dashboard)/[category]/conversation/messageActions.tsx
+++ b/app/(dashboard)/[category]/conversation/messageActions.tsx
@@ -103,6 +103,7 @@ export const MessageActions = () => {
   );
 
   const { user } = useSession() ?? {};
+  const shouldAutoAssign = Boolean(!conversation?.assignedToId && user?.preferences?.autoAssignOnTicketAction);
 
   const triggerMailboxConfetti = () => {
     if (!user?.preferences?.confetti) return;
@@ -419,7 +420,7 @@ export const MessageActions = () => {
               <Button
                 size={isAboveMd ? "default" : "sm"}
                 variant="outlined"
-                onClick={() => handleSend({ assign: false, close: false })}
+                onClick={() => handleSend({ assign: shouldAutoAssign, close: false })}
                 disabled={sendDisabled}
               >
                 Reply
@@ -429,7 +430,7 @@ export const MessageActions = () => {
               </Button>
               <Button
                 size={isAboveMd ? "default" : "sm"}
-                onClick={() => handleSend({ assign: false })}
+                onClick={() => handleSend({ assign: shouldAutoAssign })}
                 disabled={sendDisabled}
               >
                 {sending ? "Replying..." : "Reply and close"}
@@ -496,8 +497,8 @@ export const MessageActions = () => {
             handleTypingEvent(conversation.slug);
           }
         }}
-        onModEnter={() => !sendDisabled && handleSend({ assign: false })}
-        onOptionEnter={() => !sendDisabled && handleSend({ assign: false, close: false })}
+        onModEnter={() => !sendDisabled && handleSend({ assign: shouldAutoAssign })}
+        onOptionEnter={() => !sendDisabled && handleSend({ assign: shouldAutoAssign, close: false })}
         onSlashKey={() => {
           setShowCommandBar(true);
           setTimeout(() => commandInputRef.current?.focus(), 100);

--- a/app/(dashboard)/[category]/list/conversationList.tsx
+++ b/app/(dashboard)/[category]/list/conversationList.tsx
@@ -102,6 +102,7 @@ export const List = () => {
         {
           conversationFilter,
           status,
+          shouldAutoAssign: true,
         },
         {
           onSuccess: ({ updatedImmediately }) => {

--- a/app/(dashboard)/settings/preferences/autoAssignOnTicketActionSetting.tsx
+++ b/app/(dashboard)/settings/preferences/autoAssignOnTicketActionSetting.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { toast } from "sonner";
+import { useSavingIndicator } from "@/components/hooks/useSavingIndicator";
+import { SavingIndicator } from "@/components/savingIndicator";
+import { useSession } from "@/components/useSession";
+import { api } from "@/trpc/react";
+import { SwitchSectionWrapper } from "../sectionWrapper";
+
+const AutoAssignOnTicketActionSetting = () => {
+  const { user } = useSession() ?? {};
+  const savingIndicator = useSavingIndicator();
+  const utils = api.useUtils();
+  const { mutate: update } = api.user.update.useMutation({
+    onSuccess: () => {
+      utils.user.currentUser.invalidate();
+      savingIndicator.setState("saved");
+    },
+    onError: (error) => {
+      savingIndicator.setState("error");
+      toast.error("Error updating preferences", { description: error.message });
+    },
+  });
+
+  const handleSwitchChange = (checked: boolean) => {
+    savingIndicator.setState("saving");
+    update({
+      preferences: {
+        autoAssignOnTicketAction: checked,
+      },
+    });
+  };
+
+  return (
+    <div className="relative">
+      <div className="absolute top-2 right-4 z-10">
+        <SavingIndicator state={savingIndicator.state} />
+      </div>
+      {user && (
+        <SwitchSectionWrapper
+          title="Auto-Assign On Ticket Action"
+          description="Enable automatic ticket assignment upon first action on unassigned tickets"
+          initialSwitchChecked={user?.preferences?.autoAssignOnTicketAction}
+          onSwitchChange={handleSwitchChange}
+        >
+          <></>
+        </SwitchSectionWrapper>
+      )}
+    </div>
+  );
+};
+
+export default AutoAssignOnTicketActionSetting;

--- a/app/(dashboard)/settings/preferences/preferencesSetting.tsx
+++ b/app/(dashboard)/settings/preferences/preferencesSetting.tsx
@@ -1,9 +1,11 @@
+import AutoAssignOnTickeActionSetting from "./autoAssignOnTicketActionSetting";
 import ConfettiSetting from "./confettiSetting";
 import NextTicketPreviewSetting from "./nextTicketPreviewSetting";
 
 const PreferencesSetting = () => {
   return (
     <div className="space-y-6">
+      <AutoAssignOnTickeActionSetting />
       <ConfettiSetting />
       <NextTicketPreviewSetting />
     </div>

--- a/db/drizzle/0122_chief_ser_duncan.sql
+++ b/db/drizzle/0122_chief_ser_duncan.sql
@@ -1,0 +1,11 @@
+-- Migration Up: Add autoAssignOnTicketAction field to user preferences
+
+BEGIN;
+
+UPDATE "user_profiles" 
+SET "preferences" = COALESCE("preferences", '{}'::jsonb) || '{"autoAssignOnTicketAction": true}'::jsonb
+WHERE NOT (COALESCE("preferences", '{}'::jsonb) ? 'autoAssignOnTicketAction');
+
+ALTER TABLE "user_profiles" ALTER COLUMN "preferences" SET DEFAULT '{"autoAssignOnTicketAction":true}'::jsonb;
+
+COMMIT;

--- a/db/drizzle/meta/0122_snapshot.json
+++ b/db/drizzle/meta/0122_snapshot.json
@@ -1,0 +1,4470 @@
+{
+  "id": "5321bf80-e0b0-4f28-a540-5a913a96d2cd",
+  "prevId": "8e9e0620-f367-40ea-8553-93c6b5d9f1b4",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_messages": {
+      "name": "agent_messages",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "agent_messages_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "agent_thread_id": {
+          "name": "agent_thread_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_channel": {
+          "name": "slack_channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_ts": {
+          "name": "message_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agent_messages_agent_thread_id_idx": {
+          "name": "agent_messages_agent_thread_id_idx",
+          "columns": [
+            {
+              "expression": "agent_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_messages_slack_unique_idx": {
+          "name": "agent_messages_slack_unique_idx",
+          "columns": [
+            {
+              "expression": "slack_channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.agent_threads": {
+      "name": "agent_threads",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "agent_threads_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "mailbox_id": {
+          "name": "mailbox_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_channel": {
+          "name": "slack_channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_ts": {
+          "name": "thread_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_threads_mailbox_id_idx": {
+          "name": "agent_threads_mailbox_id_idx",
+          "columns": [
+            {
+              "expression": "mailbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_threads_slack_channel_thread_ts_idx": {
+          "name": "agent_threads_slack_channel_thread_ts_idx",
+          "columns": [
+            {
+              "expression": "slack_channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "thread_ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.mailboxes_aiusageevent": {
+      "name": "mailboxes_aiusageevent",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "mailboxes_aiusageevent_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "query_type": {
+          "name": "query_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens_count": {
+          "name": "input_tokens_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_tokens_count": {
+          "name": "output_tokens_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cached_tokens_count": {
+          "name": "cached_tokens_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost": {
+          "name": "cost",
+          "type": "numeric(12, 7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mailbox_id": {
+          "name": "mailbox_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mailboxes_aiusageevent_created_at_74823d57": {
+          "name": "mailboxes_aiusageevent_created_at_74823d57",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mailboxes_aiusageevent_mailbox_id_a4908f79": {
+          "name": "mailboxes_aiusageevent_mailbox_id_a4908f79",
+          "columns": [
+            {
+              "expression": "mailbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mailboxes_aiusageevent_model_name_84b8ca7a": {
+          "name": "mailboxes_aiusageevent_model_name_84b8ca7a",
+          "columns": [
+            {
+              "expression": "model_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mailboxes_aiusageevent_model_name_84b8ca7a_like": {
+          "name": "mailboxes_aiusageevent_model_name_84b8ca7a_like",
+          "columns": [
+            {
+              "expression": "model_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mailboxes_aiusageevent_query_type_b4a486cb": {
+          "name": "mailboxes_aiusageevent_query_type_b4a486cb",
+          "columns": [
+            {
+              "expression": "query_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mailboxes_aiusageevent_query_type_b4a486cb_like": {
+          "name": "mailboxes_aiusageevent_query_type_b4a486cb_like",
+          "columns": [
+            {
+              "expression": "query_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.cache": {
+      "name": "cache",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "cache_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cache_expires_at_idx": {
+          "name": "cache_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cache_key_idx": {
+          "name": "cache_key_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.conversation_events": {
+      "name": "conversation_events",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "conversation_events_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'update'"
+        },
+        "changes": {
+          "name": "changes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "by_clerk_user_id": {
+          "name": "by_clerk_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "conversation_events_conversation_id_idx": {
+          "name": "conversation_events_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_events_by_clerk_user_id_idx": {
+          "name": "conversation_events_by_clerk_user_id_idx",
+          "columns": [
+            {
+              "expression": "by_clerk_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_events_type_created_at_idx": {
+          "name": "conversation_events_type_created_at_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.conversation_followers": {
+      "name": "conversation_followers",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "conversation_followers_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "conversation_followers_conversation_id_idx": {
+          "name": "conversation_followers_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_followers_user_id_idx": {
+          "name": "conversation_followers_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conversation_followers_conversation_user_unique": {
+          "name": "conversation_followers_conversation_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "conversation_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "messages_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_to": {
+          "name": "email_to",
+          "type": "varchar(65535)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_from": {
+          "name": "email_from",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_cc": {
+          "name": "email_cc",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_bcc": {
+          "name": "email_bcc",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cleaned_up_text": {
+          "name": "cleaned_up_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clerk_user_id": {
+          "name": "clerk_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_to_id": {
+          "name": "response_to_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "references": {
+          "name": "references",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gmail_message_id": {
+          "name": "gmail_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gmail_thread_id": {
+          "name": "gmail_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_channel": {
+          "name": "slack_channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_message_ts": {
+          "name": "slack_message_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_perfect": {
+          "name": "is_perfect",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_flagged_as_bad": {
+          "name": "is_flagged_as_bad",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_info": {
+          "name": "prompt_info",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(65535)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_index": {
+          "name": "search_index",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reaction_type": {
+          "name": "reaction_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reaction_feedback": {
+          "name": "reaction_feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reaction_created_at": {
+          "name": "reaction_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "conversatio_created_c4e0d1_idx": {
+          "name": "conversatio_created_c4e0d1_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_email_conversation_id_391ad973": {
+          "name": "conversations_email_conversation_id_391ad973",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_email_gmail_message_id_3f6ee5ab": {
+          "name": "conversations_email_gmail_message_id_3f6ee5ab",
+          "columns": [
+            {
+              "expression": "gmail_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_email_gmail_thread_id_68f031bf": {
+          "name": "conversations_email_gmail_thread_id_68f031bf",
+          "columns": [
+            {
+              "expression": "gmail_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_email_is_pinned_ab83d24f": {
+          "name": "conversations_email_is_pinned_ab83d24f",
+          "columns": [
+            {
+              "expression": "is_pinned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_email_message_id_a19e9ac9": {
+          "name": "conversations_email_message_id_a19e9ac9",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_email_response_to_id_af0048dc": {
+          "name": "conversations_email_response_to_id_af0048dc",
+          "columns": [
+            {
+              "expression": "response_to_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_email_clerk_user_id": {
+          "name": "conversations_email_clerk_user_id",
+          "columns": [
+            {
+              "expression": "clerk_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "search_index_idx": {
+          "name": "search_index_idx",
+          "columns": [
+            {
+              "expression": "string_to_array(\"search_index\", ' ') array_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "messages_reason_idx": {
+          "name": "messages_reason_idx",
+          "columns": [
+            {
+              "expression": "reason",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_slack_message_ts_idx": {
+          "name": "messages_slack_message_ts_idx",
+          "columns": [
+            {
+              "expression": "slack_message_ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_reaction_count_idx": {
+          "name": "messages_reaction_count_idx",
+          "columns": [
+            {
+              "expression": "reaction_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reaction_created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"messages\".\"deleted_at\" is null",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_role_created_at_idx": {
+          "name": "messages_role_created_at_idx",
+          "columns": [
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_conversation_created_at_desc_idx": {
+          "name": "messages_conversation_created_at_desc_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(\"messages\".\"deleted_at\" is null and \"messages\".\"role\" in ($1, $2))",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.conversations_conversation": {
+      "name": "conversations_conversation",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "conversations_conversation_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "email_from": {
+          "name": "email_from",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mailbox_id": {
+          "name": "mailbox_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_from_name": {
+          "name": "email_from_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_user_email_created_at": {
+          "name": "last_user_email_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_read_at": {
+          "name": "last_read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_read_by_assignee_at": {
+          "name": "last_read_by_assignee_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_provider": {
+          "name": "conversation_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_to_clerk_id": {
+          "name": "assigned_to_clerk_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_text": {
+          "name": "embedding_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_issue_number": {
+          "name": "github_issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_issue_url": {
+          "name": "github_issue_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_repo_owner": {
+          "name": "github_repo_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_repo_name": {
+          "name": "github_repo_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_prompt": {
+          "name": "is_prompt",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_visitor": {
+          "name": "is_visitor",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "assigned_to_ai": {
+          "name": "assigned_to_ai",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "merged_into_id": {
+          "name": "merged_into_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anonymous_session_id": {
+          "name": "anonymous_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_group_id": {
+          "name": "issue_group_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggested_actions": {
+          "name": "suggested_actions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "conversations_conversation_assigned_to_clerk_id": {
+          "name": "conversations_conversation_assigned_to_clerk_id",
+          "columns": [
+            {
+              "expression": "assigned_to_clerk_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_conversation_closed_at_16474e94": {
+          "name": "conversations_conversation_closed_at_16474e94",
+          "columns": [
+            {
+              "expression": "closed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_conversation_created_at_1ec48787": {
+          "name": "conversations_conversation_created_at_1ec48787",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_conversation_email_from_aab3d292": {
+          "name": "conversations_conversation_email_from_aab3d292",
+          "columns": [
+            {
+              "expression": "email_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_conversation_email_from_aab3d292_like": {
+          "name": "conversations_conversation_email_from_aab3d292_like",
+          "columns": [
+            {
+              "expression": "email_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_conversation_last_user_email_created_at_fc6b89db": {
+          "name": "conversations_conversation_last_user_email_created_at_fc6b89db",
+          "columns": [
+            {
+              "expression": "last_user_email_created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_conversation_mailbox_id_7fb25662": {
+          "name": "conversations_conversation_mailbox_id_7fb25662",
+          "columns": [
+            {
+              "expression": "mailbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_conversation_slug_9924e9b1_like": {
+          "name": "conversations_conversation_slug_9924e9b1_like",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "embedding_vector_index": {
+          "name": "embedding_vector_index",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "conversations_anonymous_session_id_idx": {
+          "name": "conversations_anonymous_session_id_idx",
+          "columns": [
+            {
+              "expression": "anonymous_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_merged_into_id_idx": {
+          "name": "conversations_merged_into_id_idx",
+          "columns": [
+            {
+              "expression": "merged_into_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_issue_group_id_idx": {
+          "name": "conversations_issue_group_id_idx",
+          "columns": [
+            {
+              "expression": "issue_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_last_message_at_idx": {
+          "name": "conversations_last_message_at_idx",
+          "columns": [
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_conversation_status_last_user_email_created_at_idx": {
+          "name": "conversations_conversation_status_last_user_email_created_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_user_email_created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"conversations_conversation\".\"merged_into_id\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conversations_conversation_slug_key": {
+          "name": "conversations_conversation_slug_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.faqs": {
+      "name": "faqs",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "faqs_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "reply": {
+          "name": "reply",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mailbox_id": {
+          "name": "mailbox_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "suggested": {
+          "name": "suggested",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "suggested_replacement_for_id": {
+          "name": "suggested_replacement_for_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_channel": {
+          "name": "slack_channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_message_ts": {
+          "name": "slack_message_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "faqs_mailbox_created_at_idx": {
+          "name": "faqs_mailbox_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "faqs_mailbox_id_idx": {
+          "name": "faqs_mailbox_id_idx",
+          "columns": [
+            {
+              "expression": "mailbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "faqs_embedding_index": {
+          "name": "faqs_embedding_index",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "faqs_message_id_key": {
+          "name": "faqs_message_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "message_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.conversations_file": {
+      "name": "conversations_file",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "conversations_file_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mimetype": {
+          "name": "mimetype",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note_id": {
+          "name": "note_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview_url": {
+          "name": "preview_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_inline": {
+          "name": "is_inline",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "conversatio_created_9fddde_idx": {
+          "name": "conversatio_created_9fddde_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_file_message_id_idx": {
+          "name": "conversations_file_message_id_idx",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_file_note_id_idx": {
+          "name": "conversations_file_note_id_idx",
+          "columns": [
+            {
+              "expression": "note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conversations_file_slug_key": {
+          "name": "conversations_file_slug_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.mailboxes_gmailsupportemail": {
+      "name": "mailboxes_gmailsupportemail",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "mailboxes_gmailsupportemail_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(254)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "history_id": {
+          "name": "history_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mailboxes_gmailsupportemail_created_at_321a00f1": {
+          "name": "mailboxes_gmailsupportemail_created_at_321a00f1",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mailboxes_supportemail_email_99536dd8_like": {
+          "name": "mailboxes_supportemail_email_99536dd8_like",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mailboxes_supportemail_email_key": {
+          "name": "mailboxes_supportemail_email_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.guide_session_events": {
+      "name": "guide_session_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "guide_session_events_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "guide_session_id": {
+          "name": "guide_session_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "guide_session_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "mailbox_id": {
+          "name": "mailbox_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "guide_session_events_timestamp_idx": {
+          "name": "guide_session_events_timestamp_idx",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "guide_session_events_guide_session_id_idx": {
+          "name": "guide_session_events_guide_session_id_idx",
+          "columns": [
+            {
+              "expression": "guide_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "guide_session_events_type_idx": {
+          "name": "guide_session_events_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "guide_session_events_mailbox_id_idx": {
+          "name": "guide_session_events_mailbox_id_idx",
+          "columns": [
+            {
+              "expression": "mailbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.guide_session_replays": {
+      "name": "guide_session_replays",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "guide_session_replays_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "guide_session_id": {
+          "name": "guide_session_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "mailbox_id": {
+          "name": "mailbox_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "guide_session_replays_guide_session_id_idx": {
+          "name": "guide_session_replays_guide_session_id_idx",
+          "columns": [
+            {
+              "expression": "guide_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "guide_session_replays_timestamp_idx": {
+          "name": "guide_session_replays_timestamp_idx",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "guide_session_replays_mailbox_id_idx": {
+          "name": "guide_session_replays_mailbox_id_idx",
+          "columns": [
+            {
+              "expression": "mailbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.guide_sessions": {
+      "name": "guide_sessions",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "guide_sessions_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "platform_customer_id": {
+          "name": "platform_customer_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "guide_session_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'started'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steps": {
+          "name": "steps",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "mailbox_id": {
+          "name": "mailbox_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "guide_sessions_created_at_idx": {
+          "name": "guide_sessions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "guide_sessions_platform_customer_id_idx": {
+          "name": "guide_sessions_platform_customer_id_idx",
+          "columns": [
+            {
+              "expression": "platform_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "guide_sessions_conversation_id_idx": {
+          "name": "guide_sessions_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "guide_sessions_mailbox_id_idx": {
+          "name": "guide_sessions_mailbox_id_idx",
+          "columns": [
+            {
+              "expression": "mailbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "guide_sessions_status_idx": {
+          "name": "guide_sessions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "guide_sessions_uuid_unique": {
+          "name": "guide_sessions_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uuid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.mailboxes_mailbox": {
+      "name": "mailboxes_mailbox",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "mailboxes_mailbox_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gmail_support_email_id": {
+          "name": "gmail_support_email_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_escalation_channel": {
+          "name": "slack_escalation_channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_bot_token": {
+          "name": "slack_bot_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_bot_user_id": {
+          "name": "slack_bot_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_team_id": {
+          "name": "slack_team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_installation_id": {
+          "name": "github_installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_repo_owner": {
+          "name": "github_repo_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_repo_name": {
+          "name": "github_repo_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_updated_at": {
+          "name": "prompt_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "widget_hmac_secret": {
+          "name": "widget_hmac_secret",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "widget_display_mode": {
+          "name": "widget_display_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'always'"
+        },
+        "widget_display_min_value": {
+          "name": "widget_display_min_value",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "widget_host": {
+          "name": "widget_host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vip_threshold": {
+          "name": "vip_threshold",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vip_channel_id": {
+          "name": "vip_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vip_expected_response_hours": {
+          "name": "vip_expected_response_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_whitelabel": {
+          "name": "is_whitelabel",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_close_enabled": {
+          "name": "auto_close_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_close_days_of_inactivity": {
+          "name": "auto_close_days_of_inactivity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 14
+        },
+        "chat_integration_used": {
+          "name": "chat_integration_used",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "mailboxes_mailbox_created_at_5d4ea7d0": {
+          "name": "mailboxes_mailbox_created_at_5d4ea7d0",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mailboxes_mailbox_slug_key": {
+          "name": "mailboxes_mailbox_slug_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "mailboxes_mailbox_support_email_id_key": {
+          "name": "mailboxes_mailbox_support_email_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "gmail_support_email_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.mailboxes_metadataapi": {
+      "name": "mailboxes_metadataapi",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "mailboxes_metadataapi_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hmac_secret": {
+          "name": "hmac_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mailbox_id": {
+          "name": "mailbox_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mailboxes_metadataapi_created_at_1ee2d2c2": {
+          "name": "mailboxes_metadataapi_created_at_1ee2d2c2",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mailboxes_metadataapi_mailbox_id_key": {
+          "name": "mailboxes_metadataapi_mailbox_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "mailbox_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.mailboxes_platformcustomer": {
+      "name": "mailboxes_platformcustomer",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "mailboxes_platformcustomer_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "mailbox_id": {
+          "name": "mailbox_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value": {
+          "name": "value",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "links": {
+          "name": "links",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mailboxes_platformcustomer_created_at_73183c2a": {
+          "name": "mailboxes_platformcustomer_created_at_73183c2a",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mailboxes_platformcustomer_mailbox_id_58ea76bf": {
+          "name": "mailboxes_platformcustomer_mailbox_id_58ea76bf",
+          "columns": [
+            {
+              "expression": "mailbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "platformcustomer_value_idx": {
+          "name": "platformcustomer_value_idx",
+          "columns": [
+            {
+              "expression": "value",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mailboxes_platformcustomer_email_ilike": {
+          "name": "mailboxes_platformcustomer_email_ilike",
+          "columns": [
+            {
+              "expression": "\"email\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mailboxes_platformcustomer_email_key": {
+          "name": "mailboxes_platformcustomer_email_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.conversations_note": {
+      "name": "conversations_note",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "conversations_note_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clerk_user_id": {
+          "name": "clerk_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_message_ts": {
+          "name": "slack_message_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_channel": {
+          "name": "slack_channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "conversatio_created_5ad461_idx": {
+          "name": "conversatio_created_5ad461_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_note_conversation_id_a486ed4c": {
+          "name": "conversations_note_conversation_id_a486ed4c",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_note_clerk_user_id": {
+          "name": "conversations_note_clerk_user_id",
+          "columns": [
+            {
+              "expression": "clerk_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.message_notifications": {
+      "name": "message_notifications",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "message_notifications_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_customer_id": {
+          "name": "platform_customer_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "notification_text": {
+          "name": "notification_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "message_notifications_message_id_idx": {
+          "name": "message_notifications_message_id_idx",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "message_notifications_conversation_id_idx": {
+          "name": "message_notifications_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "message_notifications_platform_customer_id_idx": {
+          "name": "message_notifications_platform_customer_id_idx",
+          "columns": [
+            {
+              "expression": "platform_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "message_notifications_status_idx": {
+          "name": "message_notifications_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.website_docs_crawls": {
+      "name": "website_docs_crawls",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "website_docs_crawls_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "website_id": {
+          "name": "website_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "website_crawls_created_at_idx": {
+          "name": "website_crawls_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "website_crawls_website_id_idx": {
+          "name": "website_crawls_website_id_idx",
+          "columns": [
+            {
+              "expression": "website_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "website_crawls_status_idx": {
+          "name": "website_crawls_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.website_docs_pages": {
+      "name": "website_docs_pages",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "website_docs_pages_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "website_id": {
+          "name": "website_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "website_crawl_id": {
+          "name": "website_crawl_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_html": {
+          "name": "raw_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "markdown": {
+          "name": "markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_title": {
+          "name": "page_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "website_pages_created_at_idx": {
+          "name": "website_pages_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "website_pages_website_id_idx": {
+          "name": "website_pages_website_id_idx",
+          "columns": [
+            {
+              "expression": "website_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "website_pages_website_crawl_id_idx": {
+          "name": "website_pages_website_crawl_id_idx",
+          "columns": [
+            {
+              "expression": "website_crawl_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "website_pages_url_idx": {
+          "name": "website_pages_url_idx",
+          "columns": [
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "website_pages_embedding_index": {
+          "name": "website_pages_embedding_index",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.website_docs": {
+      "name": "website_docs",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "website_docs_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "mailbox_id": {
+          "name": "mailbox_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "websites_created_at_idx": {
+          "name": "websites_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "websites_mailbox_id_idx": {
+          "name": "websites_mailbox_id_idx",
+          "columns": [
+            {
+              "expression": "mailbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "websites_url_idx": {
+          "name": "websites_url_idx",
+          "columns": [
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.tool_apis": {
+      "name": "tool_apis",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "tool_apis_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mailbox_id": {
+          "name": "mailbox_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schema": {
+          "name": "schema",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authentication_token": {
+          "name": "authentication_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "tool_apis_mailbox_id_idx": {
+          "name": "tool_apis_mailbox_id_idx",
+          "columns": [
+            {
+              "expression": "mailbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.tools": {
+      "name": "tools",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "tools_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mailbox_id": {
+          "name": "mailbox_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_method": {
+          "name": "request_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "parameters": {
+          "name": "parameters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'"
+        },
+        "authentication_method": {
+          "name": "authentication_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "authentication_token": {
+          "name": "authentication_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_api_id": {
+          "name": "tool_api_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "available_in_chat": {
+          "name": "available_in_chat",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "available_in_anonymous_chat": {
+          "name": "available_in_anonymous_chat",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "customer_email_parameter": {
+          "name": "customer_email_parameter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "tools_mailbox_id_idx": {
+          "name": "tools_mailbox_id_idx",
+          "columns": [
+            {
+              "expression": "mailbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tools_tool_api_id_idx": {
+          "name": "tools_tool_api_id_idx",
+          "columns": [
+            {
+              "expression": "tool_api_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_slug_idx": {
+          "name": "unique_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.job_runs": {
+      "name": "job_runs",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "job_runs_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "queue_message_id": {
+          "name": "queue_message_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "job": {
+          "name": "job",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "job_runs_created_at_idx": {
+          "name": "job_runs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "job_runs_job_idx": {
+          "name": "job_runs_job_idx",
+          "columns": [
+            {
+              "expression": "job",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "job_runs_status_idx": {
+          "name": "job_runs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.user_profiles": {
+      "name": "user_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "access": {
+          "name": "access",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"role\":\"afk\",\"keywords\":[]}'::jsonb"
+        },
+        "pinned_issue_group_ids": {
+          "name": "pinned_issue_group_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"autoAssignOnTicketAction\":true}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_profiles_id_users_id_fk": {
+          "name": "user_profiles_id_users_id_fk",
+          "tableFrom": "user_profiles",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": [
+            "id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.saved_replies": {
+      "name": "saved_replies",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "saved_replies_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mailbox_id": {
+          "name": "mailbox_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "usage_count": {
+          "name": "usage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "saved_replies_mailbox_id_idx": {
+          "name": "saved_replies_mailbox_id_idx",
+          "columns": [
+            {
+              "expression": "mailbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "saved_replies_created_by_user_idx": {
+          "name": "saved_replies_created_by_user_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "saved_replies_slug_idx": {
+          "name": "saved_replies_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "saved_replies_slug_mailbox_unique": {
+          "name": "saved_replies_slug_mailbox_unique",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mailbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "saved_replies_mailbox_id_mailboxes_mailbox_id_fk": {
+          "name": "saved_replies_mailbox_id_mailboxes_mailbox_id_fk",
+          "tableFrom": "saved_replies",
+          "tableTo": "mailboxes_mailbox",
+          "columnsFrom": [
+            "mailbox_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.issue_groups": {
+      "name": "issue_groups",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "issue_groups_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "issue_groups_created_at_idx": {
+          "name": "issue_groups_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_groups_embedding_idx": {
+          "name": "issue_groups_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.stored_tools": {
+      "name": "stored_tools",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "stored_tools_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_email": {
+          "name": "customer_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parameters": {
+          "name": "parameters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "server_request_url": {
+          "name": "server_request_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "unique_tool_idx": {
+          "name": "unique_tool_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "customer_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_stored_tools_customer_email": {
+          "name": "idx_stored_tools_customer_email",
+          "columns": [
+            {
+              "expression": "customer_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"stored_tools\".\"customer_email\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    }
+  },
+  "enums": {
+    "public.guide_session_event_type": {
+      "name": "guide_session_event_type",
+      "schema": "public",
+      "values": [
+        "session_started",
+        "step_added",
+        "step_completed",
+        "step_updated",
+        "action_performed",
+        "completed",
+        "abandoned",
+        "paused",
+        "resumed"
+      ]
+    },
+    "public.guide_session_status": {
+      "name": "guide_session_status",
+      "schema": "public",
+      "values": [
+        "started",
+        "planning",
+        "active",
+        "completed",
+        "abandoned",
+        "paused"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/db/drizzle/meta/_journal.json
+++ b/db/drizzle/meta/_journal.json
@@ -855,6 +855,13 @@
       "when": 1756896140804,
       "tag": "0121_windy_vulture",
       "breakpoints": true
+    },
+    {
+      "idx": 122,
+      "version": "7",
+      "when": 1756907683091,
+      "tag": "0122_chief_ser_duncan",
+      "breakpoints": true
     }
   ]
 }

--- a/db/schema/userProfiles.ts
+++ b/db/schema/userProfiles.ts
@@ -23,10 +23,15 @@ export const userProfiles = pgTable("user_profiles", {
     }>()
     .default({ role: "afk", keywords: [] }),
   pinnedIssueGroupIds: jsonb("pinned_issue_group_ids").$type<number[]>().default([]),
-  preferences: jsonb().$type<{
-    confetti?: boolean;
-    disableNextTicketPreview?: boolean;
-  }>(),
+  preferences: jsonb()
+    .$type<{
+      autoAssignOnTicketAction?: boolean;
+      confetti?: boolean;
+      disableNextTicketPreview?: boolean;
+    }>()
+    .default({
+      autoAssignOnTicketAction: true,
+    }),
 }).enableRLS();
 
 export const userProfilesRelations = relations(userProfiles, ({ one }) => ({

--- a/jobs/bulkUpdateConversations.ts
+++ b/jobs/bulkUpdateConversations.ts
@@ -15,6 +15,7 @@ export const bulkUpdateConversations = async ({
   assignedToId,
   assignedToAI,
   message,
+  shouldAutoAssign,
 }: {
   conversationFilter: number[] | z.infer<typeof searchSchema>;
   status?: "open" | "closed" | "spam";
@@ -22,6 +23,7 @@ export const bulkUpdateConversations = async ({
   assignedToId?: string;
   assignedToAI?: boolean;
   message?: string;
+  shouldAutoAssign?: boolean;
 }) => {
   const mailbox = assertDefinedOrRaiseNonRetriableError(await getMailbox());
 
@@ -45,6 +47,7 @@ export const bulkUpdateConversations = async ({
       set: { status, assignedToId, assignedToAI },
       byUserId: userId,
       message,
+      shouldAutoAssign,
     });
   }
 

--- a/jobs/trigger.ts
+++ b/jobs/trigger.ts
@@ -49,6 +49,7 @@ const events = {
       assignedToId: z.string().optional(),
       assignedToAI: z.boolean().optional(),
       message: z.string().optional(),
+      shouldAutoAssign: z.boolean().optional(),
     }),
     jobs: ["bulkUpdateConversations"],
   },

--- a/lib/data/conversationMessage.ts
+++ b/lib/data/conversationMessage.ts
@@ -357,7 +357,7 @@ export const createReply = async (
     if (shouldAutoAssign && user && !conversation.assignedToId) {
       await updateConversation(
         conversationId,
-        { set: { assignedToId: user.id, assignedToAI: false }, byUserId: null },
+        { set: { assignedToId: user.id, assignedToAI: false }, byUserId: user.id, shouldAutoAssign },
         tx,
       );
     }

--- a/lib/slack/shared.ts
+++ b/lib/slack/shared.ts
@@ -106,7 +106,12 @@ export const handleMessageSlackAction = async (message: SlackMessage, payload: a
       await db.transaction(async (tx) => {
         await updateConversation(
           conversation.id,
-          { set: { status: "closed" }, byUserId: user?.id ?? null, message: "Resolved via Slack" },
+          {
+            set: { status: "closed" },
+            byUserId: user?.id ?? null,
+            message: "Resolved via Slack",
+            shouldAutoAssign: true,
+          },
           tx,
         );
       });

--- a/tests/e2e/settings/preferences.spec.ts
+++ b/tests/e2e/settings/preferences.spec.ts
@@ -52,4 +52,16 @@ test.describe("Settings - User preferences", () => {
     await waitForSettingsSaved(page);
     await expect(nextTicketPreviewSwitch).not.toBeChecked();
   });
+
+  test("should allow toggling on/off the auto assign on ticket action", async ({ page }) => {
+    const autoAssignOnTicketActionSetting = page.locator('h2:text("Auto-Assign On Ticket Action")');
+    const autoAssignOnTicketActionSwitch = page.locator('[aria-label="Auto-Assign On Ticket Action Switch"]');
+
+    await expect(autoAssignOnTicketActionSetting).toBeVisible();
+    await expect(autoAssignOnTicketActionSwitch).toBeChecked();
+
+    await autoAssignOnTicketActionSwitch.click();
+    await waitForSettingsSaved(page);
+    await expect(autoAssignOnTicketActionSwitch).not.toBeChecked();
+  });
 });

--- a/tests/jobs/bulkUpdateConversations.test.ts
+++ b/tests/jobs/bulkUpdateConversations.test.ts
@@ -1,0 +1,391 @@
+import { conversationFactory } from "@tests/support/factories/conversations";
+import { userFactory } from "@tests/support/factories/users";
+import { mockJobs, mockTriggerEvent } from "@tests/support/jobsUtils";
+import { eq } from "drizzle-orm";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { db } from "@/db/client";
+import { conversations, userProfiles } from "@/db/schema";
+import type { authUsers } from "@/db/supabaseSchema/auth";
+import { bulkUpdateConversations } from "@/jobs/bulkUpdateConversations";
+
+vi.mock("@/lib/data/mailbox", () => ({
+  getMailbox: vi.fn().mockResolvedValue({
+    id: 1,
+    slug: "test-mailbox",
+  }),
+}));
+
+mockJobs();
+
+let user: typeof authUsers.$inferSelect;
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  ({ user } = await userFactory.createRootUser());
+});
+
+describe("bulkUpdateConversations", () => {
+  describe("with conversation IDs array", () => {
+    it("closes multiple conversations with auto-assign", async () => {
+      const { conversation: conversation1 } = await conversationFactory.create({
+        assignedToId: null,
+        status: "open",
+      });
+      const { conversation: conversation2 } = await conversationFactory.create({
+        assignedToId: null,
+        status: "open",
+      });
+      const { conversation: conversation3 } = await conversationFactory.create({
+        assignedToId: null,
+        status: "open",
+      });
+
+      await bulkUpdateConversations({
+        conversationFilter: [conversation1.id, conversation2.id, conversation3.id],
+        status: "closed",
+        userId: user.id,
+        shouldAutoAssign: true,
+      });
+
+      const updatedConversations = await db.query.conversations.findMany({
+        where: (conversations, { inArray }) =>
+          inArray(conversations.id, [conversation1.id, conversation2.id, conversation3.id]),
+      });
+
+      updatedConversations.forEach((conv) => {
+        expect(conv).toMatchObject({
+          status: "closed",
+          assignedToId: user.id,
+          assignedToAI: false,
+        });
+        expect(conv.closedAt).toBeInstanceOf(Date);
+      });
+
+      expect(mockTriggerEvent).toHaveBeenCalledWith("conversations/embedding.create", {
+        conversationSlug: conversation1.slug,
+      });
+      expect(mockTriggerEvent).toHaveBeenCalledWith("conversations/embedding.create", {
+        conversationSlug: conversation2.slug,
+      });
+      expect(mockTriggerEvent).toHaveBeenCalledWith("conversations/embedding.create", {
+        conversationSlug: conversation3.slug,
+      });
+    });
+
+    it("reopens multiple conversations", async () => {
+      const { conversation: conversation1 } = await conversationFactory.create({
+        status: "closed",
+        closedAt: new Date(),
+      });
+      const { conversation: conversation2 } = await conversationFactory.create({
+        status: "closed",
+        closedAt: new Date(),
+      });
+
+      await bulkUpdateConversations({
+        conversationFilter: [conversation1.id, conversation2.id],
+        status: "open",
+        userId: user.id,
+      });
+
+      const updatedConversations = await db.query.conversations.findMany({
+        where: (conversations, { inArray }) => inArray(conversations.id, [conversation1.id, conversation2.id]),
+      });
+
+      updatedConversations.forEach((conv) => {
+        expect(conv).toMatchObject({
+          status: "open",
+        });
+
+        expect(conv.closedAt).toBeInstanceOf(Date);
+      });
+    });
+
+    it("marks multiple conversations as spam", async () => {
+      const { conversation: conversation1 } = await conversationFactory.create({
+        status: "open",
+      });
+      const { conversation: conversation2 } = await conversationFactory.create({
+        status: "open",
+      });
+
+      await bulkUpdateConversations({
+        conversationFilter: [conversation1.id, conversation2.id],
+        status: "spam",
+        userId: user.id,
+      });
+
+      const updatedConversations = await db.query.conversations.findMany({
+        where: (conversations, { inArray }) => inArray(conversations.id, [conversation1.id, conversation2.id]),
+      });
+
+      updatedConversations.forEach((conv) => {
+        expect(conv).toMatchObject({
+          status: "spam",
+        });
+
+        expect(conv.closedAt).toBeNull();
+      });
+    });
+
+    it("assigns conversations to AI", async () => {
+      const { conversation: conversation1 } = await conversationFactory.create({
+        assignedToId: null,
+        assignedToAI: false,
+        status: "open",
+      });
+      const { conversation: conversation2 } = await conversationFactory.create({
+        assignedToId: user.id,
+        assignedToAI: false,
+        status: "open",
+      });
+
+      await bulkUpdateConversations({
+        conversationFilter: [conversation1.id, conversation2.id],
+        assignedToAI: true,
+        userId: user.id,
+      });
+
+      const updatedConversations = await db.query.conversations.findMany({
+        where: (conversations, { inArray }) => inArray(conversations.id, [conversation1.id, conversation2.id]),
+      });
+
+      updatedConversations.forEach((conv) => {
+        expect(conv).toMatchObject({
+          status: "closed",
+          assignedToAI: true,
+          assignedToId: null,
+        });
+        expect(conv.closedAt).toBeInstanceOf(Date);
+      });
+    });
+
+    it("assigns conversations to specific user", async () => {
+      const { user: assigneeUser } = await userFactory.createRootUser();
+      const { conversation: conversation1 } = await conversationFactory.create({
+        assignedToId: null,
+      });
+      const { conversation: conversation2 } = await conversationFactory.create({
+        assignedToId: null,
+      });
+
+      await bulkUpdateConversations({
+        conversationFilter: [conversation1.id, conversation2.id],
+        assignedToId: assigneeUser.id,
+        userId: user.id,
+      });
+
+      const updatedConversations = await db.query.conversations.findMany({
+        where: (conversations, { inArray }) => inArray(conversations.id, [conversation1.id, conversation2.id]),
+      });
+
+      updatedConversations.forEach((conv) => {
+        expect(conv).toMatchObject({
+          assignedToId: assigneeUser.id,
+          assignedToAI: false,
+        });
+      });
+    });
+
+    it("respects user auto-assign preferences", async () => {
+      const { conversation: conversation1 } = await conversationFactory.create({
+        assignedToId: null,
+        status: "open",
+      });
+
+      await db
+        .update(userProfiles)
+        .set({
+          preferences: { autoAssignOnTicketAction: false },
+        })
+        .where(eq(userProfiles.id, user.id));
+
+      await bulkUpdateConversations({
+        conversationFilter: [conversation1.id],
+        status: "closed",
+        userId: user.id,
+        shouldAutoAssign: true,
+      });
+
+      const updatedConversation = await db.query.conversations.findFirst({
+        where: eq(conversations.id, conversation1.id),
+      });
+
+      expect(updatedConversation).toMatchObject({
+        status: "closed",
+        assignedToId: null,
+      });
+    });
+
+    it("does not change assignment when conversation is already assigned", async () => {
+      const { user: otherUser } = await userFactory.createRootUser();
+      const { conversation: conversation1 } = await conversationFactory.create({
+        assignedToId: otherUser.id,
+        status: "open",
+      });
+
+      await bulkUpdateConversations({
+        conversationFilter: [conversation1.id],
+        status: "closed",
+        userId: user.id,
+        shouldAutoAssign: true,
+      });
+
+      const updatedConversation = await db.query.conversations.findFirst({
+        where: eq(conversations.id, conversation1.id),
+      });
+
+      expect(updatedConversation).toMatchObject({
+        status: "closed",
+        assignedToId: otherUser.id,
+      });
+    });
+
+    it("includes message in conversation events", async () => {
+      const { conversation } = await conversationFactory.create({
+        status: "open",
+      });
+
+      const testMessage = "Bulk closing due to resolution";
+
+      await bulkUpdateConversations({
+        conversationFilter: [conversation.id],
+        status: "closed",
+        userId: user.id,
+        message: testMessage,
+      });
+
+      const updatedConversation = await db.query.conversations.findFirst({
+        where: eq(conversations.id, conversation.id),
+      });
+
+      expect(updatedConversation).toMatchObject({
+        status: "closed",
+      });
+
+      const conversationEvent = await db.query.conversationEvents.findFirst({
+        where: (conversationEvents, { eq }) => eq(conversationEvents.conversationId, conversation.id),
+      });
+
+      expect(conversationEvent).toMatchObject({
+        conversationId: conversation.id,
+        byUserId: user.id,
+        reason: testMessage,
+        type: "update",
+      });
+    });
+  });
+
+  describe("with search schema", () => {
+    it("updates conversations matching search criteria", async () => {
+      const { conversation: firstOpenConv } = await conversationFactory.create({
+        status: "open",
+        assignedToId: null,
+      });
+      const { conversation: secondOpenConv } = await conversationFactory.create({
+        status: "open",
+        assignedToId: null,
+      });
+      const { conversation: _closedConv } = await conversationFactory.create({
+        status: "closed",
+      });
+      await bulkUpdateConversations({
+        conversationFilter: {
+          status: ["open"],
+          cursor: null,
+          limit: 25,
+          sort: null,
+          search: null,
+          category: null,
+        },
+        status: "closed",
+        userId: user.id,
+        shouldAutoAssign: true,
+      });
+
+      const openConversations = await db.query.conversations.findMany({
+        where: (conversations, { inArray }) => inArray(conversations.id, [firstOpenConv.id, secondOpenConv.id]),
+      });
+      openConversations.forEach((conv) => {
+        expect(conv).toMatchObject({
+          status: "closed",
+          assignedToId: user.id,
+        });
+        expect(conv.closedAt).toBeInstanceOf(Date);
+      });
+    });
+
+    it("skips conversations that already have the target status", async () => {
+      const { conversation: firstClosedConv } = await conversationFactory.create({
+        status: "closed",
+        closedAt: new Date(),
+      });
+      const { conversation: secondClosedConv } = await conversationFactory.create({
+        status: "closed",
+        closedAt: new Date(),
+      });
+
+      const originalClosedAt1 = firstClosedConv.closedAt;
+      const originalClosedAt2 = secondClosedConv.closedAt;
+
+      await bulkUpdateConversations({
+        conversationFilter: {
+          status: null,
+          cursor: null,
+          limit: 25,
+          sort: null,
+          search: null,
+          category: null,
+        },
+        status: "closed",
+        userId: user.id,
+      });
+
+      const unchangedConversations = await db.query.conversations.findMany({
+        where: (conversations, { inArray }) => inArray(conversations.id, [firstClosedConv.id, secondClosedConv.id]),
+      });
+      expect(unchangedConversations[0]?.closedAt?.getTime()).toBe(originalClosedAt1?.getTime());
+      expect(unchangedConversations[1]?.closedAt?.getTime()).toBe(originalClosedAt2?.getTime());
+    });
+  });
+
+  describe("return value", () => {
+    it("returns message with count of updated conversations", async () => {
+      const { conversation: conv1 } = await conversationFactory.create({ status: "open" });
+      const { conversation: conv2 } = await conversationFactory.create({ status: "open" });
+      const { conversation: conv3 } = await conversationFactory.create({ status: "open" });
+
+      const result = await bulkUpdateConversations({
+        conversationFilter: [conv1.id, conv2.id, conv3.id],
+        status: "closed",
+        userId: user.id,
+      });
+
+      expect(result).toMatchObject({
+        message: "Updated 3 conversations to status: closed",
+      });
+    });
+
+    it("returns correct count when some conversations are filtered out", async () => {
+      await conversationFactory.create({ status: "open" });
+      await conversationFactory.create({ status: "closed" });
+
+      const result = await bulkUpdateConversations({
+        conversationFilter: {
+          status: ["open"],
+          cursor: null,
+          limit: 25,
+          sort: null,
+          search: null,
+          category: null,
+        },
+        status: "closed",
+        userId: user.id,
+      });
+
+      expect(result).toMatchObject({
+        message: "Updated 1 conversations to status: closed",
+      });
+    });
+  });
+});

--- a/tests/support/helpers/userProfile.ts
+++ b/tests/support/helpers/userProfile.ts
@@ -1,0 +1,13 @@
+import { eq, sql } from "drizzle-orm";
+import { db } from "@/db/client";
+import { userProfiles } from "@/db/schema";
+
+export const updateUserPreferences = async (
+  userId: string,
+  preferences: { autoAssignOnTicketAction?: boolean; confetti?: boolean; disableNextTicketPreview?: boolean },
+) => {
+  await db
+    .update(userProfiles)
+    .set({ preferences: sql`coalesce(preferences, '{}')::jsonb || ${JSON.stringify(preferences)}::jsonb` })
+    .where(eq(userProfiles.id, userId));
+};

--- a/trpc/router/mailbox/conversations/index.ts
+++ b/trpc/router/mailbox/conversations/index.ts
@@ -147,6 +147,7 @@ export const conversationsRouter = {
         assignedToId: z.string().nullable().optional(),
         message: z.string().nullable().optional(),
         assignedToAI: z.boolean().optional(),
+        shouldAutoAssign: z.boolean().optional(),
       }),
     )
     .mutation(async ({ ctx, input }) => {
@@ -165,6 +166,7 @@ export const conversationsRouter = {
         },
         byUserId: ctx.user.id,
         message: input.message ?? null,
+        shouldAutoAssign: input.shouldAutoAssign,
       });
     }),
   bulkUpdate: mailboxProcedure
@@ -175,10 +177,11 @@ export const conversationsRouter = {
         assignedToId: z.string().optional(),
         assignedToAI: z.boolean().optional(),
         message: z.string().optional(),
+        shouldAutoAssign: z.boolean().optional(),
       }),
     )
     .mutation(async ({ input, ctx }) => {
-      const { conversationFilter, status, assignedToId, message, assignedToAI } = input;
+      const { conversationFilter, status, assignedToId, message, assignedToAI, shouldAutoAssign } = input;
 
       if (Array.isArray(conversationFilter) && conversationFilter.length <= 25) {
         for (const conversationId of conversationFilter) {
@@ -186,6 +189,7 @@ export const conversationsRouter = {
             set: { status, assignedToId, assignedToAI },
             byUserId: ctx.user.id,
             message,
+            shouldAutoAssign,
           });
         }
         return { updatedImmediately: true };
@@ -198,6 +202,7 @@ export const conversationsRouter = {
         assignedToId: input.assignedToId,
         assignedToAI: input.assignedToAI,
         message: input.message,
+        shouldAutoAssign,
       });
       return { updatedImmediately: false };
     }),

--- a/trpc/router/user.ts
+++ b/trpc/router/user.ts
@@ -188,6 +188,7 @@ export const userRouter = {
       z.object({
         preferences: z
           .object({
+            autoAssignOnTicketAction: z.boolean().optional(),
             confetti: z.boolean().optional(),
             disableNextTicketPreview: z.boolean().optional(),
           })


### PR DESCRIPTION
## Closes https://github.com/antiwork/helper/issues/1008

### How?
1. Add `autoAssignOnTicketAction` field to preferences with default value of true. 
2. Migration file updates existing settings to have `autoAssignOnTicketAction` set to true.
3. The core auto-assignment logic resides in `updateConversation`. User action paths hook into this logic by setting the `shouldAutoAssign` parameter for the relevant function calls.

### Flows covered
1. Web UI - Individual and Bulk Updates
2. Slack Agent
3. Gmail - WIP

### Specs 

#### Vitest Tests

| Test File | Status | Purpose |
|-----------|--------|---------|
| `tests/lib/data/conversation.test.ts` | Modified | Core logic verification |
| `tests/trpc/router/mailbox/conversations/index.test.ts` | Modified | Verifies auto-assignment for update and bulk update paths |
| `tests/jobs/bulkUpdateConversations.test.ts` | Added | Verifies bulk update functionality with auto-assign |
| `tests/lib/slack/shared.test.ts` | Modified | Verifies Slack integration with auto-assign |
| `tests/lib/data/conversationMessage.test.ts` | Modified | Verifies message reply on web ui with auto-assign  |

#### E2E Tests

| Test File | Status | Purpose |
|-----------|--------|---------|
| `tests/e2e/settings/preferences.spec.ts` | Added | Verifies auto-assignment user preference can be set |
| `tests/e2e/conversations/conversationAction.spec.ts` | WIP | Verify user actions |
| WIP | WIP | Verify bulk actions to set auto-assignment |


### Tests Passing
|Fast - Vitest|Slow - E2E|
|-----|----|
|<img width="1408" height="830" alt="vitest" src="https://github.com/user-attachments/assets/e1a1d878-dcd4-4a57-bad4-525e70c6abc7" />|WIP|


AI Usage:
1. claude for scaffolding tests, dedupe and merging test 