### PR TITLE
refactor: move command bar tests

### DIFF
--- a/tests/e2e/conversations/commandBarActions.spec.ts
+++ b/tests/e2e/conversations/commandBarActions.spec.ts
@@ -1,0 +1,101 @@
+import { expect, test } from "@playwright/test";
+import { getOpenConversation, openCommandBar } from "../utils/settingsHelpers";
+
+test.use({ storageState: "tests/e2e/.auth/user.json" });
+
+test.beforeEach(async ({ page }) => {
+  const openConversation = await getOpenConversation();
+
+  await page.goto(`/conversations?id=${openConversation.slug}`);
+  await page.waitForLoadState("networkidle");
+});
+
+test.describe("Command Bar", () => {
+  test("should open and close command bar", async ({ page }) => {
+    await openCommandBar(page);
+
+    const commandBar = page.locator('[data-testid="command-bar"]');
+    await page.keyboard.press("Escape");
+    await expect(commandBar).not.toBeVisible();
+  });
+
+  test("should filter commands when typing in command bar", async ({ page }) => {
+    await openCommandBar(page);
+
+    const commandInput = page.locator('[aria-label="Command Bar Input"]');
+    await commandInput.fill("generate");
+
+    const generateDraftCommand = page.locator('[role="option"]').filter({ hasText: "Generate draft" });
+    await expect(generateDraftCommand).toBeVisible();
+
+    const otherCommands = page.locator('[role="option"]').filter({ hasText: "Add CC or BCC" });
+    await expect(otherCommands).not.toBeVisible();
+  });
+
+  test("should generate draft response via command bar", async ({ page }) => {
+    await openCommandBar(page);
+
+    const composer = page.locator('[aria-label="Conversation editor"] .tiptap.ProseMirror');
+    const commandBar = page.locator('[data-testid="command-bar"]');
+
+    try {
+      const generateDraftCommand = page.locator('[role="option"]').filter({ hasText: "Generate draft" });
+      await expect(generateDraftCommand).toBeVisible();
+      await generateDraftCommand.click();
+
+      const composerText = await composer.textContent();
+      const commandClosed = !(await commandBar.isVisible());
+
+      expect(commandClosed).toBe(true);
+      expect(composerText?.trim().length).toBeGreaterThan(0);
+    } catch (error) {
+      await page.keyboard.press("Escape");
+      const commandBarClosedAfterEscape = !(await commandBar.isVisible());
+      expect(commandBarClosedAfterEscape).toBe(true);
+    }
+  });
+
+  test("should toggle CC field via command bar", async ({ page }) => {
+    await openCommandBar(page);
+
+    const toggleCcCommand = page.locator('[role="option"]').filter({ hasText: "Add CC or BCC" });
+    await expect(toggleCcCommand).toBeVisible();
+    await toggleCcCommand.click();
+
+    const ccInput = page.locator('input[name="CC"]');
+    await expect(ccInput).toBeVisible();
+  });
+
+  test("should access internal note functionality", async ({ page }) => {
+    await openCommandBar(page);
+
+    const addNoteCommand = page.locator('[role="option"]').filter({ hasText: "Add internal note" });
+    await expect(addNoteCommand).toBeVisible();
+    await addNoteCommand.click();
+
+    const noteText = "This is an internal note for testing";
+    const textarea = page.getByRole("textbox", { name: "Internal Note" });
+    await textarea.fill(noteText);
+
+    await expect(textarea).toHaveValue(noteText);
+
+    const addButton = page.locator('button:has-text("Add internal note")');
+    await addButton.click();
+  });
+
+  test("should open command bar with slash key", async ({ page }) => {
+    const composer = page.locator('[aria-label="Conversation editor"] .tiptap.ProseMirror');
+    await composer.click({ force: true });
+    await composer.evaluate((el) => {
+      el.innerHTML = "";
+      el.textContent = "";
+    });
+    await composer.focus();
+    await page.keyboard.press("/");
+
+    const commandBar = page.locator('[data-testid="command-bar"]');
+    await expect(commandBar).toBeVisible();
+
+    await commandBar.waitFor({ state: "visible" });
+  });
+});

--- a/tests/e2e/conversations/commandBarActions.spec.ts
+++ b/tests/e2e/conversations/commandBarActions.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { getOpenConversation, openCommandBar } from "../utils/settingsHelpers";
+import { getOpenConversation, openCommandBar } from "../utils/conversationHelpers";
 
 test.use({ storageState: "tests/e2e/.auth/user.json" });
 

--- a/tests/e2e/conversations/conversationActions.spec.ts
+++ b/tests/e2e/conversations/conversationActions.spec.ts
@@ -2,7 +2,7 @@ import { expect, Page, test } from "@playwright/test";
 import { desc, eq } from "drizzle-orm";
 import { db } from "../../../db/client";
 import { conversationEvents, conversations } from "../../../db/schema";
-import { waitForSettingsSaved } from "../utils/settingsHelpers";
+import { getOpenConversation, openCommandBar, waitForSettingsSaved } from "../utils/settingsHelpers";
 
 test.use({ storageState: "tests/e2e/.auth/user.json" });
 
@@ -17,30 +17,6 @@ async function getConversationStatusFromDb(conversationId: number): Promise<stri
     return event.changes.status;
   }
   return "unknown";
-}
-
-async function getOpenConversation() {
-  const result = await db
-    .select({ id: conversations.id, slug: conversations.slug })
-    .from(conversations)
-    .where(eq(conversations.status, "open"))
-    .limit(1);
-
-  if (!result.length) {
-    throw new Error(
-      "No open conversation found in database. Please ensure there's at least one open conversation for testing.",
-    );
-  }
-
-  return result[0];
-}
-
-async function openCommandBar(page: any) {
-  await page.getByLabel("Command Bar Input").click();
-
-  const commandBar = page.locator('[data-testid="command-bar"]');
-  await expect(commandBar).toBeVisible();
-  await commandBar.waitFor({ state: "visible" });
 }
 
 async function sendReplyMessage(page: Page, message: string, { close }: { close?: boolean } = {}) {
@@ -159,96 +135,6 @@ test.describe("Conversation Actions", () => {
       await expect(replyButton).toBeEnabled();
       await replyButton.click();
       await page.waitForLoadState("networkidle");
-    });
-  });
-
-  test.describe("Command Bar", () => {
-    test("should open and close command bar", async ({ page }) => {
-      await openCommandBar(page);
-
-      const commandBar = page.locator('[data-testid="command-bar"]');
-      await page.keyboard.press("Escape");
-      await expect(commandBar).not.toBeVisible();
-    });
-
-    test("should filter commands when typing in command bar", async ({ page }) => {
-      await openCommandBar(page);
-
-      const commandInput = page.locator('[aria-label="Command Bar Input"]');
-      await commandInput.fill("generate");
-
-      const generateDraftCommand = page.locator('[role="option"]').filter({ hasText: "Generate draft" });
-      await expect(generateDraftCommand).toBeVisible();
-
-      const otherCommands = page.locator('[role="option"]').filter({ hasText: "Add CC or BCC" });
-      await expect(otherCommands).not.toBeVisible();
-    });
-
-    test("should generate draft response via command bar", async ({ page }) => {
-      await openCommandBar(page);
-
-      const composer = page.locator('[aria-label="Conversation editor"] .tiptap.ProseMirror');
-      const commandBar = page.locator('[data-testid="command-bar"]');
-
-      try {
-        const generateDraftCommand = page.locator('[role="option"]').filter({ hasText: "Generate draft" });
-        await expect(generateDraftCommand).toBeVisible();
-        await generateDraftCommand.click();
-
-        const composerText = await composer.textContent();
-        const commandClosed = !(await commandBar.isVisible());
-
-        expect(commandClosed).toBe(true);
-        expect(composerText?.trim().length).toBeGreaterThan(0);
-      } catch (error) {
-        await page.keyboard.press("Escape");
-        const commandBarClosedAfterEscape = !(await commandBar.isVisible());
-        expect(commandBarClosedAfterEscape).toBe(true);
-      }
-    });
-
-    test("should toggle CC field via command bar", async ({ page }) => {
-      await openCommandBar(page);
-
-      const toggleCcCommand = page.locator('[role="option"]').filter({ hasText: "Add CC or BCC" });
-      await expect(toggleCcCommand).toBeVisible();
-      await toggleCcCommand.click();
-
-      const ccInput = page.locator('input[name="CC"]');
-      await expect(ccInput).toBeVisible();
-    });
-
-    test("should access internal note functionality", async ({ page }) => {
-      await openCommandBar(page);
-
-      const addNoteCommand = page.locator('[role="option"]').filter({ hasText: "Add internal note" });
-      await expect(addNoteCommand).toBeVisible();
-      await addNoteCommand.click();
-
-      const noteText = "This is an internal note for testing";
-      const textarea = page.getByRole("textbox", { name: "Internal Note" });
-      await textarea.fill(noteText);
-
-      await expect(textarea).toHaveValue(noteText);
-
-      const addButton = page.locator('button:has-text("Add internal note")');
-      await addButton.click();
-    });
-
-    test("should open command bar with slash key", async ({ page }) => {
-      const composer = page.locator('[aria-label="Conversation editor"] .tiptap.ProseMirror');
-      await composer.click({ force: true });
-      await composer.evaluate((el) => {
-        el.innerHTML = "";
-        el.textContent = "";
-      });
-      await composer.focus();
-      await page.keyboard.press("/");
-
-      const commandBar = page.locator('[data-testid="command-bar"]');
-      await expect(commandBar).toBeVisible();
-
-      await commandBar.waitFor({ state: "visible" });
     });
   });
 

--- a/tests/e2e/conversations/conversationActions.spec.ts
+++ b/tests/e2e/conversations/conversationActions.spec.ts
@@ -1,8 +1,9 @@
 import { expect, Page, test } from "@playwright/test";
 import { desc, eq } from "drizzle-orm";
 import { db } from "../../../db/client";
-import { conversationEvents, conversations } from "../../../db/schema";
-import { getOpenConversation, openCommandBar, waitForSettingsSaved } from "../utils/settingsHelpers";
+import { conversationEvents } from "../../../db/schema";
+import { getOpenConversation, openCommandBar } from "../utils/conversationHelpers";
+import { waitForSettingsSaved } from "../utils/settingsHelpers";
 
 test.use({ storageState: "tests/e2e/.auth/user.json" });
 

--- a/tests/e2e/utils/conversationHelpers.ts
+++ b/tests/e2e/utils/conversationHelpers.ts
@@ -1,0 +1,28 @@
+import { expect } from "@playwright/test";
+import { eq } from "drizzle-orm";
+import { db } from "../../../db/client";
+import { conversations } from "../../../db/schema";
+
+export async function openCommandBar(page: any) {
+  await page.getByLabel("Command Bar Input").click();
+
+  const commandBar = page.locator('[data-testid="command-bar"]');
+  await expect(commandBar).toBeVisible();
+  await commandBar.waitFor({ state: "visible" });
+}
+
+export async function getOpenConversation() {
+  const result = await db
+    .select({ id: conversations.id, slug: conversations.slug })
+    .from(conversations)
+    .where(eq(conversations.status, "open"))
+    .limit(1);
+
+  if (!result.length) {
+    throw new Error(
+      "No open conversation found in database. Please ensure there's at least one open conversation for testing.",
+    );
+  }
+
+  return result[0];
+}

--- a/tests/e2e/utils/settingsHelpers.ts
+++ b/tests/e2e/utils/settingsHelpers.ts
@@ -1,4 +1,7 @@
-import { Page } from "@playwright/test";
+import { expect, Page } from "@playwright/test";
+import { eq } from "drizzle-orm";
+import { db } from "../../../db/client";
+import { conversations } from "../../../db/schema";
 
 export async function waitForSettingsSaved(page: Page) {
   const saving = page.getByText("Saving");
@@ -14,4 +17,28 @@ export async function waitForSettingsSaved(page: Page) {
     }
     console.warn("No saving indicator found. This should mean there were no changes, but may be worth checking.");
   }
+}
+
+export async function openCommandBar(page: any) {
+  await page.getByLabel("Command Bar Input").click();
+
+  const commandBar = page.locator('[data-testid="command-bar"]');
+  await expect(commandBar).toBeVisible();
+  await commandBar.waitFor({ state: "visible" });
+}
+
+export async function getOpenConversation() {
+  const result = await db
+    .select({ id: conversations.id, slug: conversations.slug })
+    .from(conversations)
+    .where(eq(conversations.status, "open"))
+    .limit(1);
+
+  if (!result.length) {
+    throw new Error(
+      "No open conversation found in database. Please ensure there's at least one open conversation for testing.",
+    );
+  }
+
+  return result[0];
 }

--- a/tests/e2e/utils/settingsHelpers.ts
+++ b/tests/e2e/utils/settingsHelpers.ts
@@ -1,7 +1,4 @@
-import { expect, Page } from "@playwright/test";
-import { eq } from "drizzle-orm";
-import { db } from "../../../db/client";
-import { conversations } from "../../../db/schema";
+import { Page } from "@playwright/test";
 
 export async function waitForSettingsSaved(page: Page) {
   const saving = page.getByText("Saving");
@@ -17,28 +14,4 @@ export async function waitForSettingsSaved(page: Page) {
     }
     console.warn("No saving indicator found. This should mean there were no changes, but may be worth checking.");
   }
-}
-
-export async function openCommandBar(page: any) {
-  await page.getByLabel("Command Bar Input").click();
-
-  const commandBar = page.locator('[data-testid="command-bar"]');
-  await expect(commandBar).toBeVisible();
-  await commandBar.waitFor({ state: "visible" });
-}
-
-export async function getOpenConversation() {
-  const result = await db
-    .select({ id: conversations.id, slug: conversations.slug })
-    .from(conversations)
-    .where(eq(conversations.status, "open"))
-    .limit(1);
-
-  if (!result.length) {
-    throw new Error(
-      "No open conversation found in database. Please ensure there's at least one open conversation for testing.",
-    );
-  }
-
-  return result[0];
 }


### PR DESCRIPTION
Ref:- https://github.com/antiwork/helper/issues/992

This PR just moves command bar E2E tests out of tests/e2e/conversations/conversationActions.spec.ts


Now command bar action tests could run concurrently earlier they were limited by conversation action tests to run serially.

![Screenshot 2025-09-05 at 11 25 53 PM](https://github.com/user-attachments/assets/8ca38cf0-0f23-4183-8fe7-6e2d4ed2e10f)


![Screenshot 2025-09-05 at 11 32 03 PM](https://github.com/user-attachments/assets/e7e1eb9b-2ab4-4c95-b4c2-b01a2d0cfbd4)



AI Disclosure:-
No AI was used in this PR