### PR TITLE
feat: enable auto-assign via slack 

### DIFF
--- a/db/schema/userProfiles.ts
+++ b/db/schema/userProfiles.ts
@@ -37,5 +37,14 @@ export const userProfilesRelations = relations(userProfiles, ({ one }) => ({
   }),
 }));
 
-export type BasicUserProfile = { id: string; displayName: string | null; email: string | null };
+export type BasicUserProfile = {
+  id: string;
+  displayName: string | null;
+  email: string | null;
+  preferences?: {
+    confetti?: boolean;
+    disableNextTicketPreview?: boolean;
+    autoAssignOnReply?: boolean;
+  } | null;
+};
 export type FullUserProfile = typeof userProfiles.$inferSelect & { email: string | null };

--- a/db/schema/userProfiles.ts
+++ b/db/schema/userProfiles.ts
@@ -37,14 +37,5 @@ export const userProfilesRelations = relations(userProfiles, ({ one }) => ({
   }),
 }));
 
-export type BasicUserProfile = {
-  id: string;
-  displayName: string | null;
-  email: string | null;
-  preferences?: {
-    confetti?: boolean;
-    disableNextTicketPreview?: boolean;
-    autoAssignOnReply?: boolean;
-  } | null;
-};
+export type BasicUserProfile = { id: string; displayName: string | null; email: string | null };
 export type FullUserProfile = typeof userProfiles.$inferSelect & { email: string | null };

--- a/lib/data/user.ts
+++ b/lib/data/user.ts
@@ -37,7 +37,12 @@ export const getProfile = cache(
 
 export const getBasicProfileById = cache(async (userId: string) => {
   const [user] = await db
-    .select({ id: userProfiles.id, displayName: userProfiles.displayName, email: authUsers.email })
+    .select({
+      id: userProfiles.id,
+      displayName: userProfiles.displayName,
+      email: authUsers.email,
+      preferences: userProfiles.preferences,
+    })
     .from(userProfiles)
     .innerJoin(authUsers, eq(userProfiles.id, authUsers.id))
     .where(eq(userProfiles.id, userId));
@@ -46,7 +51,12 @@ export const getBasicProfileById = cache(async (userId: string) => {
 
 export const getBasicProfileByEmail = cache(async (email: string) => {
   const [user] = await db
-    .select({ id: userProfiles.id, displayName: userProfiles.displayName, email: authUsers.email })
+    .select({
+      id: userProfiles.id,
+      displayName: userProfiles.displayName,
+      email: authUsers.email,
+      preferences: userProfiles.preferences,
+    })
     .from(userProfiles)
     .innerJoin(authUsers, eq(userProfiles.id, authUsers.id))
     .where(eq(authUsers.email, email));

--- a/lib/data/user.ts
+++ b/lib/data/user.ts
@@ -1,8 +1,8 @@
-import { eq, isNull } from "drizzle-orm";
+import { eq, getTableColumns, isNull } from "drizzle-orm";
 import { cache } from "react";
 import { takeUniqueOrThrow } from "@/components/utils/arrays";
 import { db } from "@/db/client";
-import { BasicUserProfile, userProfiles } from "@/db/schema/userProfiles";
+import { FullUserProfile, userProfiles } from "@/db/schema/userProfiles";
 import { authUsers } from "@/db/supabaseSchema/auth";
 import { createAdminClient } from "@/lib/supabase/server";
 import { getFirstName, getFullName } from "../auth/authUtils";
@@ -37,12 +37,7 @@ export const getProfile = cache(
 
 export const getBasicProfileById = cache(async (userId: string) => {
   const [user] = await db
-    .select({
-      id: userProfiles.id,
-      displayName: userProfiles.displayName,
-      email: authUsers.email,
-      preferences: userProfiles.preferences,
-    })
+    .select({ id: userProfiles.id, displayName: userProfiles.displayName, email: authUsers.email })
     .from(userProfiles)
     .innerJoin(authUsers, eq(userProfiles.id, authUsers.id))
     .where(eq(userProfiles.id, userId));
@@ -51,12 +46,25 @@ export const getBasicProfileById = cache(async (userId: string) => {
 
 export const getBasicProfileByEmail = cache(async (email: string) => {
   const [user] = await db
-    .select({
-      id: userProfiles.id,
-      displayName: userProfiles.displayName,
-      email: authUsers.email,
-      preferences: userProfiles.preferences,
-    })
+    .select({ id: userProfiles.id, displayName: userProfiles.displayName, email: authUsers.email })
+    .from(userProfiles)
+    .innerJoin(authUsers, eq(userProfiles.id, authUsers.id))
+    .where(eq(authUsers.email, email));
+  return user ?? null;
+});
+
+export const getFullProfileById = cache(async (userId: string): Promise<FullUserProfile | null> => {
+  const [user] = await db
+    .select({ ...getTableColumns(userProfiles), email: authUsers.email })
+    .from(userProfiles)
+    .innerJoin(authUsers, eq(userProfiles.id, authUsers.id))
+    .where(eq(userProfiles.id, userId));
+  return user ?? null;
+});
+
+export const getFullProfileByEmail = cache(async (email: string): Promise<FullUserProfile | null> => {
+  const [user] = await db
+    .select({ ...getTableColumns(userProfiles), email: authUsers.email })
     .from(userProfiles)
     .innerJoin(authUsers, eq(userProfiles.id, authUsers.id))
     .where(eq(authUsers.email, email));
@@ -166,9 +174,9 @@ export const updateUserMailboxData = async (
   };
 };
 
-export const findUserViaSlack = cache(async (token: string, slackUserId: string): Promise<BasicUserProfile | null> => {
+export const findUserViaSlack = cache(async (token: string, slackUserId: string): Promise<FullUserProfile | null> => {
   const slackUser = await getSlackUser(token, slackUserId);
-  const user = await getBasicProfileByEmail(slackUser?.profile?.email ?? "");
+  const user = await getFullProfileByEmail(slackUser?.profile?.email ?? "");
   return user ?? null;
 });
 

--- a/lib/slack/agent/generateAgentResponse.ts
+++ b/lib/slack/agent/generateAgentResponse.ts
@@ -369,12 +369,18 @@ export const generateAgentResponse = async (
         showStatus(`Sending reply...`, { toolName: "sendReply", parameters: { ticketId } });
         const conversation = await findConversation(ticketId);
         if (!conversation) return { error: "Ticket not found" };
+
+        const slackUser = slackUserId
+          ? await findUserViaSlack(assertDefined(mailbox.slackBotToken), slackUserId)
+          : null;
+        const shouldAutoAssign = slackUser?.preferences?.autoAssignOnReply && !conversation.assignedToId;
+
         await createReply({
           conversationId: conversation.id,
           message: confirmedReplyText,
-          user: slackUserId ? await findUserViaSlack(assertDefined(mailbox.slackBotToken), slackUserId) : null,
+          user: slackUser,
           close: false,
-          shouldAutoAssign: false,
+          shouldAutoAssign,
         });
         return { message: "Reply sent" };
       },

--- a/tests/lib/slack/shared.test.ts
+++ b/tests/lib/slack/shared.test.ts
@@ -166,13 +166,14 @@ describe("handleSlackAction", () => {
     });
   });
 
-  it("creates a reply and closes the conversation when the sending method is email_and_close", async () => {
+  it("creates a reply and closes the conversation with auto-assignment when the sending method is email_and_close", async () => {
     const { profile } = await userFactory.createRootUser({
       userOverrides: {
         email: "user@example.com",
       },
       mailboxOverrides: { slackBotToken: "xoxb-12345678901234567890" },
     });
+    profile.preferences = { autoAssignOnReply: true };
     const { conversation } = await conversationFactory.create();
 
     const message = {
@@ -204,6 +205,50 @@ describe("handleSlackAction", () => {
       user: profile,
       close: true,
       slack: { channel: "C12345", messageTs: "1234567890.123456" },
+      shouldAutoAssign: true,
+    });
+  });
+
+  it("creates a reply with auto-assignment when the sending method is email", async () => {
+    const { profile } = await userFactory.createRootUser({
+      userOverrides: {
+        email: "user@example.com",
+      },
+      mailboxOverrides: { slackBotToken: "xoxb-12345678901234567890" },
+    });
+    profile.preferences = { autoAssignOnReply: true };
+    const { conversation } = await conversationFactory.create();
+
+    const message = {
+      conversationId: conversation.id,
+      slackChannel: "C12345",
+      slackMessageTs: "1234567890.123456",
+    };
+
+    vi.mocked(findUserViaSlack).mockResolvedValueOnce(profile);
+
+    const payload = {
+      type: "view_submission",
+      user: { id: "U12345" },
+      view: {
+        state: {
+          values: {
+            reply: { message: { value: "Test reply" } },
+            escalation_actions: { sending_method: { selected_option: { value: "email" } } },
+          },
+        },
+      },
+    };
+
+    await handleMessageSlackAction(message, payload);
+
+    expect(createReply).toHaveBeenCalledWith({
+      conversationId: conversation.id,
+      message: "Test reply",
+      user: profile,
+      close: false,
+      slack: { channel: "C12345", messageTs: "1234567890.123456" },
+      shouldAutoAssign: true,
     });
   });
 
@@ -245,6 +290,132 @@ describe("handleSlackAction", () => {
       user: profile,
       slackChannel: "C12345",
       slackMessageTs: "1234567890.123456",
+    });
+  });
+
+  it("opens respond modal then submits email and auto-assigns when user preference enabled", async () => {
+    const { profile } = await userFactory.createRootUser({
+      userOverrides: {
+        email: "user@example.com",
+      },
+      mailboxOverrides: { slackBotToken: "xoxb-12345678901234567890" },
+    });
+
+    profile.preferences = { autoAssignOnReply: true };
+    const { conversation } = await conversationFactory.create({ assignedToId: null });
+
+    const message = {
+      conversationId: conversation.id,
+      slackChannel: "C12345",
+      slackMessageTs: "1234567890.123456",
+    };
+
+    const openPayload = {
+      actions: [{ action_id: "respond_in_slack" }],
+      user: { id: "U12345" },
+      trigger_id: "trigger123",
+    };
+
+    vi.mocked(findUserViaSlack).mockResolvedValueOnce(profile);
+
+    await handleMessageSlackAction(message, openPayload);
+
+    expect(openSlackModal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        token: "xoxb-12345678901234567890",
+        triggerId: "trigger123",
+        title: "Reply",
+      }),
+    );
+
+    const submitPayload = {
+      type: "view_submission",
+      user: { id: "U12345" },
+      view: {
+        state: {
+          values: {
+            reply: { message: { value: "Follow up reply" } },
+            escalation_actions: { sending_method: { selected_option: { value: "email" } } },
+          },
+        },
+      },
+    };
+
+    vi.mocked(findUserViaSlack).mockResolvedValueOnce(profile);
+
+    await handleMessageSlackAction(message, submitPayload);
+
+    expect(createReply).toHaveBeenCalledWith({
+      conversationId: conversation.id,
+      message: "Follow up reply",
+      user: profile,
+      close: false,
+      slack: { channel: "C12345", messageTs: "1234567890.123456" },
+      shouldAutoAssign: true,
+    });
+  });
+
+  it("opens respond modal then submits email_and_close and auto-assigns when user preference enabled", async () => {
+    const { profile } = await userFactory.createRootUser({
+      userOverrides: {
+        email: "user@example.com",
+      },
+      mailboxOverrides: { slackBotToken: "xoxb-12345678901234567890" },
+    });
+    // enable auto-assign preference
+    profile.preferences = { autoAssignOnReply: true };
+    const { conversation } = await conversationFactory.create({ assignedToId: null });
+
+    const message = {
+      conversationId: conversation.id,
+      slackChannel: "C12345",
+      slackMessageTs: "1234567890.123456",
+    };
+
+    // Simulate opening the respond modal
+    const openPayload = {
+      actions: [{ action_id: "respond_in_slack" }],
+      user: { id: "U12345" },
+      trigger_id: "trigger456",
+    };
+
+    vi.mocked(findUserViaSlack).mockResolvedValueOnce(profile);
+
+    await handleMessageSlackAction(message, openPayload);
+
+    expect(openSlackModal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        token: "xoxb-12345678901234567890",
+        triggerId: "trigger456",
+        title: "Reply",
+      }),
+    );
+
+    // Simulate submitting the modal with sending_method = "email_and_close"
+    const submitPayload = {
+      type: "view_submission",
+      user: { id: "U12345" },
+      view: {
+        state: {
+          values: {
+            reply: { message: { value: "Reply and close this ticket" } },
+            escalation_actions: { sending_method: { selected_option: { value: "email_and_close" } } },
+          },
+        },
+      },
+    };
+
+    vi.mocked(findUserViaSlack).mockResolvedValueOnce(profile);
+
+    await handleMessageSlackAction(message, submitPayload);
+
+    expect(createReply).toHaveBeenCalledWith({
+      conversationId: conversation.id,
+      message: "Reply and close this ticket",
+      user: profile,
+      close: true,
+      slack: { channel: "C12345", messageTs: "1234567890.123456" },
+      shouldAutoAssign: true,
     });
   });
 });

--- a/tests/support/factories/users.ts
+++ b/tests/support/factories/users.ts
@@ -4,7 +4,7 @@ import { assertDefined } from "@/components/utils/assert";
 import { db } from "@/db/client";
 import { mailboxes } from "@/db/schema";
 import { authUsers } from "@/db/supabaseSchema/auth";
-import { getBasicProfileById } from "@/lib/data/user";
+import { getFullProfileById } from "@/lib/data/user";
 
 const createUser = async (overrides: Partial<typeof authUsers.$inferInsert> = {}) => {
   const user = await db
@@ -15,7 +15,7 @@ const createUser = async (overrides: Partial<typeof authUsers.$inferInsert> = {}
 
   return {
     user,
-    profile: assertDefined(await getBasicProfileById(user.id)),
+    profile: assertDefined(await getFullProfileById(user.id)),
   };
 };
 


### PR DESCRIPTION
Enables auto-assignment on reply via slack

1. Agent chat

https://github.com/user-attachments/assets/9547365f-3d23-4ef2-a006-484141a04a74

2. Respond Modal
    
|Reply| Reply and Close|
|------|----------|
|<img width="1208" height="825" alt="reply_slack_modal" src="https://github.com/user-attachments/assets/02bf6370-c55c-41e4-838b-e9eccabcf290" />|<img width="1208" height="727" alt="reply_and_close_slack_modal" src="https://github.com/user-attachments/assets/b8615db7-78a2-493d-9408-9b7d79bdf41c" />|

### Specs Covered
1. `createReply` - auto assign behaviour with user preference enabled and disabled
2. `openRespondModal` - reply flow + reply and close flow

### AI Usage:
1. claude for slicing out parts of code from #1023

### Checklist
- [x] Self Reviewed

### Ref:
- https://github.com/antiwork/helper/issues/1008
> Slack is a good shout but tbh it's not used enough to be an essential part of the feature - would be open to a follow-up PR adding it though! It's not needed for bulk update.
- https://github.com/antiwork/helper/pull/1023#issuecomment-3255478732