### PR TITLE
chore: remove un necessary tests in tests/e2e/conversations/conversations.spec.ts

### DIFF
--- a/tests/e2e/conversations/conversations.spec.ts
+++ b/tests/e2e/conversations/conversations.spec.ts
@@ -52,13 +52,6 @@ test.describe("Working Conversation Management", () => {
     }
   });
 
-  test("should handle clicking on filters", async ({ page }) => {
-    const openFilter = page.locator('button:has-text("open")');
-    await openFilter.click();
-
-    await expect(page).toHaveURL(/.*mine.*/);
-  });
-
   test("should handle select all functionality", async ({ page }) => {
     const conversationLinks = page.locator(CONVERSATION_LINKS_SELECTOR);
     const conversationCount = await conversationLinks.count();
@@ -94,7 +87,7 @@ test.describe("Working Conversation Management", () => {
     }
   });
 
-  test("should support keyboard navigation", async ({ page }) => {
+  test("should support keyboard navigation and should focus search with Ctrl+K hotkey", async ({ page }) => {
     const searchInput = page.getByRole("textbox", { name: "Search conversations" });
 
     await searchInput.focus();
@@ -112,10 +105,6 @@ test.describe("Working Conversation Management", () => {
     expect(["INPUT", "BUTTON", "A"].includes(activeElementAfterTab)).toBeTruthy();
 
     await searchInput.clear();
-  });
-
-  test("should focus search input with Ctrl+K hotkey", async ({ page }) => {
-    const searchInput = page.getByRole("textbox", { name: "Search conversations" });
 
     await searchInput.blur();
 
@@ -258,29 +247,9 @@ test.describe("Working Conversation Management", () => {
     await expect(todayOption).toBeVisible();
   });
 
-  test("should clear date filter with clear filters button", async ({ page }) => {
-    const filterToggleButton = page.getByRole("button", { name: "Filter Toggle" });
-    await expect(filterToggleButton).toBeVisible();
-    await filterToggleButton.click();
-
-    const dateFilterButton = page.getByRole("button", { name: "Date Filter" });
-    await expect(dateFilterButton).toBeVisible();
-
-    await dateFilterButton.click();
-    const yesterdayOption = page.locator('[role="menuitemradio"], [role="option"]').filter({ hasText: "Yesterday" });
-    await yesterdayOption.click();
-    await expect(dateFilterButton).toHaveText(/Yesterday/);
-
-    const clearFiltersButton = page.getByRole("button", { name: "Clear Filters" });
-    await expect(clearFiltersButton).toBeVisible();
-
-    await clearFiltersButton.click();
-
-    await expect(dateFilterButton).toHaveText(/Created/);
-    await expect(clearFiltersButton).not.toBeVisible();
-  });
-
-  test("should preserve date filter after page refresh", async ({ page }) => {
+  test("should preserve date filter after page refresh and should clear date filter with clear filters button", async ({
+    page,
+  }) => {
     const toggleFilters = async () => {
       const filterToggleButton = page.getByRole("button", { name: "Filter Toggle" });
       await expect(filterToggleButton).toBeVisible();
@@ -307,17 +276,23 @@ test.describe("Working Conversation Management", () => {
     await expect(dateFilterButtonAfterRefresh).toHaveText(/Last 30 days/);
     const clearFiltersButton = page.getByRole("button", { name: "Clear Filters" });
     await expect(clearFiltersButton).toBeVisible();
+
+    await clearFiltersButton.click();
+
+    await expect(dateFilterButton).toHaveText(/Created/);
+    await expect(clearFiltersButton).not.toBeVisible();
   });
 
-  test("should show context snippets for deep matches", async ({ page }) => {
+  test("should show context snippets and highlight search terms for deep matches", async ({ page }) => {
     await searchConversations(page, "support");
 
     const messageTexts = page.locator("p.text-muted-foreground.max-w-4xl.text-xs");
-    const highlightedMessages = page.locator("mark.bg-secondary-200");
+    const highlights = page.locator("mark.bg-secondary-200");
 
     const messageCount = await messageTexts.count();
-    const highlightCount = await highlightedMessages.count();
+    const highlightCount = await highlights.count();
 
+    // Test context snippets for deep matches
     if (messageCount > 0 && highlightCount > 0) {
       for (let i = 0; i < Math.min(messageCount, 3); i++) {
         const message = messageTexts.nth(i);
@@ -335,14 +310,8 @@ test.describe("Working Conversation Management", () => {
         }
       }
     }
-  });
 
-  test("should highlight search terms in snippets", async ({ page }) => {
-    await searchConversations(page, "support");
-
-    const highlights = page.locator("mark.bg-secondary-200");
-    const highlightCount = await highlights.count();
-
+    // Test search term highlighting
     if (highlightCount > 0) {
       const firstHighlight = highlights.first();
       await expect(firstHighlight).toBeVisible();

--- a/tests/e2e/conversations/conversations.spec.ts
+++ b/tests/e2e/conversations/conversations.spec.ts
@@ -19,30 +19,6 @@ test.describe("Working Conversation Management", () => {
     await page.keyboard.press("Enter");
   }
 
-  test("should display dashboard with conversations", async ({ page }) => {
-    await expect(page).toHaveTitle("Mine");
-
-    const searchInput = page.getByRole("textbox", { name: "Search conversations" });
-    await expect(searchInput).toBeVisible();
-
-    const openFilter = page.locator('button:has-text("open")');
-    await expect(openFilter).toBeVisible();
-
-    await takeDebugScreenshot(page, "working-dashboard.png");
-  });
-
-  test("should have functional search", async ({ page }) => {
-    const searchInput = page.getByRole("textbox", { name: "Search conversations" });
-    await expect(searchInput).toBeVisible();
-
-    await searchInput.fill("test search");
-
-    await expect(searchInput).toHaveValue("test search");
-
-    await searchInput.clear();
-    await expect(searchInput).toHaveValue("");
-  });
-
   test("should show account information", async ({ page }) => {
     const gumroadButton = page.locator('button:has-text("Gumroad")').first();
     await expect(gumroadButton).toBeVisible();
@@ -116,30 +92,6 @@ test.describe("Working Conversation Management", () => {
       const searchInput = page.getByRole("textbox", { name: "Search conversations" });
       await expect(searchInput).toBeVisible();
     }
-  });
-
-  test("should be responsive on mobile", async ({ page }) => {
-    await page.setViewportSize({ width: 375, height: 667 });
-
-    const searchInput = page.getByRole("textbox", { name: "Search conversations" });
-    await expect(searchInput).toBeVisible();
-
-    const selectAllButton = page.locator('button:has-text("Select all")');
-    await expect(selectAllButton).not.toBeVisible();
-
-    await takeDebugScreenshot(page, "dashboard-mobile.png");
-  });
-
-  test("should maintain authentication state", async ({ page }) => {
-    await page.reload();
-
-    await expect(page).toHaveURL(/.*mine.*/);
-
-    const searchInput = page.getByRole("textbox", { name: "Search conversations" });
-    await expect(searchInput).toBeVisible();
-
-    const openFilter = page.locator('button:has-text("open")');
-    await expect(openFilter).toBeVisible();
   });
 
   test("should support keyboard navigation", async ({ page }) => {
@@ -357,41 +309,6 @@ test.describe("Working Conversation Management", () => {
     await expect(clearFiltersButton).toBeVisible();
   });
 
-  test("should show truncated text for non-search results", async ({ page }) => {
-    await page.getByRole("textbox", { name: "Search conversations" }).clear();
-    await expect(page.getByRole("textbox", { name: "Search conversations" })).toHaveValue("");
-
-    const messageTexts = page.locator("p.text-muted-foreground.max-w-4xl.text-xs");
-    const messageCount = await messageTexts.count();
-
-    if (messageCount > 0) {
-      const firstMessage = messageTexts.first();
-      await expect(firstMessage).toBeVisible();
-
-      const classList = await firstMessage.getAttribute("class");
-      expect(classList).toContain("truncate");
-
-      await takeDebugScreenshot(page, "search-snippet-no-search.png");
-    }
-  });
-
-  test("should always use truncate class with search snippets", async ({ page }) => {
-    await searchConversations(page, "support");
-
-    const messageTexts = page.locator("p.text-muted-foreground.max-w-4xl.text-xs");
-    const messageCount = await messageTexts.count();
-
-    if (messageCount > 0) {
-      for (let i = 0; i < Math.min(messageCount, 3); i++) {
-        const message = messageTexts.nth(i);
-        const classList = await message.getAttribute("class");
-        expect(classList).toContain("truncate");
-      }
-
-      await takeDebugScreenshot(page, "search-snippet-with-truncate.png");
-    }
-  });
-
   test("should show context snippets for deep matches", async ({ page }) => {
     await searchConversations(page, "support");
 
@@ -439,19 +356,5 @@ test.describe("Working Conversation Management", () => {
 
       await takeDebugScreenshot(page, "search-snippet-highlights.png");
     }
-  });
-
-  test("should handle search with no results gracefully", async ({ page }) => {
-    await searchConversations(page, "xyzunlikelyterm123");
-
-    const searchInput = page.getByRole("textbox", { name: "Search conversations" });
-    await expect(searchInput).toBeVisible();
-    await expect(searchInput).toHaveValue("xyzunlikelyterm123");
-
-    const highlights = page.locator("mark.bg-secondary-200");
-    const highlightCount = await highlights.count();
-    expect(highlightCount).toBe(0);
-
-    await takeDebugScreenshot(page, "search-snippet-no-results.png");
   });
 });


### PR DESCRIPTION
Ref:- https://github.com/antiwork/helper/issues/992

There is no functional change in the PR. This PR just eliminated duplicate/un necessary tests. Below are the test that i removed.

1) "Should display dashboard with conversations" - we are already checking the page contains conversations in the below tests
2) "should have functional search" :- We are testing searching conversations in other tests so just checking if input is functional doesn't make sense
3) "should maintain authentication state" :- These tests are for conversation file and we already have authentication login/signup e2e tests
4) "should be responsive on mobile":- This is not really testing anything, it's just checking if "Search conversations" is visible on mobile
5) "should show truncated text for non-search results" :- We are checking for truncate class in all the other search related tests so don't need a separate test just for checking a class.
6) "should always use truncate class with search snippets":- Same as above
7) "should handle search with no results gracefully":- Not really checking anything and doesn't add any value
8) Combined "should clear date filter with clear filters button" and "should preserve date filter after page refresh" together
9) Combined "should show context snippets and highlight search terms for deep matches" together


Now there are only 9 tests 

![Screenshot 2025-09-05 at 11 14 56 PM](https://github.com/user-attachments/assets/174c36f2-7ce0-4e20-a165-938065e34d3c)


AI Disclosure:-
No AI was used in this PR 