### PR TITLE
ci: enable workflows to run on forks

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   autofix:
-    runs-on: ubicloud-standard-4
+    runs-on: ${{ github.repository == 'antiwork/helper' && 'ubicloud-standard-4' || 'ubuntu-latest' }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   e2e:
-    runs-on: ubicloud-standard-2
+    runs-on: ${{ github.repository == 'antiwork/helper' && 'ubicloud-standard-2' || 'ubuntu-latest' }}
     timeout-minutes: 60
     env:
       CI: true

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   evals:
-    runs-on: ubicloud-standard-2
+    runs-on: ${{ github.repository == 'antiwork/helper' && 'ubicloud-standard-2' || 'ubuntu-latest' }}
 
     steps:
       - name: Check out repository code

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubicloud-standard-2
+    runs-on: ${{ github.repository == 'antiwork/helper' && 'ubicloud-standard-2' || 'ubuntu-latest' }}
 
     steps:
       - name: Check out repository code

--- a/packages/react/CONTRIBUTING.md
+++ b/packages/react/CONTRIBUTING.md
@@ -33,7 +33,7 @@ We use Vitest for testing. Some key guidelines:
 1. Create a new branch for your feature/fix
 2. Write tests for new functionality
 3. Ensure all tests pass
-4. Include screenshots of your test suite passing locally
+4. Include screenshots of your test suite passing locally or from your fork's github action
 5. Use native-sounding English in all communication with no excessive capitalization (e.g HOW IS THIS GOING), multiple question marks (how's this going???), grammatical errors (how's dis going), or typos (thnx fr update).
    - ❌ Before: "is this still open ?? I am happy to work on it ??"
    - ✅ After: "Is this actively being worked on? I've started work on it here…"


### PR DESCRIPTION
## Closes https://github.com/antiwork/helper/issues/991 with reference to work in https://github.com/antiwork/flexile/pull/1096 & https://github.com/antiwork/flexile/pull/1069

### How?
1. Conditionally select runner instance based on the repository

Updated contributing guidelines to reflect the same

### Test Link - https://github.com/sm17p/helper/pull/1

### Screenshots

<img width="941" height="811" alt="P1" src="https://github.com/user-attachments/assets/0f4ee523-db3e-48fc-a28c-abfa963e7b00" />

<img width="1095" height="811" alt="e2e" src="https://github.com/user-attachments/assets/8dbcc73d-d5ea-4d2a-820d-06eae3109d5c" />

### AI Disclosure
No usage